### PR TITLE
Add migration framework for database

### DIFF
--- a/docs/contribute/db-migrations.md
+++ b/docs/contribute/db-migrations.md
@@ -1,0 +1,53 @@
+# Database Migrations
+
+It is important that any changes made to the database models include migrations that
+can modify the database state from one state to another.
+
+Whilst we use Sequelize as our ORM layer, we do not use the migration tooling
+it provides - we have our own.
+
+
+## Creating migrations
+
+### Filename
+
+A migration is provided as a JavaScript in the directory `forge/db/migrations`.
+Its file name must follow the pattern:
+
+```
+YYYYMMDD-nn-description.js
+```
+
+ - `YYYYMMDD` - the date the migration is added
+ - `nn` - a two digit number
+ - `description` - a name for the migration
+
+For example `20220204-01-add-billing.js`.
+
+This ensures the migrations have a natural order to be applied. The `nn` part of
+the name allows multiple migrations to be added on the same day, but kept in the
+right order.
+
+### Structure
+
+The migration code should use the following layout:
+
+```
+module.exports = {
+    up: async (context) => {
+        // Apply the migration
+    },
+    down: async (context) => {
+        // Remove the migration
+    }
+}
+```
+
+The `up` function applies the migration. This can be to create new tables, add columns
+to existing ones - whatever is needed.
+
+The `down` function reverses the migration. It should restore the database back to
+how it was prior to the migration.
+
+The `context` argument is an instance of [Sequelize.QueryInterface](https://sequelize.org/v6/class/lib/dialects/abstract/query-interface.js~QueryInterface.html) that can be used to perform
+operations on the database.

--- a/forge/app.js
+++ b/forge/app.js
@@ -19,13 +19,17 @@ const forge = require('./forge')
         process.exit(1)
     }
 
