### PR TITLE
Set up local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "lint:fix": "eslint -c .eslintrc 'forge/**/*.js' 'frontend/**/*.js' 'test/**/*.js' --ignore-pattern 'frontend/dist/**' --fix",
         "test": "npm run lint && npm run test:unit && npm run test:system",
         "test:unit": "mocha test/unit/**/*_spec.js",
-        "test:system": "mocha test/system/**/*_spec.js"
+        "test:system": "mocha test/system/**/*_spec.js",
+        "dev:local": "cd ../flowforge-driver-localfs && npm install ../flowforge-nr-storage ../flowforge-nr-auth ../flowforge-nr-audit-logger && cd ../flowforge && npm install ../flowforge-driver-localfs"
     },
     "bin": {
         "flowforge": "./forge/app.js"


### PR DESCRIPTION
This adds the `dev:local` script to the package.json.

This will convert the current checked out version to local mode. This means that it will load @flowforge/localfs from a locally checked out version (and it's @flowforge/nr-* dependencies)

It expects the following directory tree

devleopment root
  - flowforge
  - flowforge-driver-localfs
  - flowforge-nr-storage
  - flowforge-nr-auth
  - flowforge-nr-audit-logger

Fixes #387 