### PR TITLE
Fix verbose logging from auth routes

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -170,7 +170,8 @@ module.exports = fp(async function (app, opts, done) {
                     remember: { type: 'boolean', default: false }
                 }
             }
-        }
+        },
+        logLevel: 'warn'
     }, async (request, reply) => {
         const result = await app.db.controllers.User.authenticateCredentials(request.body.username, request.body.password)
         if (result) {
@@ -193,7 +194,7 @@ module.exports = fp(async function (app, opts, done) {
      * @static
      * @memberof forge.routes.session
      */
-    app.post('/account/logout', async (request, reply) => {
+    app.post('/account/logout', { logLevel: 'warn' }, async (request, reply) => {
         if (request.sid) {
             await app.db.controllers.Session.deleteSession(request.sid)
         }
@@ -218,7 +219,8 @@ module.exports = fp(async function (app, opts, done) {
                     email: { type: 'string' }
                 }
             }
-        }
+        },
+        logLevel: 'warn'
     }, async (request, reply) => {
         if (!app.settings.get('user:signup') && !app.settings.get('team:user:invite:external')) {
             reply.code(400).send({ error: 'user registration not enabled' })
@@ -273,7 +275,7 @@ module.exports = fp(async function (app, opts, done) {
         }
     })
 
-    app.get('/account/verify/:token', async (request, reply) => {
+    app.get('/account/verify/:token', { logLevel: 'warn' }, async (request, reply) => {
         try {
             let sessionUser
             if (request.sid) {
@@ -310,7 +312,7 @@ module.exports = fp(async function (app, opts, done) {
         }
     })
 
-    app.post('/account/verify', { preHandler: app.verifySession }, async (request, reply) => {
+    app.post('/account/verify', { preHandler: app.verifySession, logLevel: 'warn' }, async (request, reply) => {
         if (!app.postoffice.enabled()) {
             reply.code(400).send({ error: 'email not configured' })
             return
@@ -339,7 +341,8 @@ module.exports = fp(async function (app, opts, done) {
                     email: { type: 'string' }
                 }
             }
-        }
+        },
+        logLevel: 'warn'
     }, async (request, reply) => {
         if (!app.settings.get('user:reset-password')) {
             reply.code(400).send({ error: 'password reset not enabled' })
@@ -373,7 +376,8 @@ module.exports = fp(async function (app, opts, done) {
                     password: { type: 'string' }
                 }
             }
-        }
+        },
+        logLevel: 'warn'
     }, async (request, reply) => {
         if (!app.settings.get('user:reset-password')) {
             reply.code(400).send({ error: 'password reset not enabled' })


### PR DESCRIPTION
Force these routes to `warn` for requests

These routes log at Info currently, had to add `logLevel: 'warn'` to each route.