### PR TITLE
Fix 403 for node admin users creating projects

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -61,7 +61,14 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.post('/', {
-        preHandler: app.needsPermission('project:create'),
+        preHandler: [
+            async (request, reply) => {
+                if (request.body && request.body.team) {
+                    request.teamMembership = await request.session.User.getTeamMembership(request.body.team)
+                }
+            },
+            app.needsPermission('project:create')
+        ],
         schema: {
             body: {
                 type: 'object',


### PR DESCRIPTION
This should allow members with owner access to a team to create a project