### PR TITLE
Add initial Project Stacks

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -3,13 +3,10 @@ module.exports = {
         this._driver = driver
         this._app = app
         this.options = options
-
-        let value = {}
+        this.properties = {}
         if (driver.init) {
-            value = await this._driver.init(app, options)
+            this.properties = await this._driver.init(app, options)
         }
-
-        return value
     },
     create: async (project, options) => {
         let value = {}
@@ -74,5 +71,6 @@ module.exports = {
         if (this._driver.shutdown) {
             await this._driver.shutdown()
         }
-    }
+    },
+    properties: () => this.properties
 }

--- a/forge/db/migrations/20220214-01-add-stacks.js
+++ b/forge/db/migrations/20220214-01-add-stacks.js
@@ -12,21 +12,18 @@ module.exports = {
                 autoIncrement: true
             },
             active: { type: DataTypes.BOOLEAN, defaultValue: true },
-            name: { type: DataTypes.STRING, allowNull: false },
-            nodejs: { type: DataTypes.STRING, allowNull: false },
-            nodered: { type: DataTypes.STRING, allowNull: false },
-            memory: { type: DataTypes.STRING, allowNull: false },
-            cpu: { type: DataTypes.STRING, allowNull: false },
-            driverProperties: { type: DataTypes.TEXT },
+            name: { type: DataTypes.STRING, allowNull: false, unique: true },
+            properties: { type: DataTypes.TEXT },
             createdAt: { type: DataTypes.DATE },
             updatedAt: { type: DataTypes.DATE }
         })
