### PR TITLE
Add nyc for code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/jsdoc
 *.env
 *.env.local
 package-lock.json
+coverage
+.nyc_output

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,4 @@
+{
+    "all": true,
+    "include": ["forge/**"]
+}

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -111,3 +111,50 @@ If you are developing locally and need to enable external email sending, you can
    useful app that does the job: https://nodemailer.com/app/
  - Alternatively, set the `email.debug` option to `true` in your configuration file
    and the app will print all emails to its log.
+
+### Testing
+
+Our testing philosophy follows the principle of:
+
+> Write tests. Not too many. Mostly integration [^1]
+
+[^1]: https://kentcdodds.com/blog/write-tests
+
+We create both unit tests and system level tests. The former is suitable for
+well-contained components that need to provide a stable api and behaviour to
+the rest of the code base. The latter is for testing the external behaviour
+of the platform as a whole with as little internal mocking as possible.
+
+We use code coverage reporting as *one* aspect of assessing our testing coverage.
+We do not treat 100% coverage as an imperative goal - that can often lead to
+busy work writing tests that don't provide any real value in understanding the
+overall quality of the system.
+
+Unit tests should provide sufficient coverage to give us confidence that a 
+component's behaviour does not unexpectedly change.
+
+We do not *currently* have automated testing capability for the front-end. That
+relies on manual verification.
+
+#### Running tests
+
+To run the tests for the project, you can use the following npm tasks:
+
+ - `npm run test` - runs the whole test suite, covering code linting, unit and systems tests.
+ - `npm run lint` - runs the linting tests
+ - `npm run test:unit` - runs the unit tests
+ - `npm run test:system` - runs the system tests
+
+#### Reporting code coverage
+
+The `test:*` tasks have corresponding code coverage tasks. These tasks run the 
+tests using `nyc` to generate code coverage information.
+
+ - `npm run cover` - runs the whole test suite (excluding linting) with code 
+   coverage enabled and generates a report (via the `cover:report` task)
+ - `npm run cover:unit` - runs the unit tests with code coverage enabled. It
+  does *not* generate the report.
+ - `npm run cover:system` - runs the system tests with code coverage enabled. It
+  does *not* generate the report.
+ - `npm run cover:report` - generates a report of the code coverage. This is 
+  printed to the console and generates a browseable HTML copy under `coverage/index.html`

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
         "test": "npm run lint && npm run test:unit && npm run test:system",
         "test:unit": "mocha test/unit/**/*_spec.js",
         "test:system": "mocha test/system/**/*_spec.js",
+        "cover": "npm run cover:unit && npm run cover:system && npm run cover:report",
+        "cover:unit": "nyc --silent npm run test:unit",
+        "cover:system": "nyc --silent npm run test:system",
+        "cover:report": "nyc report --reporter=text --reporter html",
         "dev:local": "cd ../flowforge-driver-localfs && npm install ../flowforge-nr-storage ../flowforge-nr-auth ../flowforge-nr-audit-logger && cd ../flowforge && npm install ../flowforge-driver-localfs",
         "install-stack": "mkdir -p var/stacks/${npm_config_vers} && npm install --prefix var/stacks/${npm_config_vers} node-red@${npm_config_vers}"
     },
@@ -91,6 +95,7 @@
         "mocha-cli": "^1.0.1",
         "nodemon": "^2.0.15",
         "npm-run-all": "^4.1.5",
+        "nyc": "^15.1.0",
         "postcss": "^8.4.6",
         "postcss-loader": "^6.2.1",
         "postcss-preset-env": "^6.7.0",


### PR DESCRIPTION
Closes #383

Introduces `nyc` for code coverage reporting using the following npm tasks:

 - `npm run cover` - runs the whole test suite (excluding linting) with code 
   coverage enabled and generates a report (via the `cover:report` task)
 - `npm run cover:unit` - runs the unit tests with code coverage enabled. It
  does *not* generate the report.
 - `npm run cover:system` - runs the system tests with code coverage enabled. It
  does *not* generate the report.
 - `npm run cover:report` - generates a report of the code coverage. This is 
  printed to the console and generates a browseable HTML copy under `coverage/index.html`
