### PR TITLE
send correct credentials object

### DIFF
--- a/forge/routes/storage/index.js
+++ b/forge/routes/storage/index.js
@@ -75,7 +75,7 @@ module.exports = async function (app) {
         if (project) {
             const creds = await app.db.models.StorageCredentials.byProject(id)
             if (creds) {
-                response.send(creds)
+                response.send(creds.credentials)
             } else {
                 response.send({})
             }


### PR DESCRIPTION
Fix for https://github.com/flowforge/flowforge/issues/397

IMO we should consider a `0.3.1` patch for this rather than waiting till 0.4, as it results in users loosing their credential data from flows on a project restart and there is no log warning or explanation.