-        await context.addColumn('Projects', 'ProjectStackId', {
+        await context.addColumn('Projects', 'stackId', {
             type: DataTypes.INTEGER,
             references: { model: 'ProjectStacks', key: 'id' },
             onDelete: 'set null',
             onUpdate: 'cascade'
         })
+        await context.removeColumn('Projects', 'type')
     },
     down: async (context) => {
     }

--- a/forge/db/migrations/20220214-01-add-stacks.js
+++ b/forge/db/migrations/20220214-01-add-stacks.js
@@ -1,0 +1,33 @@
+/**
+ * Add the ProjectStacks table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.createTable('ProjectStacks', {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            active: { type: DataTypes.BOOLEAN, defaultValue: true },
+            name: { type: DataTypes.STRING, allowNull: false },
+            nodejs: { type: DataTypes.STRING, allowNull: false },
+            nodered: { type: DataTypes.STRING, allowNull: false },
+            memory: { type: DataTypes.STRING, allowNull: false },
+            cpu: { type: DataTypes.STRING, allowNull: false },
+            driverProperties: { type: DataTypes.TEXT },
+            createdAt: { type: DataTypes.DATE },
+            updatedAt: { type: DataTypes.DATE }
+        })
+        await context.addColumn('Projects', 'ProjectStackId', {
+            type: DataTypes.INTEGER,
+            references: { model: 'ProjectStacks', key: 'id' },
+            onDelete: 'set null',
+            onUpdate: 'cascade'
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/migrations/20220214-01-add-stacks.js
+++ b/forge/db/migrations/20220214-01-add-stacks.js
@@ -17,13 +17,19 @@ module.exports = {
             createdAt: { type: DataTypes.DATE },
             updatedAt: { type: DataTypes.DATE }
         })
-        await context.addColumn('Projects', 'stackId', {
+        await context.addColumn('Projects', 'ProjectStackId', {
             type: DataTypes.INTEGER,
             references: { model: 'ProjectStacks', key: 'id' },
             onDelete: 'set null',
             onUpdate: 'cascade'
         })
-        await context.removeColumn('Projects', 'type')
+        // We cannot safely remove columns when using sqlite as it triggers
+        // 'on delete cascade' events that wipes the ProjectSettings table
+        // https://stackoverflow.com/a/70486686/2117239
+        // Possible workaround is to wrap this with a modification to the
+        // other tables to remove the `on delete cascade` constraint - and
+        // then restore it afterwards.
+        // await context.removeColumn('Projects', 'type')
     },
     down: async (context) => {
     }

--- a/forge/db/migrations/20220214-02-add-templates.js
+++ b/forge/db/migrations/20220214-02-add-templates.js
@@ -1,0 +1,34 @@
+/**
+ * Add the ProjectTemplates
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.createTable('ProjectTemplates', {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            name: { type: DataTypes.STRING },
+            settings: { type: DataTypes.TEXT },
+            createdAt: { type: DataTypes.DATE },
+            updatedAt: { type: DataTypes.DATE },
+            ParentId: {
+                type: DataTypes.INTEGER,
+                references: { model: 'ProjectTemplates', key: 'id' },
+                onDelete: 'set null',
+                onUpdate: 'cascade'
+            }
+        })
+        await context.addColumn('Projects', 'ProjectTemplateId', {
+            type: DataTypes.INTEGER,
+            references: { model: 'ProjectTemplates', key: 'id' },
+            onDelete: 'set null',
+            onUpdate: 'cascade'
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/migrations/_20220214-02-add-templates.js
+++ b/forge/db/migrations/_20220214-02-add-templates.js
@@ -11,7 +11,7 @@ module.exports = {
                 primaryKey: true,
                 autoIncrement: true
             },
-            name: { type: DataTypes.STRING },
+            name: { type: DataTypes.STRING, unique: true },
             settings: { type: DataTypes.TEXT },
             createdAt: { type: DataTypes.DATE },
             updatedAt: { type: DataTypes.DATE },

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -11,6 +11,7 @@ module.exports = {
     schema: {
         id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
         name: { type: DataTypes.STRING, allowNull: false },
+        type: { type: DataTypes.STRING, allowNull: false },
         url: { type: DataTypes.STRING, allowNull: false },
         slug: { type: DataTypes.VIRTUAL, get () { return this.id } },
         state: { type: DataTypes.STRING, allowNull: false, defaultValue: 'running' },

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -43,6 +43,8 @@ module.exports = {
             }
         })
         this.hasMany(M.ProjectSettings)
+        this.belongsTo(M.ProjectStack)
+        this.belongsTo(M.ProjectTemplate)
     },
     hooks: function (M) {
         return {

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -11,7 +11,6 @@ module.exports = {
     schema: {
         id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
         name: { type: DataTypes.STRING, allowNull: false },
-        type: { type: DataTypes.STRING, allowNull: false },
         url: { type: DataTypes.STRING, allowNull: false },
         slug: { type: DataTypes.VIRTUAL, get () { return this.id } },
         state: { type: DataTypes.STRING, allowNull: false, defaultValue: 'running' },
@@ -44,7 +43,7 @@ module.exports = {
         })
         this.hasMany(M.ProjectSettings)
         this.belongsTo(M.ProjectStack)
-        this.belongsTo(M.ProjectTemplate)
+        // this.belongsTo(M.ProjectTemplate)
     },
     hooks: function (M) {
         return {
@@ -136,12 +135,17 @@ module.exports = {
                     return this.findAll({
                         include: {
                             model: M.Team,
-                            include: {
-                                model: M.TeamMember,
-                                where: {
-                                    UserId: user.id
+                            include: [
+                                {
+                                    model: M.TeamMember,
+                                    where: {
+                                        UserId: user.id
+                                    }
+                                },
+                                {
+                                    model: M.ProjectStack
                                 }
-                            },
+                            ],
                             required: true
                         }
                     })
@@ -149,20 +153,30 @@ module.exports = {
                 byId: async (id) => {
                     return this.findOne({
                         where: { id: id },
-                        include: {
-                            model: M.Team,
-                            attributes: ['id', 'name', 'slug', 'links']
-                        }
+                        include: [
+                            {
+                                model: M.Team,
+                                attributes: ['id', 'name', 'slug', 'links']
+                            },
+                            {
+                                model: M.ProjectStack
+                            }
+                        ]
                     })
                 },
                 byTeam: async (teamHashId) => {
                     const teamId = M.Team.decodeHashid(teamHashId)
                     return this.findAll({
-                        include: {
-                            model: M.Team,
-                            where: { id: teamId },
-                            attributes: ['id', 'name', 'slug', 'links']
-                        }
+                        include: [
+                            {
+                                model: M.Team,
+                                where: { id: teamId },
+                                attributes: ['id', 'name', 'slug', 'links']
+                            },
+                            {
+                                model: M.ProjectStack
+                            }
+                        ]
                     })
                 }
             }

--- a/forge/db/models/ProjectStack.js
+++ b/forge/db/models/ProjectStack.js
@@ -2,30 +2,101 @@
  * A Project Stack definition
  * @namespace forge.db.models.ProjectStack
  */
-const { DataTypes } = require('sequelize')
+const { DataTypes, literal, Op } = require('sequelize')
 
 module.exports = {
     name: 'ProjectStack',
     schema: {
-        name: { type: DataTypes.STRING, allowNull: false },
+        name: { type: DataTypes.STRING, allowNull: false, unique: true },
         active: { type: DataTypes.BOOLEAN, defaultValue: true },
-        nodejs: { type: DataTypes.STRING, allowNull: false },
-        nodered: { type: DataTypes.STRING, allowNull: false },
-        memory: { type: DataTypes.STRING, allowNull: false },
-        cpu: { type: DataTypes.STRING, allowNull: false },
-        driverProperties: {
+        properties: {
             type: DataTypes.TEXT,
             set (value) {
-                this.setDataValue('driverProperties', JSON.stringify(value))
+                this.setDataValue('properties', JSON.stringify(value))
             },
             get () {
-                const rawValue = this.getDataValue('driverProperties') || '{}'
+                const rawValue = this.getDataValue('properties') || '{}'
                 return JSON.parse(rawValue)
             }
-
         }
+    },
+    meta: {
+        links: 'stacks'
     },
     associations: function (M) {
         this.hasMany(M.Project)
+    },
+    hooks: {
+        beforeDestroy: async (stack, opts) => {
+            const projectCount = await stack.projectCount()
+            if (projectCount > 0) {
+                throw new Error('Cannot delete stack that is used by projects')
+            }
+        }
+    },
+    finders: function (M) {
+        const self = this
+        return {
+            static: {
+                byId: async function (id) {
+                    if (typeof id === 'string') {
+                        id = M.ProjectStack.decodeHashid(id)
+                    }
+                    return self.findOne({
+                        where: { id },
+                        attributes: {
+                            include: [
+                                [
+                                    literal(`(
+                                        SELECT COUNT(*)
+                                        FROM "Projects" AS "project"
+                                        WHERE
+                                        "project"."ProjectStackId" = "ProjectStack"."id"
+                                    )`),
+                                    'projectCount'
+                                ]
+                            ]
+                        }
+                    })
+                },
+                getAll: async (pagination = {}) => {
+                    const limit = parseInt(pagination.limit) || 30
+                    const where = {}
+                    if (pagination.cursor) {
+                        where.id = { [Op.gt]: M.ProjectStack.decodeHashid(pagination.cursor) }
+                    }
+                    const { count, rows } = await this.findAndCountAll({
+                        where,
+                        order: [['id', 'ASC']],
+                        limit,
+                        attributes: {
+                            include: [
+                                [
+                                    literal(`(
+                                        SELECT COUNT(*)
+                                        FROM "Projects" AS "project"
+                                        WHERE
+                                        "project"."ProjectStackId" = "ProjectStack"."id"
+                                    )`),
+                                    'projectCount'
+                                ]
+                            ]
+                        }
+                    })
+                    return {
+                        meta: {
+                            next_cursor: rows.length === limit ? rows[rows.length - 1].hashid : undefined
+                        },
+                        count: count,
+                        stacks: rows
+                    }
+                }
+            },
+            instance: {
+                projectCount: async function () {
+                    return await M.Project.count({ where: { ProjectStackId: this.id } })
+                }
+            }
+        }
     }
 }

--- a/forge/db/models/ProjectStack.js
+++ b/forge/db/models/ProjectStack.js
@@ -1,0 +1,31 @@
+/**
+ * A Project Stack definition
+ * @namespace forge.db.models.ProjectStack
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    name: 'ProjectStack',
+    schema: {
+        name: { type: DataTypes.STRING, allowNull: false },
+        active: { type: DataTypes.BOOLEAN, defaultValue: true },
+        nodejs: { type: DataTypes.STRING, allowNull: false },
+        nodered: { type: DataTypes.STRING, allowNull: false },
+        memory: { type: DataTypes.STRING, allowNull: false },
+        cpu: { type: DataTypes.STRING, allowNull: false },
+        driverProperties: {
+            type: DataTypes.TEXT,
+            set (value) {
+                this.setDataValue('driverProperties', JSON.stringify(value))
+            },
+            get () {
+                const rawValue = this.getDataValue('driverProperties') || '{}'
+                return JSON.parse(rawValue)
+            }
+
+        }
+    },
+    associations: function (M) {
+        this.hasMany(M.Project)
+    }
+}

--- a/forge/db/models/ProjectTemplate.js
+++ b/forge/db/models/ProjectTemplate.js
@@ -1,0 +1,27 @@
+/**
+ * A Project Stack definition
+ * @namespace forge.db.models.ProjectTemplate
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    name: 'ProjectTemplate',
+    schema: {
+        name: { type: DataTypes.STRING, allowNull: false },
+        settings: {
+            type: DataTypes.TEXT,
+            set (value) {
+                this.setDataValue('settings', JSON.stringify(value))
+            },
+            get () {
+                const rawValue = this.getDataValue('settings') || '{}'
+                return JSON.parse(rawValue)
+            }
+        }
+    },
+    associations: function (M) {
+        this.hasMany(M.Project)
+        this.hasMany(this, { as: 'children', foreignKey: 'ParentId' })
+        this.belongsTo(this, { as: 'parent', foreignKey: 'ParentId' })
+    }
+}

--- a/forge/db/models/ProjectTemplate.js
+++ b/forge/db/models/ProjectTemplate.js
@@ -7,7 +7,7 @@ const { DataTypes } = require('sequelize')
 module.exports = {
     name: 'ProjectTemplate',
     schema: {
-        name: { type: DataTypes.STRING, allowNull: false },
+        name: { type: DataTypes.STRING, allowNull: false, unique: true },
         settings: {
             type: DataTypes.TEXT,
             set (value) {

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -52,6 +52,8 @@ const modelTypes = [
     'Session',
     'Project',
     'ProjectSettings',
+    'ProjectStack',
+    'ProjectTemplate',
     'AccessToken',
     'AuthClient',
     'StorageFlow',

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -53,7 +53,7 @@ const modelTypes = [
     'Project',
     'ProjectSettings',
     'ProjectStack',
-    'ProjectTemplate',
+    // 'ProjectTemplate',
     'AccessToken',
     'AuthClient',
     'StorageFlow',
@@ -151,11 +151,12 @@ async function init (app) {
         }
 
         if (!m.schema.links && (!m.meta || m.meta.links !== false)) {
+            const pathComponent = (m.meta && typeof m.meta.links === 'string') ? m.meta.links : (m.name.toLowerCase() + 's')
             m.schema.links = {
                 type: DataTypes.VIRTUAL,
                 get () {
                     return {
-                        self: app.config.base_url + '/api/v1/' + m.name.toLowerCase() + 's/' + this.hashid
+                        self: `${app.config.base_url}/api/v1/${pathComponent}/${this.hashid}`
                     }
                 }
             }

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -4,7 +4,6 @@ module.exports = {
         const result = {
             id: proj.id,
             name: proj.name,
-            type: proj.type,
             url: proj.url,
             createdAt: proj.createdAt,
             updatedAt: proj.updatedAt,
@@ -16,6 +15,14 @@ module.exports = {
                 name: proj.Team.name,
                 slug: proj.Team.slug,
                 links: proj.Team.links
+            }
+        }
+        if (proj.ProjectStack) {
+            result.stack = {
+                id: proj.ProjectStack.hashid,
+                name: proj.ProjectStack.name,
+                properties: proj.ProjectStack.properties || {},
+                links: proj.ProjectStack.links
             }
         }
         return result
@@ -30,7 +37,6 @@ module.exports = {
             return {
                 id: t.id,
                 name: t.name,
-                type: t.type,
                 url: t.url,
                 createdAt: t.createdAt,
                 updatedAt: t.updatedAt,

--- a/forge/db/views/ProjectStack.js
+++ b/forge/db/views/ProjectStack.js
@@ -1,0 +1,18 @@
+module.exports = {
+    stack: function (app, stack) {
+        if (stack) {
+            const result = stack.toJSON()
+            const filtered = {
+                id: result.hashid,
+                name: result.name,
+                active: result.active,
+                properties: result.properties || {},
+                createdAt: result.createdAt,
+                projectCount: result.projectCount
+            }
+            return filtered
+        } else {
+            return null
+        }
+    }
+}

--- a/forge/db/views/index.js
+++ b/forge/db/views/index.js
@@ -10,7 +10,7 @@
  * @memberof forge.db
  */
 
-const modelTypes = ['User', 'Team', 'Project', 'Invitation', 'AuditLog']
+const modelTypes = ['User', 'Team', 'Project', 'Invitation', 'AuditLog', 'ProjectStack']
 
 async function init (app) {
     modelTypes.forEach(type => {

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -11,6 +11,8 @@ const Team = require('./team.js')
 const Project = require('./project.js')
 const Admin = require('./admin.js')
 const Settings = require('./settings.js')
+const Stack = require('./stack.js')
+const Template = require('./template.js')
 
 module.exports = async function (app) {
     app.addHook('preHandler', app.verifyTokenOrSession)
@@ -31,6 +33,8 @@ module.exports = async function (app) {
     app.register(Users, { prefix: '/users' })
     app.register(Team, { prefix: '/teams' })
     app.register(Project, { prefix: '/projects' })
+    app.register(Stack, { prefix: '/stacks' })
+    app.register(Template, { prefix: '/templates' })
     app.get('*', function (request, reply) {
         reply.code(404).type('text/html').send('Not Found')
     })

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -12,7 +12,7 @@ const Project = require('./project.js')
 const Admin = require('./admin.js')
 const Settings = require('./settings.js')
 const Stack = require('./stack.js')
-const Template = require('./template.js')
+// const Template = require('./template.js')
 
 module.exports = async function (app) {
     app.addHook('preHandler', app.verifyTokenOrSession)
@@ -34,7 +34,7 @@ module.exports = async function (app) {
     app.register(Team, { prefix: '/teams' })
     app.register(Project, { prefix: '/projects' })
     app.register(Stack, { prefix: '/stacks' })
-    app.register(Template, { prefix: '/templates' })
+    // app.register(Template, { prefix: '/templates' })
     app.get('*', function (request, reply) {
         reply.code(404).type('text/html').send('Not Found')
     })

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -121,7 +121,7 @@ module.exports = async function (app) {
         await project.setProjectStack(stack)
         await project.reload({
             include: [
-                { model: app.db.model.ProjectStacks }
+                { model: app.db.models.ProjectStack }
             ]
         })
         await app.containers.create(project, {})

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -118,7 +118,11 @@ module.exports = async function (app) {
 
         await team.addProject(project)
         await project.setProjectStack(stack)
-
+        await project.reload({
+            include: [
+                { model: app.db.model.ProjectStacks }
+            ]
+        })
         await app.containers.create(project, {})
 
         await app.db.controllers.AuditLog.projectLog(

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -104,6 +104,7 @@ module.exports = async function (app) {
 
         const project = await app.db.models.Project.create({
             name: request.body.name,
+            type: '',
             url: ''
         })
 

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -15,7 +15,8 @@ module.exports = async function (app) {
             const response = {
                 'team:user:invite:external': app.settings.get('team:user:invite:external') && app.postoffice.enabled(),
                 'team:create': app.settings.get('team:create'),
-                email: app.postoffice.enabled()
+                email: app.postoffice.enabled(),
+                stacks: app.containers.properties().stack || {}
             }
 
             if (request.session.User.admin) {

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -14,6 +14,10 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.stacks
      */
     app.get('/', async (request, reply) => {
+        const paginationOptions = app.getPaginationOptions(request)
+        const stacks = await app.db.models.ProjectStack.getAll(paginationOptions)
+        stacks.stacks = stacks.stacks.map(s => app.db.views.ProjectStack.stack(s))
+        reply.send(stacks)
     })
 
     /**
@@ -23,6 +27,12 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.stacks
      */
     app.get('/:stackId', async (request, reply) => {
+        const stack = await app.db.models.ProjectStack.byId(request.params.stackId)
+        if (stack) {
+            reply.send(app.db.views.ProjectStack.stack(stack))
+        } else {
+            reply.code(404).type('text/html').send('Not Found')
+        }
     })
 
     /**
@@ -32,8 +42,39 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.stacks
      */
     app.post('/', {
-        preHandler: app.needsPermission('stack:create')
+        preHandler: app.needsPermission('stack:create'),
+        schema: {
+            body: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                    name: { type: 'string' },
+                    active: { type: 'boolean' },
+                    properties: { type: 'object' }
+                }
+            }
+        }
     }, async (request, reply) => {
+        // Only admins can create a stack
+        const stackProperties = {
+            name: request.body.name,
+            active: request.body.active !== undefined ? request.body.active : undefined,
+            properties: request.body.properties
+        }
+        try {
+            const stack = await app.db.models.ProjectStack.create(stackProperties)
+            const response = app.db.views.ProjectStack.stack(stack)
+            response.projectCount = 0
+            reply.send(response)
+        } catch (err) {
+            let responseMessage
+            if (err.errors) {
+                responseMessage = err.errors.map(err => err.message).join(',')
+            } else {
+                responseMessage = err.toString()
+            }
+            reply.code(400).send({ error: responseMessage })
+        }
     })
 
     /**
@@ -45,6 +86,15 @@ module.exports = async function (app) {
     app.delete('/:stackId', {
         preHandler: app.needsPermission('stack:delete')
     }, async (request, reply) => {
+        const stack = await app.db.models.ProjectStack.byId(request.params.stackId)
+        // The `beforeDestroy` hook of the ProjectStack model ensures
+        // we don't delete an in-use stack
+        try {
+            await stack.destroy()
+            reply.send({ status: 'okay' })
+        } catch (err) {
+            reply.code(400).send({ error: err.toString() })
+        }
     })
 
     /**
@@ -56,5 +106,21 @@ module.exports = async function (app) {
     app.put('/:stackId', {
         preHandler: app.needsPermission('stack:edit')
     }, async (request, reply) => {
+        const stack = await app.db.models.ProjectStack.byId(request.params.stackId)
+        if (stack.projectCount > 0) {
+            reply.code(400).send({ error: 'Cannot edit in-use stack' })
+        } else {
+            if (request.body.name !== undefined) {
+                stack.name = request.body.name
+            }
+            if (request.body.active !== undefined) {
+                stack.active = request.body.active
+            }
+            if (request.body.properties !== undefined) {
+                stack.properties = request.body.properties
+            }
+            await stack.save()
+            reply.send(app.db.views.ProjectStack.stack(stack))
+        }
     })
 }

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -1,0 +1,60 @@
+/**
+ * Project stack api routes
+ *
+ * - /api/v1/stacks
+ *
+ * @namespace stacks
+ * @memberof forge.routes.api
+ */
+module.exports = async function (app) {
+    /**
+     * Get a list of all stacks
+     * @name /api/v1/stacks/:id
+     * @static
+     * @memberof forge.routes.api.stacks
+     */
+    app.get('/', async (request, reply) => {
+    })
+
+    /**
+     * Get the details of a stack
+     * @name /api/v1/stacks/:id
+     * @static
+     * @memberof forge.routes.api.stacks
+     */
+    app.get('/:stackId', async (request, reply) => {
+    })
+
+    /**
+     * Create a stack
+     * @name /api/v1/stacks
+     * @static
+     * @memberof forge.routes.api.stacks
+     */
+    app.post('/', {
+        preHandler: app.needsPermission('stack:create')
+    }, async (request, reply) => {
+    })
+
+    /**
+     * Delete a stack
+     * @name /api/v1/stacks
+     * @static
+     * @memberof forge.routes.api.stacks
+     */
+    app.delete('/:stackId', {
+        preHandler: app.needsPermission('stack:delete')
+    }, async (request, reply) => {
+    })
+
+    /**
+     * Update a stack
+     * @name /api/v1/stacks
+     * @static
+     * @memberof forge.routes.api.stacks
+     */
+    app.put('/:stackId', {
+        preHandler: app.needsPermission('stack:edit')
+    }, async (request, reply) => {
+    })
+}

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -7,7 +7,6 @@
  * @memberof forge.routes.api
  */
 module.exports = async function (app) {
-
     /**
      * Get a list of all templates
      * @name /api/v1/templates/:id

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -1,0 +1,61 @@
+/**
+ * Project Template api routes
+ *
+ * - /api/v1/templates
+ *
+ * @namespace templates
+ * @memberof forge.routes.api
+ */
+module.exports = async function (app) {
+
+    /**
+     * Get a list of all templates
+     * @name /api/v1/templates/:id
+     * @static
+     * @memberof forge.routes.api.templates
+     */
+    app.get('/', async (request, reply) => {
+    })
+
+    /**
+     * Get the details of a template
+     * @name /api/v1/templates/:id
+     * @static
+     * @memberof forge.routes.api.templates
+     */
+    app.get('/:templateId', async (request, reply) => {
+    })
+
+    /**
+     * Create a template
+     * @name /api/v1/templates
+     * @static
+     * @memberof forge.routes.api.templates
+     */
+    app.post('/', {
+        preHandler: app.needsPermission('template:create')
+    }, async (request, reply) => {
+    })
+
+    /**
+     * Delete a template
+     * @name /api/v1/templates
+     * @static
+     * @memberof forge.routes.api.templates
+     */
+    app.delete('/:templateId', {
+        preHandler: app.needsPermission('template:delete')
+    }, async (request, reply) => {
+    })
+
+    /**
+     * Update a template
+     * @name /api/v1/templates
+     * @static
+     * @memberof forge.routes.api.templates
+     */
+    app.put('/:templateId', {
+        preHandler: app.needsPermission('template:edit')
+    }, async (request, reply) => {
+    })
+}

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -22,7 +22,16 @@ const defaultPermissions = {
     'project:audit-log': { description: 'Access Project Audit Log', role: Roles.Member },
     // Project Editor
     'project:flows:view': { description: 'View Project Flows', role: Roles.Member },
-    'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member }
+    'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member },
+    // Templates
+    'template:create': { description: 'Create a Template', role: Roles.Admin },
+    'template:delete': { description: 'Delete a Template', role: Roles.Admin },
+    'template:edit': { description: 'Edit a Template', role: Roles.Admin },
+    // Stacks
+    'stack:create': { description: 'Create a Stack', role: Roles.Admin },
+    'stack:delete': { description: 'Delete a Stack', role: Roles.Admin },
+    'stack:edit': { description: 'Edit a Stack', role: Roles.Admin }
+
 }
 
 module.exports = fp(async function (app, opts, done) {

--- a/frontend/src/api/stacks.js
+++ b/frontend/src/api/stacks.js
@@ -1,0 +1,34 @@
+import client from './client'
+import paginateUrl from '@/utils/paginateUrl'
+
+const getStacks = async (cursor, limit) => {
+    const url = paginateUrl('/api/v1/stacks', cursor, limit)
+    return client.get(url).then(res => {
+        return res.data
+    })
+}
+
+const create = async (options) => {
+    return client.post('/api/v1/stacks/', options).then(res => {
+        return res.data
+    })
+}
+const deleteStack = async (stackId) => {
+    return await client.delete(`/api/v1/stacks/${stackId}`)
+}
+const getStack = async (stackId) => {
+    return await client.get(`/api/v1/stacks/${stackId}`)
+}
+const updateStack = async (stackId, options) => {
+    return client.put(`/api/v1/stacks/${stackId}`, options).then(res => {
+        return res.data
+    })
+}
+
+export default {
+    create,
+    getStack,
+    deleteStack,
+    getStacks,
+    updateStack
+}

--- a/frontend/src/pages/admin/AdminStackEditButton.vue
+++ b/frontend/src/pages/admin/AdminStackEditButton.vue
@@ -1,0 +1,23 @@
+<template>
+    <DropdownMenu buttonClass="forge-button-inline px-2" alt="Open stack menu" :options="options"></DropdownMenu>
+</template>
+<script>
+import { DotsHorizontalIcon } from '@heroicons/vue/outline'
+import DropdownMenu from '@/components/DropdownMenu'
+export default {
+    name: "AdminStackEditButton",
+    props: ['onedit', 'ondelete'],
+    computed: {
+        options: function() {
+            return [
+                { name: "Edit stack", action: () => { this.onedit() } },
+                { name: "Delete stack", action: () => { this.ondelete() } },
+            ]
+        }
+    },
+    components: {
+        DotsHorizontalIcon,
+        DropdownMenu
+    }
+}
+</script>

--- a/frontend/src/pages/admin/Stacks.vue
+++ b/frontend/src/pages/admin/Stacks.vue
@@ -1,0 +1,119 @@
+<template>
+    <form class="space-y-6">
+        <FormHeading>Stacks
+            <template v-slot:tools>
+                <button type="button" class="forge-button pl-2 mb-1" @click="showCreateStackDialog"><span class="text-xs">Create stack</span></button>
+            </template>
+        </FormHeading>
+        <ItemTable :items="stacks" :columns="columns" />
+        <div v-if="nextCursor">
+            <a v-if="!loading" @click.stop="loadItems" class="forge-button-inline">Load more...</a>
+        </div>
+    </form>
+    <AdminStackEditDialog @stackCreated="stackCreated" @stackUpdated="stackUpdated" ref="adminStackEditDialog"/>
+    <AdminStackDeleteDialog @deleteStack="deleteStack"  ref="adminStackDeleteDialog"/>
+
+</template>
+
+<script>
+import stacksApi from '@/api/stacks'
+
+import ItemTable from '@/components/tables/ItemTable'
+import FormRow from '@/components/FormRow'
+import FormHeading from '@/components/FormHeading'
+import Breadcrumbs from '@/mixins/Breadcrumbs';
+
+import TeamCell from '@/components/tables/cells/TeamCell'
+import { markRaw } from "vue"
+import { mapState } from 'vuex'
+
+import AdminStackEditDialog from './dialogs/AdminStackEditDialog'
+import AdminStackEditButton from './AdminStackEditButton'
+import AdminStackDeleteDialog from './dialogs/AdminStackDeleteDialog'
+
+const StackPropertiesTable = {
+    template: `<div>{{properties}}</div>`,
+    props: ['properties']
+}
+
+export default {
+    name: 'AdminStacks',
+    mixins: [ Breadcrumbs ],
+    data() {
+        return {
+            stacks: [],
+            loading: false,
+            nextCursor: null,
+            columns: [
+                {name: "Stack", class: ['w-56'], property: 'name'},
+                {name: "Active", class: ['w-32','text-center'], property: 'active'},
+                {name: "Properties", class: ['flex-grow'],  component: { is: markRaw(StackPropertiesTable)} },
+                {name: 'Project Count', class:['w-32','text-center'],property: 'projectCount'},
+                {name: '', class: ['w-16','text-center'], component: { is: markRaw(AdminStackEditButton)}}
+            ]
+        }
+    },
+    async created() {
+        this.setBreadcrumbs([
+            {label:"Admin", to:{name:"Admin Settings"}},
+            {label:"Stacks"}
+        ]);
+        StackPropertiesTable.template = '<table class="table-auto">'
+        Object.entries(this.settings.stacks.properties).forEach(([key, value]) => {
+            StackPropertiesTable.template += `<tr><td class="pr-8">${value.label}</td><td>{{properties.${key}}}</td></tr>`
+            // tableColumns.push({name: value.label, class:['w-32'], property:`properties.${key}`})
+        })
+        StackPropertiesTable.template += "</table>"
+        await this.loadItems()
+    },
+    computed: {
+        ...mapState('account',['settings']),
+    },
+    methods: {
+        showCreateStackDialog() {
+            this.$refs.adminStackEditDialog.show();
+        },
+        showEditStackDialog(stack) {
+            this.$refs.adminStackEditDialog.show(stack);
+        },
+        showConfirmStackDeleteDialog(stack) {
+            this.$refs.adminStackDeleteDialog.show(stack);
+        },
+        async stackCreated(stack) {
+            stack.onedit = (data) => { this.showEditStackDialog(stack); }
+            stack.ondelete = (data) => { this.showConfirmStackDeleteDialog(stack); }
+            this.stacks.push(stack)
+        },
+        async stackUpdated(stack) {
+            const index = this.stacks.findIndex(s => s.id === stack.id)
+            if (index > -1) {
+                stack.onedit = (data) => { this.showEditStackDialog(stack); }
+                stack.ondelete = (data) => { this.showConfirmStackDeleteDialog(stack); }
+                this.stacks[index] = stack
+            }
+        },
+        async deleteStack(stack) {
+            const result = await stacksApi.deleteStack(stack.id)
+            const index = this.stacks.indexOf(stack)
+            this.stacks.splice(index,1)
+        },
+        loadItems: async function() {
+            this.loading = true;
+            const result = await stacksApi.getStacks(this.nextCursor,30)
+            this.nextCursor = result.meta.next_cursor;
+            result.stacks.forEach(v => {
+                v.onedit = (data) => { this.showEditStackDialog(v); }
+                v.ondelete = (data) => { this.showConfirmStackDeleteDialog(v); }
+                this.stacks.push(v);
+            })
+        },
+    },
+    components: {
+        FormRow,
+        FormHeading,
+        ItemTable,
+        AdminStackEditDialog,
+        AdminStackDeleteDialog
+    }
+}
+</script>

--- a/frontend/src/pages/admin/dialogs/AdminStackDeleteDialog.vue
+++ b/frontend/src/pages/admin/dialogs/AdminStackDeleteDialog.vue
@@ -1,0 +1,95 @@
+<template>
+  <TransitionRoot appear :show="isOpen" as="template">
+    <Dialog as="div" @close="close">
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div class="min-h-screen px-4 text-center">
+          <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
+          <span class="inline-block h-screen align-middle" aria-hidden="true">
+            &#8203;
+          </span>
+          <TransitionChild
+            as="template"
+            enter="duration-300 ease-out"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
+              <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Delete stack</DialogTitle>
+                <form class="space-y-6">
+                  <div class="mt-2 space-y-2">
+                      <p class="text-sm text-gray-500">
+                          <span v-if="!deleteDisabled">
+                              Are you sure you want to delete this stack?
+                          </span>
+                          <span v-else>
+                              You cannot delete a stack that is still being used by projects.
+                          </span>
+                      </p>
+                  </div>
+                  <div class="mt-4 flex flex-row justify-end">
+                      <button type="button" class="forge-button-secondary ml-4" @click="close">Cancel</button>
+                      <button type="button" class="forge-button-danger ml-4" :disabled="deleteDisabled" @click="confirm">Delete</button>
+                  </div>
+              </form>
+          </div>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script>
+import { ref } from 'vue'
+import {
+    TransitionRoot,
+    TransitionChild,
+    Dialog,
+    DialogOverlay,
+    DialogTitle,
+} from '@headlessui/vue'
+
+import FormRow from '@/components/FormRow'
+
+export default {
+    name: 'AdminStackDeleteDialog',
+
+    components: {
+        TransitionRoot,
+        TransitionChild,
+        Dialog,
+        DialogOverlay,
+        DialogTitle,
+        FormRow
+    },
+    data() {
+        return {
+            deleteDisabled: false,
+            stack: null
+        }
+    },
+    methods: {
+        confirm() {
+            this.$emit('deleteStack', this.stack)
+            this.isOpen = false
+        }
+    },
+    setup() {
+        const isOpen = ref(false)
+        return {
+            isOpen,
+            close() {
+                isOpen.value = false
+            },
+            show(stack) {
+                this.stack = stack;
+                this.deleteDisabled = stack.projectCount > 0;
+                isOpen.value = true
+            },
+        }
+    },
+}
+</script>

--- a/frontend/src/pages/admin/dialogs/AdminStackEditDialog.vue
+++ b/frontend/src/pages/admin/dialogs/AdminStackEditDialog.vue
@@ -1,0 +1,182 @@
+<template>
+  <TransitionRoot appear :show="isOpen" as="template">
+    <Dialog as="div" @close="close">
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div class="min-h-screen px-4 text-center">
+          <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
+          <span class="inline-block h-screen align-middle" aria-hidden="true">
+            &#8203;
+          </span>
+          <TransitionChild
+            as="template"
+            enter="duration-300 ease-out"
+            enter-from="opacity-0 scale-95"
+            enter-to="opacity-100 scale-100"
+            leave="duration-200 ease-in"
+            leave-from="opacity-100 scale-100"
+            leave-to="opacity-0 scale-95"
+          >
+            <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
+              <DialogTitle as="h3" class="text-lg font-medium leading-6"><span v-if="stack">Update</span><span v-else>Create</span> stack</DialogTitle>
+              <form class="space-y-6 mt-2">
+                  <FormRow v-model="input.name" :error="errors.name" :disabled="editDisabled">Name</FormRow>
+                  <FormRow v-model="input.active" type="checkbox">Active</FormRow>
+                  <template v-for="(prop) in stackProperties" :key="prop.name">
+                    <FormRow v-model="input.properties[prop.name]" :error="errors[prop.name]" :disabled="editDisabled">{{prop.label}}</FormRow>
+                  </template>
+                  <div class="mt-4 flex flex-row justify-end">
+                      <button type="button" class="forge-button-secondary ml-4" @click="close">Cancel</button>
+                      <button type="button" :disabled="!formValid" class="forge-button ml-4" @click="confirm"><span v-if="stack">Update</span><span v-else>Create</span></button>
+                  </div>
+              </form>
+          </div>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script>
+import stacksApi from '@/api/stacks'
+
+import { ref } from 'vue'
+import {
+    TransitionRoot,
+    TransitionChild,
+    Dialog,
+    DialogOverlay,
+    DialogTitle,
+} from '@headlessui/vue'
+
+import FormHeading from '@/components/FormHeading'
+import FormRow from '@/components/FormRow'
+import { mapState } from 'vuex'
+
+export default {
+    name: 'AdminStackCreateDialog',
+
+    components: {
+        TransitionRoot,
+        TransitionChild,
+        Dialog,
+        DialogOverlay,
+        DialogTitle,
+        FormRow,
+        FormHeading,
+    },
+    data() {
+        return {
+            input: {
+                name: "",
+                active: true,
+                properties: {}
+            },
+            errors: {},
+            editDisabled: false
+        }
+    },
+    watch: {
+        'input.properties': {
+            deep: true,
+            handler(v) {
+                this.stackProperties.forEach(prop => {
+                    if (v[prop.name] && !prop.validator.test(v[prop.name])) {
+                        this.errors[prop.name] = prop.invalidMessage
+                    } else {
+                        this.errors[prop.name] = ""
+                    }
+                })
+
+            }
+        },
+        'input.name': function(v) {
+            if (v && !/^[a-z0-9-_\/@\.]+$/i.test(v)) {
+                this.errors.name = "Must only contain a-z 0-9 - _ / @ ."
+            } else {
+                this.errors.name = ""
+            }
+        },
+    },
+    computed: {
+        formValid() {
+            return (this.input.name)
+        },
+        ...mapState('account',['settings']),
+        stackProperties() {
+            return Object.entries(this.settings.stacks.properties).map(([key, value]) => {
+                return {
+                    name: key,
+                    label: value.label,
+                    invalidMessage: value.invalidMessage || "Invalid",
+                    validator: new RegExp(value.validate)
+                }
+            })
+        }
+    },
+    methods: {
+        confirm() {
+            const opts = {
+                name: this.input.name,
+                active: this.input.active,
+                properties: {}
+            };
+            this.stackProperties.forEach(prop => {
+                opts.properties[prop.name] = this.input.properties[prop.name]
+            })
+
+            if (this.stack) {
+                // Update
+                stacksApi.updateStack(this.stack.id, opts).then((response) => {
+                    this.isOpen = false
+                    this.$emit('stackUpdated',response)
+                }).catch(err => {
+                    console.log(err.response.data);
+                    if (err.response.data) {
+                        if (/name/.test(err.response.data.error)) {
+                            this.errors.name = "Name unavailable"
+                        }
+                    }
+                });
+            } else {
+                stacksApi.create(opts).then((response) => {
+                    this.isOpen = false
+                    this.$emit('stackCreated',response)
+                }).catch(err => {
+                    console.log(err.response.data);
+                    if (err.response.data) {
+                        if (/name/.test(err.response.data.error)) {
+                            this.errors.name = "Name unavailable"
+                        }
+                    }
+                });
+            }
+        },
+    },
+    setup() {
+        const isOpen = ref(false)
+        return {
+            isOpen,
+            close() {
+                isOpen.value = false
+            },
+            show(stack) {
+                this.stack = stack
+                if (stack) {
+                    this.editDisabled = stack.projectCount > 0
+                    this.input = {
+                        name: stack.name,
+                        active: stack.active,
+                        properties: stack.properties
+                    }
+                } else {
+                    this.editDisabled = false
+                    this.input = { active: true, name: "", properties: {} }
+                }
+                this.errors = {}
+                isOpen.value = true
+            },
+        }
+    },
+}
+</script>

--- a/frontend/src/pages/admin/index.vue
+++ b/frontend/src/pages/admin/index.vue
@@ -16,7 +16,8 @@ const navigation = [
     { name: "Overview", path: "/admin/overview" },
     { name: "Settings", path: "/admin/settings" },
     { name: "Users", path: "/admin/users" },
-    { name: "Teams", path: "/admin/teams" }
+    { name: "Teams", path: "/admin/teams" },
+    { name: "Stacks", path: "/admin/stacks" }
 ]
 
 export default {

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -9,6 +9,7 @@ import AdminUsers from '@/pages/admin/Users/index.vue'
 import AdminUsersGeneral from '@/pages/admin/Users/General.vue'
 import AdminUsersInvitations from '@/pages/admin/Users/Invitations.vue'
 import AdminTeams from '@/pages/admin/Teams.vue'
+import AdminStacks from '@/pages/admin/Stacks.vue'
 import AdminCreateUser from '@/pages/admin/Users/createUser.vue'
 import { AdjustmentsIcon } from '@heroicons/vue/outline'
 
@@ -53,7 +54,8 @@ export default [
                     { path: 'invitations', component: AdminUsersInvitations }
                 ]
             },
-            { path: 'teams', component: AdminTeams }
+            { path: 'teams', component: AdminTeams },
+            { path: 'stacks', component: AdminStacks }
         ]
     }
 ]

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -29,6 +29,7 @@
 
 <script>
 import projectApi from '@/api/project'
+import stacksApi from '@/api/stacks'
 import DropdownMenu from '@/components/DropdownMenu'
 import { ExternalLinkIcon, ClipboardCopyIcon, TrendingUpIcon, TemplateIcon, HeartIcon, CogIcon} from '@heroicons/vue/outline'
 import FormHeading from '@/components/FormHeading'

--- a/frontend/src/pages/project/Settings/General.vue
+++ b/frontend/src/pages/project/Settings/General.vue
@@ -8,6 +8,10 @@
             Name
         </FormRow>
 
+        <FormRow v-model="input.stackDescription" type="uneditable">
+            Stack
+        </FormRow>
+
         <div class="space-x-4 whitespace-nowrap">
             <template v-if="!editing.projectName">
                 <button type="button" class="forge-button forge-button-small" @click="editName">Edit project settings</button>
@@ -39,7 +43,8 @@ export default {
             },
             input: {
                 projectId: "",
-                projectName: ""
+                projectName: "",
+                stackDescription: ""
             },
             original: {
                 projectName: ""
@@ -82,6 +87,9 @@ export default {
         },
         fetchData () {
             this.input.projectId = this.project.id;
+            if (this.project.stack) {
+                this.input.stackDescription = this.project.stack.name;
+            }
             this.input.projectName = this.project.name;
         }
     },

--- a/frontend/src/pages/project/Settings/General.vue
+++ b/frontend/src/pages/project/Settings/General.vue
@@ -89,6 +89,8 @@ export default {
             this.input.projectId = this.project.id;
             if (this.project.stack) {
                 this.input.stackDescription = this.project.stack.name;
+            } else {
+                this.input.stackDescription = "none"
             }
             this.input.projectName = this.project.name;
         }

--- a/frontend/src/pages/project/create.vue
+++ b/frontend/src/pages/project/create.vue
@@ -14,6 +14,8 @@
                     </template>
                 </FormRow>
 
+                <FormRow :options="stacks" v-model="input.stack" id="stack">Stack</FormRow>
+
                 <!-- <FormRow v-model="input.description" id="description">Description</FormRow> -->
 
                 <button type="button" :disabled="!createEnabled" @click="createProject" class="forge-button">
@@ -27,6 +29,7 @@
 <script>
 import teamApi from '@/api/team'
 import projectApi from '@/api/project'
+import stacksApi from '@/api/stacks'
 
 import FormRow from '@/components/FormRow'
 import FormHeading from '@/components/FormHeading'
@@ -43,9 +46,11 @@ export default {
             init: false,
             currentTeam: null,
             teams: [],
+            stacks: [],
             input: {
                 name: NameGenerator(),
                 team: "",
+                stack: "",
                 // description: "",
                 options: {
                     type: "basic"
@@ -83,6 +88,10 @@ export default {
                 { label: 'Create project' }
             ])
         }
+
+        const stackList = await stacksApi.getStacks()
+        this.stacks = stackList.stacks.filter(stack => stack.active).map(stack => { return { value: stack.id, label: stack.name } })
+        this.input.stack = this.stacks.length > 0 ? this.stacks[0].value : ""
         this.init = true;
         setTimeout(() => {
             // There must be a better Vue way of doing this, but I can't find it.

--- a/frontend/src/pages/project/create.vue
+++ b/frontend/src/pages/project/create.vue
@@ -14,7 +14,7 @@
                     </template>
                 </FormRow>
 
-                <FormRow :options="stacks" v-model="input.stack" id="stack">Stack</FormRow>
+                <FormRow :options="stacks" :error="errors.stack" v-model="input.stack" id="stack">Stack</FormRow>
 
                 <!-- <FormRow v-model="input.description" id="description">Description</FormRow> -->
 
@@ -55,12 +55,15 @@ export default {
                 options: {
                     type: "basic"
                 }
+            },
+            errors: {
+                stack: ''
             }
         }
     },
     computed: {
         createEnabled: function() {
-            return this.input.team && this.input.name
+            return this.input.stack && this.input.team && this.input.name
         }
     },
     async created() {
@@ -91,12 +94,15 @@ export default {
 
         const stackList = await stacksApi.getStacks()
         this.stacks = stackList.stacks.filter(stack => stack.active).map(stack => { return { value: stack.id, label: stack.name } })
-        this.input.stack = this.stacks.length > 0 ? this.stacks[0].value : ""
         this.init = true;
         setTimeout(() => {
             // There must be a better Vue way of doing this, but I can't find it.
             // Without the setTimeout, the select box doesn't update
-            this.input.team = this.currentTeam;
+            this.input.team = this.currentTeam
+            this.input.stack = this.stacks.length > 0 ? this.stacks[0].value : ""
+            if (this.stacks.length === 0) {
+                this.errors.stack = "No stacks available. Ask an Administator to create a new stack definition"
+            }
         },100);
     },
     methods: {


### PR DESCRIPTION
This PR adds the initial implementation of Stacks.

This covers:
 - the database model
 - the api endpoints for CRUD actions
 - UI updates to allow Admins to manage stacks
 - Create Project form has a drop-down select to pick the stack to use

A stack consists of:
 - `id`
 - `name` - must be unique and is what the end user sees when picking a stack
 - `active` (boolean) - allows a stack to be disabled (cannot be used to create new projects) without deleting
 - `properties` - an object of driver-defined key/value pairs

The `localfs` driver has been updated via https://github.com/flowforge/flowforge-driver-localfs/pull/30 to support stacks - mainly how it provides a list of the properties a stack should contain.