-    const server = await forge()
+    try {
+        const server = await forge()
 
-    // Start the server
-    server.listen(server.config.port, '0.0.0.0', function (err, address) {
-        if (err) {
-            console.error(err)
-            process.exit(1)
-        }
-    })
+        // Start the server
+        server.listen(server.config.port, '0.0.0.0', function (err, address) {
+            if (err) {
+                console.error(err)
+                process.exit(1)
+            }
+        })
+    } catch (err) {
+        process.exitCode = 1
+    }
 })()

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -58,7 +58,9 @@ module.exports = fp(async function (app, opts, next) {
     if (fs.existsSync(path.join(process.env.FLOWFORGE_HOME, '/etc/flowforge.local.yml'))) {
         configFile = path.join(process.env.FLOWFORGE_HOME, '/etc/flowforge.local.yml')
     }
-    app.log.info(`Config File: ${configFile}`)
+    if (!opts.config) {
+        app.log.info(`Config File: ${configFile}`)
+    }
     try {
         const configFileContent = fs.readFileSync(configFile, 'utf-8')
         const config = opts.config === undefined

--- a/forge/db/migrations/examples/20220204-01-add-billing.js
+++ b/forge/db/migrations/examples/20220204-01-add-billing.js
@@ -1,0 +1,17 @@
+/**
+ * This is an example migration that adds a column to the Users table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        context.addColumn('Users', 'billing', {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        })
+    },
+    down: async (context) => {
+        context.removeColumn('Users', 'billing')
+    }
+}

--- a/forge/db/migrations/index.js
+++ b/forge/db/migrations/index.js
@@ -1,0 +1,95 @@
+const { DataTypes, Model } = require('sequelize')
+
+const fs = require('fs').promises
+
+const MIGRATIONS_DIR = __dirname
+
+class MetaVersion extends Model {}
+
+let pendingMigrations = []
+let app
+
+async function init (_app) {
+    pendingMigrations = []
+    app = _app
+    // Ensure the metadata table exists
+    // This is not kept with the other models as it needs to exist to bootstrap
+    // the version checks
+
+    MetaVersion.init({
+        version: {
+            type: DataTypes.STRING,
+            allowNull: false
+        }
+    }, {
+        sequelize: app.db.sequelize,
+        modelName: 'MetaVersion',
+        timestamps: true,
+        createdAt: false
+    })
+    await MetaVersion.sync()
+    await checkPendingMigrations()
+}
+
+async function getCurrentVersion () {
+    return await MetaVersion.findOne({ order: [['id', 'DESC']] })
+}
+
+async function checkPendingMigrations () {
+    let migrationFiles = await fs.readdir(MIGRATIONS_DIR)
+    migrationFiles = migrationFiles.filter(name => /^\d\d\d\d\d\d\d\d-\d\d-.*\.js$/.test(name))
+    migrationFiles.sort()
+
+    const tables = await app.db.sequelize.getQueryInterface().showAllSchemas()
+
+    if (tables.length === 1) {
+        // We only have the MetaVersion table. This means this is a brand-new
+        // database. We don't want to apply any migrations but we do want to
+        // initialise the MetaVersion table to know they have been pre-applied
+        for (let i = 0; i < migrationFiles.length; i++) {
+            await MetaVersion.create({ version: migrationFiles[i] })
+        }
+    } else {
+        // We have a populated database. Need to check if there are any migrations
+        // to apply
+        const currentVersion = await getCurrentVersion()
+
+        // If currentVersion is null, then all migrations are needed
+        let found = !currentVersion
+        // Loop through the migrations from oldest to newest.
+        // Filter out entries until we find the one matching the currentVersion.
+        // From that point, return the remaining migrations
+        pendingMigrations = migrationFiles.filter(name => {
+            if (found) { return true }
+            if (name === currentVersion.version) {
+                found = true
+            }
+            return false
+        })
+    }
+}
+
+async function applyMigration (filename) {
+    const queryInterface = app.db.sequelize.getQueryInterface()
+    const migration = require('./' + filename)
+    app.log.info(' - %s', filename)
+    await migration.up(queryInterface)
+    await MetaVersion.create({ version: filename })
+}
+async function applyPendingMigrations () {
+    if (pendingMigrations.length > 0) {
+        app.log.info('Applying migrations:')
+        for (let i = 0; i < pendingMigrations.length; i++) {
+            await applyMigration(pendingMigrations[i])
+        }
+        app.log.info('Finished applying migrations')
+        await checkPendingMigrations()
+    }
+}
+
+module.exports = {
+    init,
+    getCurrentVersion,
+    hasPendingMigrations: _ => pendingMigrations.length > 0,
+    applyPendingMigrations
+}

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -10,10 +10,16 @@ const csrf = require('fastify-csrf')
 const postoffice = require('./postoffice')
 
 module.exports = async (options) => {
+    // TODO: Defer logger configuration until after `config` module is registered
+    //       so that we can pull it from user-provided config
+    let loggerLevel = 'info'
+    if (options.config && options.config.logging) {
+        loggerLevel = options.config.logging.level || 'info'
+    }
     const server = fastify({
         maxParamLength: 500,
         logger: {
-            level: 'info',
+            level: loggerLevel,
             prettyPrint: {
                 translateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss.l'Z'",
                 ignore: 'pid,hostname'
@@ -26,32 +32,37 @@ module.exports = async (options) => {
         // console.log(error.stack)
     })
 
-    // Config : loads environment configuration
-    await server.register(config, options)
-    // DB : the database connection/models/views/controllers
-    await server.register(db)
-    // Settings
-    await server.register(settings)
-    // License
-    await server.register(license)
+    try {
+        // Config : loads environment configuration
+        await server.register(config, options)
+        // DB : the database connection/models/views/controllers
+        await server.register(db)
+        // Settings
+        await server.register(settings)
+        // License
+        await server.register(license)
 
-    // HTTP Server configuration
-    if (!server.settings.get('cookieSecret')) {
-        await server.settings.set('cookieSecret', server.db.utils.generateToken(12))
+        // HTTP Server configuration
+        if (!server.settings.get('cookieSecret')) {
+            await server.settings.set('cookieSecret', server.db.utils.generateToken(12))
+        }
+        await server.register(cookie, {
+            secret: server.settings.get('cookieSecret')
+        })
+        await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
+
+        // Routes : the HTTP routes
+        await server.register(routes, { logLevel: 'warn' })
+        // Post Office : handles email
+        await server.register(postoffice)
+        // Containers:
+        await server.register(containers)
+
+        await server.ready()
+
+        return server
+    } catch (err) {
+        server.log.error(`Failed to start: ${err.toString()}`)
+        throw err
     }
-    await server.register(cookie, {
-        secret: server.settings.get('cookieSecret')
-    })
-    await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
-
-    // Routes : the HTTP routes
-    await server.register(routes, { logLevel: 'warn' })
-    // Post Office : handles email
-    await server.register(postoffice)
-    // Containers:
-    await server.register(containers)
-
-    await server.ready()
-
-    return server
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
         "start-watch": "NODE_ENV=development nodemon -w forge -w ee/forge -i forge/containers/localfs_root forge/app.js",
         "build-watch": "webpack --mode=development -c ./config/webpack.config.js --watch",
         "docs": "jsdoc -c ./config/jsdoc.json",
-        "lint": "eslint -c .eslintrc forge/**/*.js frontend/**/*.js test/**/*.js --ignore-pattern 'frontend/dist/**'",
-        "lint:fix": "eslint -c .eslintrc forge/**/*.js frontend/**/*.js test/**/*.js --ignore-pattern 'frontend/dist/**' --fix",
+        "lint": "eslint -c .eslintrc 'forge/**/*.js' 'frontend/**/*.js' 'test/**/*.js' --ignore-pattern 'frontend/dist/**'",
+        "lint:fix": "eslint -c .eslintrc 'forge/**/*.js' 'frontend/**/*.js' 'test/**/*.js' --ignore-pattern 'frontend/dist/**' --fix",
         "test": "npm run lint && npm run test:unit && npm run test:system",
         "test:unit": "mocha test/unit/**/*_spec.js",
         "test:system": "mocha test/system/**/*_spec.js"

--- a/test/unit/forge/db/controllers/Invitation_spec.js
+++ b/test/unit/forge/db/controllers/Invitation_spec.js
@@ -17,6 +17,7 @@ describe('Invitation controller', function () {
     let app
     beforeEach(async function () {
         app = await setup()
+        app.settings.set('team:user:invite:external', true)
     })
 
     function checkInvite (invite, invitorId, inviteeId, teamId) {
@@ -103,9 +104,7 @@ describe('Invitation controller', function () {
             result.dave.should.match(/Not an existing user/)
         })
 
-        it.skip('creates invitations for external users', async function () {
-            // TODO: skipping as the default postoffice config means external
-            //       invites are refused
+        it('creates invitations for external users', async function () {
             const invitor = await app.db.models.User.byUsername('alice')
             const team = await app.db.models.Team.byName('CTeam')
             const userList = ['dave@example.com']

--- a/test/unit/forge/db/migrations/migrations_spec.js
+++ b/test/unit/forge/db/migrations/migrations_spec.js
@@ -1,0 +1,157 @@
+// This checks the models defined in forge/db/models generates
+// tables that match what the migrations generate
+//
+// If there is a mismatch, it means the models have been changed
+// but there is no migration file provided to handle it.
+
+const should = require('should') // eslint-disable-line
+const FF_UTIL = require('flowforge-test-utils')
+// const Forge = FF_UTIL.require('forge/forge.js')
+// const { sha256 } = FF_UTIL.require('forge/db/utils')
+const { Sequelize } = require('sequelize')
+const path = require('path')
+const fs = require('fs').promises
+
+const MIGRATIONS_DIR = FF_UTIL.resolve('forge/db/migrations')
+
+describe('Validate migrations', async function () {
+    let migrationFiles
+    let migrationApp
+
+    // async function getTableSchemaHashes (q) {
+    //     let tables = await q.showAllSchemas()
+    //     tables = tables.map(t => t.name)
+    //     tables.sort()
+    //     const result = {}
+    //
+    //     for (let i = 0; i < tables.length; i++) {
+    //         const schema = await q.describeTable(tables[i])
+    //         const cols = Object.keys(schema)
+    //         cols.sort()
+    //         const fingerPrint = cols.map(c => JSON.stringify(schema[c])).join('')
+    //         result[tables[i]] = sha256(fingerPrint)
+    //     }
+    //     return result
+    // }
+
+    before(async function () {
+        // Create a blank database to apply migrations to
+        migrationApp = new Sequelize({
+            dialect: 'sqlite',
+            storage: ':memory:',
+            logging: false
+        })
+        await migrationApp.sync()
+
+        const queryInterface = migrationApp.getQueryInterface()
+
+        // Get the list of migration files
+        migrationFiles = await fs.readdir(MIGRATIONS_DIR)
+        if (migrationFiles.length === 0) {
+            throw new Error('No migration files found in', MIGRATIONS_DIR)
+        }
+        migrationFiles = migrationFiles.filter(name => /^\d\d.*\.js$/.test(name))
+        migrationFiles.sort()
+
+        // const accumulatedVersions = {}
+        let skipOnError = false
+
+        migrationFiles.forEach(file => {
+            describe(`Test migration ${file}`, function () {
+                let migration
+                // let expectedPostVersions
+
+                before(async function () {
+                    const pathToFile = path.relative(__dirname, path.join(MIGRATIONS_DIR, file))
+                    migration = require(pathToFile)
+                    // expectedPostVersions = { ...accumulatedVersions, ...(migration.versions || {}) }
+                    if (skipOnError) {
+                        this.skip()
+                    }
+                })
+
+                it('Applies cleanly', async function () {
+                    await migration.up(queryInterface)
+                })
+
+                // it('Table versions match', async function () {
+                //     const postVersions = await getTableSchemaHashes(queryInterface)
+                //
+                //     const expectedTables = Object.keys(expectedPostVersions)
+                //     const actualTables = Object.keys(postVersions)
+                //
+                //     expectedTables.length.should.eql(actualTables.length)
+                //
+                //     for (let i = 0; i < expectedTables.length; i++) {
+                //         const tableName = expectedTables[i]
+                //         expectedPostVersions[tableName].should.eql(postVersions[tableName], `Table '${tableName}' version mismatch`)
+                //     }
+                // })
+
+                it('Downgrades cleanly', async function () {
+                    if (migration.down) {
+                        await migration.down(queryInterface)
+                        // accumulatedVersions still contains the hashes
+                        // from before this migration was applied.
+                        // We can compare against that to check the migration
+                        // has been removed.
+
+                        // // Get the hashes following migration.down
+                        // const postDownVersions = await getTableSchemaHashes(queryInterface)
+                        //
+                        // const expectedTables = Object.keys(accumulatedVersions)
+                        // const actualTables = Object.keys(postDownVersions)
+                        //
+                        // expectedTables.length.should.eql(actualTables.length)
+                        //
+                        // for (let i = 0; i < expectedTables.length; i++) {
+                        //     const tableName = expectedTables[i]
+                        //     accumulatedVersions[tableName].should.eql(postDownVersions[tableName], `Table '${tableName}' version mismatch after applying migration.down`)
+                        // }
+
+                        // Reapply up for the next test
+                        await migration.up(queryInterface)
+                    }
+                })
+
+                after(function () {
+                    if (this.currentTest.state === 'failed') {
+                        skipOnError = true
+                    }
+                    // accumulatedVersions = expectedPostVersions
+                })
+            })
+        })
+        // describe('Check models against migrations', function () {
+        //     let forgeApp
+        //     it('Final migration matches models', async function () {
+        //         // Initialise an instance of Forge using the built-in models
+        //         forgeApp = await Forge({
+        //             config: {
+        //                 db: {
+        //                     type: 'sqlite',
+        //                     storage: ':memory:',
+        //                     migrations: {
+        //                         auto: false,
+        //                         skipCheck: true
+        //                     }
+        //                 },
+        //                 driver: { type: 'stub' },
+        //                 email: { enabled: false }
+        //             }
+        //         })
+        //         const modelVersions = await getTableSchemaHashes(forgeApp.db.sequelize.getQueryInterface())
+        //         const expectedTables = Object.keys(accumulatedVersions)
+        //         const actualTables = Object.keys(modelVersions)
+        //
+        //         expectedTables.length.should.eql(actualTables.length)
+        //
+        //         for (let i = 0; i < expectedTables.length; i++) {
+        //             const tableName = expectedTables[i]
+        //             accumulatedVersions[tableName].should.eql(modelVersions[tableName], `Table '${tableName}' version mismatch betweem model and migrations`)
+        //         }
+        //     })
+        // })
+    })
+    it('Generate tests', async function () { })
+})

--- a/test/unit/forge/db/setup.js
+++ b/test/unit/forge/db/setup.js
@@ -1,32 +1,28 @@
-const fastify = require('fastify')
 const FF_UTIL = require('flowforge-test-utils')
-const db = FF_UTIL.require('forge/db')
-const postoffice = FF_UTIL.require('forge/postoffice')
+const Forge = FF_UTIL.require('forge/forge.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
+const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
 module.exports = async function (settings = {}, config = {}) {
-    const app = fastify()
-
     config = {
         ...config,
+        logging: {
+            level: 'warn'
+        },
         db: {
             type: 'sqlite',
             storage: ':memory:'
         },
         email: {
-            enabled: true
+            enabled: true,
+            transport: new LocalTransport()
+        },
+        driver: {
+            type: 'stub'
         }
     }
 
-    // Quick fix - need a better strategry for per-test settings
-    app.decorate('settings', { get: (key) => settings[key] })
-    app.decorate('config', config)
-
-    // {
-    //     //
-    // })
-    await app.register(db)
-    await app.register(postoffice)
+    const forge = await Forge({ config })
 
     /*
         alice (admin)
@@ -37,17 +33,17 @@ module.exports = async function (settings = {}, config = {}) {
         BTeam - bob(owner), alice(member)
         CTeam - alice(owner)
     */
-    await app.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
-    const userAlice = await app.db.models.User.create({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })
-    const userBob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-    /* const userChris = */ await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
-    const team1 = await app.db.models.Team.create({ name: 'ATeam' })
-    const team2 = await app.db.models.Team.create({ name: 'BTeam' })
-    const team3 = await app.db.models.Team.create({ name: 'CTeam' })
+    await forge.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
+    const userAlice = await forge.db.models.User.create({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })
+    const userBob = await forge.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+    /* const userChris = */ await forge.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+    const team1 = await forge.db.models.Team.create({ name: 'ATeam' })
+    const team2 = await forge.db.models.Team.create({ name: 'BTeam' })
+    const team3 = await forge.db.models.Team.create({ name: 'CTeam' })
     await team1.addUser(userAlice, { through: { role: Roles.Owner } })
     await team1.addUser(userBob, { through: { role: Roles.Member } })
     await team2.addUser(userBob, { through: { role: Roles.Owner } })
     await team2.addUser(userAlice, { through: { role: Roles.Owner } })
     await team3.addUser(userAlice, { through: { role: Roles.Owner } })
-    return app
+    return forge
 }


### PR DESCRIPTION
This adds the ability to create database migrations.

Some basic principles:

 - a new table, `MetaVersions` is added that lists migrations (by filename) that have been applied and when.
 - for first run, when there is no database, we use the Sequelize models to create the database. As, by definition, they will be at the latest version, we record all migrations as having been run.
 - for later runs, it checks the latest migration to have been run from the `MetaVersions` table against the list of migration files. If it finds any migration files that are more recent (based on filename convention), they get applied automatically.

Each migration defines an `up` and `down` function that can be used to apply and rollback. Currently we only use the `up` functions.

We will need additional CLI tooling for manually applying individual migrations - and reverting them.

This PR gets enough in place for initial migrations to be created.

