### PR TITLE
Fix build.yml to run a code build before test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Install Dependencies
       run: npm install
     - name: Build the forge
-      run: npm run test
+      run: npm run build
     - name: Test the forge
       run: npm run test


### PR DESCRIPTION
A typo meant we were running the tests twice, rather than a build then a test.