### PR TITLE
Allow logging level to be changed

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -36,6 +36,9 @@ module.exports = async (options = {}) => {
     try {
         // Config : loads environment configuration
         await server.register(config, options)
+        if (server.config.logging?.level) {
+            server.log.level = server.config.logging.level
+        }
         // DB : the database connection/models/views/controllers
         await server.register(db)
         // Settings


### PR DESCRIPTION
This allows logging level to be set in the `etc/flowforge.yml` file.

Fixes #337