### PR TITLE
Auto-accept pending invites when registering to the platform

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -23,9 +23,15 @@ const forge = require('./forge')
         const server = await forge()
 
         // Setup shutdown event handling
+        let stopping = false
         async function exitWhenStopped () {
-            server.log.info('Stopping FlowForge platform')
-            await server.close()
+            if (!stopping) {
+                stopping = true
+                server.log.info('Stopping FlowForge platform')
+                await server.close()
+                server.log.info('FlowForge platform stopped')
+                process.exit(0)
+            }
         }
         process.on('SIGINT', exitWhenStopped)
         process.on('SIGTERM', exitWhenStopped)

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -127,26 +127,10 @@ module.exports = async function (app) {
         }
 
         try {
-            const newTeam = await app.db.models.Team.create({
+            const team = await app.db.controllers.Team.createTeamForUser({
                 name: request.body.name,
                 slug: request.body.slug
-            })
-            await newTeam.addUser(request.session.User, { through: { role: Roles.Owner } })
-
-            const team = await app.db.models.Team.bySlug(newTeam.slug)
-
-            await app.db.controllers.AuditLog.teamLog(
-                newTeam.id,
-                request.session.User.id,
-                'team.created'
-            )
-            await app.db.controllers.AuditLog.teamLog(
-                newTeam.id,
-                request.session.User.id,
-                'user.added',
-                { role: RoleNames[Roles.Owner] }
-            )
-
+            }, request.session.User)
             reply.send(app.db.views.Team.team(team))
         } catch (err) {
             let responseMessage

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -1,6 +1,5 @@
 const TeamMembers = require('./teamMembers.js')
 const TeamInvitations = require('./teamInvitations.js')
-const { Roles, RoleNames } = require('../../lib/roles.js')
 
 /**
  * Team api routes

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -1,5 +1,3 @@
-const { Roles } = require('../../lib/roles.js')
-
 /**
  * User Invitations api routes
  *
@@ -28,13 +26,7 @@ module.exports = async function (app) {
     app.patch('/:invitationId', async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId, request.session.User)
         if (invitation) {
-            await invitation.team.addUser(request.session.User, { through: { role: Roles.Member } })
-            await invitation.destroy()
-            await app.db.controllers.AuditLog.teamLog(
-                invitation.team.id,
-                request.session.User.id,
-                'user.invite.accept'
-            )
+            await app.db.controllers.Invitation.acceptInvitation(invitation, request.session.User)
             reply.send({ status: 'okay' })
         } else {
             reply.code(404).type('text/html').send('Not Found')
@@ -48,12 +40,7 @@ module.exports = async function (app) {
     app.delete('/:invitationId', async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId, request.session.User)
         if (invitation) {
-            await invitation.destroy()
-            await app.db.controllers.AuditLog.teamLog(
-                invitation.team.id,
-                request.session.User.id,
-                'user.invite.reject'
-            )
+            await app.db.controllers.Invitation.rejectInvitation(invitation, request.session.User)
             reply.send({ status: 'okay' })
         } else {
             reply.code(404).type('text/html').send('Not Found')

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -1,5 +1,4 @@
 const sharedUser = require('./shared/users')
-const { Roles, RoleNames } = require('../../lib/roles.js')
 
 /**
  * Users api routes

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -89,23 +89,10 @@ module.exports = async function (app) {
             })
 
             if (request.body.createDefaultTeam) {
-                const newTeam = await app.db.models.Team.create({
+                await app.db.controllers.Team.createTeamForUser({
                     name: `Team ${request.body.name}`,
                     slug: request.body.username
-                })
-                await newTeam.addUser(newUser, { through: { role: Roles.Owner } })
-                // DRY: /api/v1/teams - create team route does this as well
-                await app.db.controllers.AuditLog.teamLog(
-                    newTeam.id,
-                    request.session.User.id,
-                    'team.created'
-                )
-                await app.db.controllers.AuditLog.teamLog(
-                    newTeam.id,
-                    newUser.id,
-                    'user.added',
-                    { role: RoleNames[Roles.Owner] }
-                )
+                }, newUser)
             }
             reply.send({ status: 'okay' })
         } catch (err) {

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -17,7 +17,7 @@
  */
 const fp = require('fastify-plugin')
 
-const { Roles } = require('../../lib/roles')
+const { Roles, RoleNames } = require('../../lib/roles')
 
 // Default to a 12 hour session if the user ticks 'remember me'
 // TODO - turn this into an idle timeout, with a separate 'max session' timeout.
@@ -284,20 +284,24 @@ module.exports = fp(async function (app, opts, done) {
             const verifiedUser = await app.db.controllers.User.verifyEmailToken(sessionUser, request.params.token)
 
             if (app.settings.get('user:team:auto-create')) {
-                // Create a team
-                const newTeam = await app.db.models.Team.create({
+                await app.db.controllers.Team.createTeamForUser({
                     name: `Team ${verifiedUser.name}`,
                     slug: verifiedUser.username
-                })
-                await newTeam.addUser(verifiedUser, { through: { role: Roles.Owner } })
+                }, verifiedUser)
             }
 
             const pendingInvitations = await app.db.models.Invitation.forExternalEmail(verifiedUser.email)
             for (let i = 0; i < pendingInvitations.length; i++) {
                 const invite = pendingInvitations[i]
-                invite.external = false
-                invite.inviteeId = verifiedUser.id
-                await invite.save()
+                // For now we'll auto-accept any invites for this user
+                // See https://github.com/flowforge/flowforge/issues/275#issuecomment-1040113991
+                await app.db.controllers.Invitation.acceptInvitation(invite, verifiedUser)
+                // // If we go back to having the user be able to accept invites
+                // // as a secondary step, the following code will convert the external
+                // // invite into an internal one.
+                // invite.external = false
+                // invite.inviteeId = verifiedUser.id
+                // await invite.save()
             }
 
             reply.redirect('/')

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -17,8 +17,6 @@
  */
 const fp = require('fastify-plugin')
 
-const { Roles, RoleNames } = require('../../lib/roles')
-
 // Default to a 12 hour session if the user ticks 'remember me'
 // TODO - turn this into an idle timeout, with a separate 'max session' timeout.
 const SESSION_MAX_AGE = 60 * 60 * 12 // 12 hours in seconds

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -8,7 +8,7 @@
                 and provide their login details manually
             </template>
         </FormRow>
-        <FormRow v-model="input['user:team:auto-create']" type="checkbox" :disabled="!input['user:signup']">
+        <FormRow v-model="input['user:team:auto-create']" type="checkbox">
             Create a personal team for users when they register
             <template #description>
                 If a team is not automatically created, they will either have to manually create one, or be invited


### PR DESCRIPTION
Fixes #275

This PR also centralises the logic for accepting/rejecting invites and for creating teams. This ensures complete consistency around audit-logging and reduces code duplication.

It also allows the 'create personal team' option to be enabled even if the user-can-register option is disabled - which allows a personal team to be created when accepting an invite.