### PR TITLE
Force teamId/ProjectId to a string

### DIFF
--- a/forge/db/models/AuditLog.js
+++ b/forge/db/models/AuditLog.js
@@ -33,7 +33,7 @@ module.exports = {
                 forEntity: async (entityType, projectId, pagination = {}) => {
                     const limit = parseInt(pagination.limit) || 30
                     const where = {
-                        entityId: projectId,
+                        entityId: projectId.toString(),
                         entityType: entityType
                     }
                     if (pagination.cursor) {


### PR DESCRIPTION
PostgreSQL needs the types to match, where as sqlite will cast on the fly.

should fix #260 