### PR TITLE
Move initialisation of instanceId and add cookieSecret

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -55,8 +55,11 @@ const postoffice = require('./postoffice');
     await server.register(license)
 
     // HTTP Server configuration
+    if (!server.settings.get('cookieSecret')) {
+        await server.settings.set('cookieSecret', server.db.utils.generateToken(12))
+    }
     await server.register(cookie, {
-        secret: server.db.utils.sha256(server.settings.get('instanceId'))
+        secret: server.settings.get('cookieSecret')
     })
     await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
 

--- a/forge/app.js
+++ b/forge/app.js
@@ -47,10 +47,16 @@ const postoffice = require('./postoffice');
 
     // Config : loads environment configuration
     await server.register(config)
+    // DB : the database connection/models/views/controllers
+    await server.register(db)
+    // Settings
+    await server.register(settings)
+    // License
+    await server.register(license)
 
+    // HTTP Server configuration
     await server.register(cookie, {
-        // TODO: this needs to be generated per-instance
-        secret: 'flowforge-secret'
+        secret: server.db.utils.sha256(server.settings.get('instanceId'))
     })
     await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
 
@@ -58,21 +64,14 @@ const postoffice = require('./postoffice');
     if (!process.env.BASE_URL) {
         process.env.BASE_URL = `http://localhost:${process.env.PORT}`
     }
-
     if (!process.env.API_URL) {
         process.env.API_URL = process.env.BASE_URL
     }
 
-    // DB : the database connection/models/views/controllers
-    await server.register(db)
-    // Settings
-    await server.register(settings)
-    // License
-    await server.register(license)
     // Routes : the HTTP routes
     await server.register(routes, { logLevel: 'warn' })
     // Post Office : handles email
-    server.register(postoffice)
+    await server.register(postoffice)
     // Containers:
     await server.register(containers)
 

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -8,7 +8,6 @@
  */
 const path = require('path')
 const fs = require('fs').promises
-const { v4: uuidv4 } = require('uuid')
 
 const setupApp = path.join(__dirname, '../../../frontend/dist-setup/setup.html')
 
@@ -48,7 +47,6 @@ module.exports = async function (app) {
             return
         }
         await app.settings.set('setup:initialised', true)
-        await app.settings.set('instanceId', uuidv4())
         reply.send({ status: 'okay' })
     })
 

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -5,6 +5,9 @@ module.exports = {
     // Instance ID:
     instanceId: null,
 
+    // Secret used to sign cookies:
+    cookieSecret: null,
+
     // Whether the intial setup has been run
     'setup:initialised': false,
 

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -1,3 +1,4 @@
+const { v4: uuidv4 } = require('uuid')
 const fp = require('fastify-plugin')
 
 const defaultSettings = require('./defaults')
@@ -24,6 +25,10 @@ module.exports = fp(async function (app, _opts, next) {
             settings[key] = value
             await app.db.models.PlatformSettings.upsert({ key, value })
         }
+    }
+
+    if (!settingsApi.get('instanceId')) {
+        await settingsApi.set('instanceId', uuidv4())
     }
 
     app.decorate('settings', settingsApi)


### PR DESCRIPTION
Closes #219

In the existing code, `instanceId` is only been set once the setup process is completed. This PR moves that to much earlier - when we set up settings.

I did that as I thought we needed to use it to sign our cookies with (which has to happen before setup runs).

Having done that, I realise using anything derived from `instanceId` would mean `instanceId` itself has to become a closely guarded secret. To avoid putting that burden on it, I've also added `cookieSecret` to settings which is initialised when needed.