### PR TITLE
Fix missing () on end of toString

### DIFF
--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -101,7 +101,7 @@ module.exports = fp(async function (app, _opts, next) {
         if (EMAIL_ENABLED) {
             mailTransport.sendMail(mail, err => {
                 if (err) {
-                    app.log.warn(`Failed to send email: ${err.toString}`)
+                    app.log.warn(`Failed to send email: ${err.toString()}`)
                 }
             })
             if (app.config.email.debug) {


### PR DESCRIPTION
missed the `()` off when converting error message to template