### PR TITLE
Add project meta data to the Subscription

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -13,7 +13,12 @@ module.exports = {
         if (this._app.license.active() && this._app.billing) {
             const subscription = this._app.db.models.Subscription.byTeam(project.Team.id)
             if (subscription) {
-                this._app.billing.addProject(project.Team, project)
+                try {
+                    this._app.billing.addProject(project.Team, project)
+                } catch (err) {
+                    // Rethrow or wrap
+                    throw new Error('Problem with setting up Billing')
+                }
             } else {
                 throw new Error('No Subscription for this team')
             }
@@ -25,16 +30,21 @@ module.exports = {
     },
     remove: async (project) => {
         let value = {}
+        if (this._driver.remove) {
+            value = await this._driver.remove(project)
+        }
         if (this._app.license.active() && this._app.billing) {
             const subscription = this._app.db.models.Subscription.byTeam(project.Team.id)
             if (subscription) {
-                this._app.billing.removeProject(project.Team, project)
+                try {
+                    this._app.billing.removeProject(project.Team, project)
+                } catch (err) {
+                    // Rethrow or wrap?
+                    throw new Error('Problem with setting up Billing')
+                }
             } else {
                 throw new Error('No Subscription for this team')
             }
-        }
-        if (this._driver.remove) {
-            value = await this._driver.remove(project)
         }
         return value
     },

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -2,7 +2,7 @@ module.exports.init = function (app) {
     const stripe = require('stripe')(app.config.billing.stripe.key)
 
     return {
-        createSubscriptionSession: async (team, user) => {
+        createSubscriptionSession: async (team) => {
             const session = await stripe.checkout.sessions.create({
                 mode: 'subscription',
                 line_items: [{
@@ -20,12 +20,6 @@ module.exports.init = function (app) {
                 success_url: `${app.config.base_url}/team/${team.slug}/overview?billing_session={CHECKOUT_SESSION_ID}`,
                 cancel_url: `${app.config.base_url}/team/${team.slug}/overview`
             })
-            // app.db.controllers.AuditLog.teamLog({
-            //     team.id,
-            //     user.id,
-            //     'billing.session.created',
-            //     { session: session.id }
-            // })
             app.log.info(`Creating Subscription for team ${team.hashid}`)
             return session
         },

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -76,7 +76,8 @@ module.exports.init = function (app) {
                 try {
                     await stripe.subscriptions.update(subscription.subscription, update)
                 } catch (error) {
-                    app.log.info(`Problem adding first project to subscription\n${error.message}`)
+                    app.log.warn(`Problem adding first project to subscription\n${error.message}`)
+                    throw error
                 }
             }
         },
@@ -111,11 +112,12 @@ module.exports.init = function (app) {
                         metadata: metadata
                     })
                 } catch (err) {
-                    console.log(err)
+                    app.log.warn(`failed removing project from subscription\n${err.message}`)
+                    throw err
                 }
             } else {
                 // not found?
-                console.log('Something wrong here')
+                app.log.warn('Project not found in Subscription, possible Grandfathered in')
             }
         },
         closeSubscription: async (subscription) => {

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -60,7 +60,7 @@ module.exports.init = function (app) {
                         metadata: metadata
                     })
                 } catch (error) {
-                    app.log.info(`Problem adding project to subscription\n${error.message}`)
+                    app.log.warn(`Problem adding project to subscription\n${error.message}`)
                 }
             } else {
                 const metadata = {}


### PR DESCRIPTION
Previously the project id was added to the Project line item on the subscription not the subscription for all but the fist project

While stored it's not visible in the stripe dashboard (We could build our own dashboard for this)

Added code to add all projects to the subscriptions metadata.

We might want to revert this when/if we have projects at different price points.

Fixes #423