### PR TITLE
Add support for Environment Variables in Project Templates

### DIFF
--- a/docs/contribute/adding-template-settings.md
+++ b/docs/contribute/adding-template-settings.md
@@ -1,0 +1,94 @@
+# Adding Template Settings
+
+Withing FlowForge, each Project is created from a Template. The Template defines
+a set of preconfigured options for the Project. This includes runtime settings - 
+values that you would normally expect to set in your Node-RED settings.js file.
+
+The Template also defines which of those options can be customised by a Project.
+
+This guide explains how to add a new Node-RED runtime option to the Template object
+so that it can be customised for individual Projects and passed through to the
+underlying Node-RED settings.js file.
+
+This is reasonably straight-forward for simple boolean/string/numeric types.
+For other types (objects/arrays) it gets more complicated and we don't currently
+have good examples to follow.
+
+For the 'simple' cases, the steps are:
+
+1. Update the Frontend
+   1. Pick a name for the setting, add it to the list of known settings and any
+      validation logic that is needed
+   2. Add it to the appropriate Template section
+2. Update the runtime
+   1. Add it to the known list of settings and any additional validation logic
+3. Update the Launcher
+   1. Update the template used to generate settings.js with the new property
+
+
+## 1. Updating the Frontend
+
+There are a set of views in the frontend used to present and edit templates. They
+get used in two different ways:
+
+ 1. When creating/editing a template. 
+    All options are available and there is a dropdown that lets the user set the
+    policy on the setting (which controls whether a project is allowed to override
+    the setting)
+ 2. When editing project settings.
+    All options are shown, but only lets the user modify those that the template
+    policy allows to be changed.
+
+This reuse of the views saves a lot of code duplication, at the cost of some
+complication in implementing it.
+
+
+### 1.1 - Pick a name for the setting
+
+The name should try to match its corresponding property in the Node-RED settings.js
+file. Some thought should be made as to organisation of the properties.
+
+1. Edit `frontend/src/pages/admin/Template/utils.js`
+2. Add the new property name to the `templateFields` and `defaultTemplateValues` objects.
+   Notice the names are flat strings with `_` used as a hierarchy separator... that
+   will make more sense if you're looking at the file.
+3. If the value needs any sort of validation, add it to `templateValidators` in the
+   same file.
+
+### 1.2 - Add it to the appropriate Template section
+
+Current there are:
+
+ - Editor
+ - Palette
+ - Environment - a special case that is unlikely to get other options added
+
+These each live in their own file under `frontend/src/pages/admin/Template/sections/`.
+
+Pick an existing setting that most closely matches the setting you want to add 
+(ie checkbox or text input), and copy its entry to the appropriate place.
+
+Make sure you update *all* of the references of the copied property name to your
+new property name.
+
+
+## 2. Updating the Runtime
+
+### 2.1 - Adding it to the known list
+
+1. Edit `forge/db/controllers/ProjectTemplate.js` to add the new property to the
+   list of known settings.
+
+2. In that same file, update the `validateSettings` function with any additional
+   validation or data cleansing needed.
+
+
+## 3. Update nr-launcher
+
+In the `flowforge-nr-launcher` repo...
+
+1. Edit `lib/runtimeSettings.js` to include the new setting in the generate settings.js
+   file. Note that you must handle the case where the new setting is not present - 
+   either by applying a sensible default, or omitting the value.
+
+

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -1,0 +1,38 @@
+module.exports = {
+    /**
+     * Get the settings object that should be passed to nr-launcher so it can
+     * start Node-RED with the proper project configuration.
+     *
+     * This merges the Project Template settings with the Project's own settings.
+     *
+     * @param {*} app the forge app
+     * @param {*} project the project to get the settings for
+     * @returns the runtime settings object
+     */
+    getRuntimeSettings: async function (app, project) {
+        // This assumes the project has been loaded via `byId` so that
+        // it has the template and ProjectSettings attached
+        let result = {}
+        const env = {}
+        if (project.ProjectTemplate) {
+            result = project.ProjectTemplate.settings
+            if (result.env) {
+                result.env.forEach(envVar => {
+                    env[envVar.name] = envVar.value
+                })
+            }
+        }
+        if (project.ProjectSettings[0]?.key === 'settings') {
+            const projectSettings = project.ProjectSettings[0].value
+            result = app.db.controllers.ProjectTemplate.mergeSettings(result, projectSettings)
+            if (result.env) {
+                result.env.forEach(envVar => {
+                    env[envVar.name] = envVar.value
+                })
+            }
+        }
+
+        result.env = env
+        return result
+    }
+}

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -1,8 +1,84 @@
+const validSettings = [
+    'disableEditor',
+    'httpAdminRoot',
+    'codeEditor',
+    'palette_allowInstall',
+    'palette_nodesExcludes',
+    'modules_allowInstall'
+    // 'env' // Handled separately
+]
+
+function getTemplateValue (template, path) {
+    const parts = path.split('_')
+    let p = template
+    while (parts.length > 0) {
+        const part = parts.shift()
+        if (p[part] === undefined) {
+            return
+        } else {
+            p = p[part]
+        }
+    }
+    return p
+}
+
+function setTemplateValue (template, path, value) {
+    const parts = path.split('_')
+    let p = template
+    while (parts.length > 1) {
+        const part = parts.shift()
+        if (p[part] === undefined) {
+            p[part] = {}
+        }
+        p = p[part]
+    }
+    const lastPart = parts.shift()
+    p[lastPart] = value
+}
+
 module.exports = {
-    validateSettings: function (app, settings) {
-        if (settings.httpAdminRoot !== undefined) {
-            let httpAdminRoot = settings.httpAdminRoot
-            delete settings.httpAdminRoot
+    /**
+     * For a given template, check the project settings are valid. This consists of:
+     *  1. ensure the template policy allows the settings to be provided - drop
+     *     any that are blocked by policy
+     *  2. do any setting-specific validation and cleansing of the value
+     * @param {*} app the forge app
+     * @param {*} settings the project settings to validate.
+     * @param {*} template the template to validate against
+     * @returns the validated and cleansed object
+     */
+    validateSettings: function (app, settings, template) {
+        const result = {}
+
+        // First pass - copy over only the known and policy-permitted settings
+        validSettings.forEach(name => {
+            const value = getTemplateValue(settings, name)
+            if (value !== undefined) {
+                if (!template || getTemplateValue(template.policy, name)) {
+                    setTemplateValue(result, name, value)
+                }
+            }
+        })
+        result.env = []
+        if (settings.env) {
+            const templateEnvPolicyMap = {}
+            const templateEnv = template?.settings.env
+            if (templateEnv) {
+                templateEnv.forEach(envVar => {
+                    templateEnvPolicyMap[envVar.name] = envVar.policy
+                })
+            }
+            settings.env.forEach(envVar => {
+                if (templateEnvPolicyMap[envVar.name] !== false && !/ /.test(envVar.name)) {
+                    result.env.push(envVar)
+                }
+            })
+        }
+
+        // Validate individual settings
+        if (result.httpAdminRoot !== undefined) {
+            let httpAdminRoot = result.httpAdminRoot
+            delete result.httpAdminRoot
             if (typeof httpAdminRoot === 'string') {
                 httpAdminRoot = httpAdminRoot.trim()
                 if (httpAdminRoot.length > 0) {
@@ -12,29 +88,56 @@ module.exports = {
                     if (httpAdminRoot[httpAdminRoot.length - 1] === '/') {
                         httpAdminRoot = httpAdminRoot.substring(0, httpAdminRoot.length - 1)
                     }
-                    if (!/[0-9a-z_\-\\/]+$/i.test(httpAdminRoot)) {
+                    if (!/^[0-9a-z_\-\\/]*$/i.test(httpAdminRoot)) {
                         throw new Error('Invalid settings.httpAdminRoot')
                     }
-                    settings.httpAdminRoot = httpAdminRoot
                 }
+                result.httpAdminRoot = httpAdminRoot
             }
         }
-        if (settings.palette?.nodeExcludes !== undefined) {
-            const paletteNodeExcludes = settings.palette.nodeExcludes
-            delete settings.palette.nodeExcludes
+        if (result.palette?.nodesExcludes !== undefined) {
+            const paletteNodeExcludes = result.palette.nodesExcludes
+            delete result.palette.nodesExcludes
             if (typeof paletteNodeExcludes === 'string' && paletteNodeExcludes.length > 0) {
                 const parts = paletteNodeExcludes.split(',').map(fn => fn.trim()).filter(fn => fn.length > 0)
                 if (parts.length > 0) {
                     for (let i = 0; i < parts.length; i++) {
                         const fn = parts[i]
                         if (!/^[a-z0-9\-._]+\.js$/i.test(fn)) {
-                            throw new Error('Invalid settings.palette.nodeExcludes')
+                            throw new Error('Invalid settings.palette.nodesExcludes')
                         }
                     }
-                    settings.palette.nodeExcludes = parts.join(',')
+                    result.palette.nodesExcludes = parts.join(',')
                 }
             }
         }
-        return settings
+        return result
+    },
+
+    /**
+     * For a given project, merge in the provided settings. This will update
+     * settings that have a new value provided, whilst leaving others untouched
+     *
+     * TODO: This probably doesn't belong in the ProjectTemplate controller
+     * as it doesn't do anything with the template itself. However it makes use of
+     * validSettings/getTemplateValue/setTemplateValue from this file which
+     * aren't otherwise exposed.
+     * @param {*} app the forge app
+     * @param {*} existingSettings the existing project settings
+     * @param {*} settings the new settings to merge in
+     */
+    mergeSettings: function (app, existingSettings, settings) {
+        // Quick deep clone that is safe as we know settings are JSON-safe
+        const result = JSON.parse(JSON.stringify(existingSettings))
+        validSettings.forEach(name => {
+            const value = getTemplateValue(settings, name)
+            if (value !== undefined) {
+                setTemplateValue(result, name, value)
+            }
+        })
+        if (settings.env) {
+            result.env = settings.env
+        }
+        return result
     }
 }

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -17,6 +17,7 @@ const modelTypes = [
     'Team',
     'Invitation',
     'AuditLog',
+    'Project',
     'ProjectTemplate'
 ]
 

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -17,7 +17,10 @@ module.exports = {
             allowNull: false,
             get () {
                 const originalUrl = this.getDataValue('url')?.replace(/\/$/, '') || ''
-                let httpAdminRoot = this.ProjectSettings?.[0]?.value.httpAdminRoot || this.ProjectTemplate?.settings?.httpAdminRoot
+                let httpAdminRoot = this.ProjectSettings?.[0]?.value.httpAdminRoot
+                if (httpAdminRoot === undefined) {
+                    httpAdminRoot = this.ProjectTemplate?.settings?.httpAdminRoot
+                }
                 if (httpAdminRoot) {
                     if (httpAdminRoot[0] !== '/') {
                         httpAdminRoot = `/${httpAdminRoot}`

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -144,28 +144,6 @@ module.exports = {
                         return result.value
                     }
                     return undefined
-                },
-                async getRuntimeSettings () {
-                    // This assumes the project has been loaded via `byId` so that
-                    // it has the template and ProjectSettings attached
-                    let result = {}
-                    if (this.ProjectTemplate) {
-                        result = this.ProjectTemplate.settings
-                    }
-                    if (this.ProjectSettings[0]?.key === 'settings') {
-                        const projectSettings = this.ProjectSettings[0].value
-                        // This is a quick hacky deep merge that limits itself to 2 levels
-                        Object.entries(projectSettings).forEach(([key, value]) => {
-                            if (Array.isArray(value) || typeof value !== 'object') {
-                                result[key] = value
-                            } else {
-                                Object.entries(value).forEach(([subkey, subvalue]) => {
-                                    result[key][subkey] = subvalue
-                                })
-                            }
-                        })
-                    }
-                    return result
                 }
             },
             static: {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -217,9 +217,14 @@ module.exports = async function (app) {
             request.project.name = request.body.name
         }
         if (request.body.settings) {
-            // TODO: validate only settings the template policy permits to be set are included
-            const newSettings = app.db.controllers.ProjectTemplate.validateSettings(request.body.settings)
-            await request.project.updateSetting('settings', newSettings)
+            // Validate the settings
+            //  1. only store known keys
+            //  2. only store values for keys the template policy allows to be set
+            const newSettings = app.db.controllers.ProjectTemplate.validateSettings(request.body.settings, request.project.ProjectTemplate)
+            // Merge the settings into the existing values
+            const currentProjectSettings = await request.project.getSetting('settings') || {}
+            const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)
+            await request.project.updateSetting('settings', updatedSettings)
         }
         await request.project.save()
 
@@ -237,13 +242,18 @@ module.exports = async function (app) {
      */
     app.get('/:projectId/settings', async (request, reply) => {
         const settings = await app.containers.settings(request.project)
+        settings.env = settings.env || {}
         settings.baseURL = request.project.url
         settings.forgeURL = app.config.base_url
         settings.storageURL = request.project.storageURL
         settings.auditURL = request.project.auditURL
         settings.state = request.project.state
         settings.stack = request.project.ProjectStack?.properties || {}
-        settings.settings = await request.project.getRuntimeSettings()
+        settings.settings = await app.db.controllers.Project.getRuntimeSettings(request.project)
+        if (settings.settings.env) {
+            settings.env = Object.assign({}, settings.settings.env, settings.env)
+            delete settings.settings.env
+        }
         reply.send(settings)
     })
 

--- a/frontend/src/components/FormRow.vue
+++ b/frontend/src/components/FormRow.vue
@@ -9,7 +9,7 @@
                        :disabled="disabled"
                        @change="$emit('update:modelValue', $event.target.checked)"
                 >
-                <label :for="inputId" class="text-sm font-medium text-gray-700"><slot></slot></label>
+                <label v-if="hasTitle" :for="inputId" class="text-sm font-medium text-gray-700"><slot></slot></label>
                 <div v-if="hasAppend" class="inline ml-2"><slot name="append"></slot></div>
             </div>
             <div v-if="error" class="ml-9 text-red-400 inline text-xs">{{error}}</div>
@@ -26,13 +26,13 @@
                        :disabled="disabled"
                        @change="$emit('update:modelValue', $event.target.value)"
                 >
-                <label :for="inputId" class="text-sm font-medium text-gray-700"><slot></slot></label>
+                <label v-if="hasTitle" :for="inputId" class="text-sm font-medium text-gray-700"><slot></slot></label>
             </div>
             <div v-if="error" class="ml-9 text-red-400 inline text-xs">{{error}}</div>
             <div v-if="hasDescription" class="mt-1 text-xs text-gray-400 mb-2 ml-9 space-y-1"><slot name="description"></slot></div>
         </template>
         <template v-else>
-            <label :for="inputId" class="block text-sm font-medium text-gray-700 mb-1"><slot></slot></label>
+            <label v-if="hasTitle" :for="inputId" class="block text-sm font-medium text-gray-700 mb-1"><slot></slot></label>
             <div v-if="hasDescription" class="text-xs text-gray-400 mb-2 space-y-1"><slot name="description"></slot></div>
             <div class="flex flex-col sm:flex-row relative">
                 <template v-if="options && type !== 'uneditable'">
@@ -92,9 +92,13 @@ export default {
         }
     },
     setup (props, { slots }) {
+        const hasTitle = ref(false)
         const hasDescription = ref(false)
         const hasAppend = ref(false)
         const hasCustomInput = ref(false)
+        if (slots.default && slots.default().length) {
+            hasTitle.value = true
+        }
         if (slots.description && slots.description().length) {
             hasDescription.value = true
         }
@@ -105,6 +109,7 @@ export default {
             hasCustomInput.value = true
         }
         return {
+            hasTitle,
             hasDescription,
             hasAppend,
             hasCustomInput

--- a/frontend/src/pages/admin/Template/components/ChangeIndicator.vue
+++ b/frontend/src/pages/admin/Template/components/ChangeIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="value" class="flex h-full"><SparklesIcon class="text-gray-500 w-4"></SparklesIcon></div>
+    <div v-if="value" class="flex h-7"><SparklesIcon class="text-gray-500 w-4"></SparklesIcon></div>
 </template>
 <script>
 import { SparklesIcon } from '@heroicons/vue/outline'

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -1,0 +1,166 @@
+<template>
+    <form class="space-y-4" @submit.prevent>
+        <FormHeading>
+            <div class="flex">
+                <div class="mr-4">Environment Variables</div>
+                <div class="flex justify-center"><ChangeIndicator :value="editable.changed.env"></ChangeIndicator></div>
+            </div>
+        </FormHeading>
+        <table class="w-full max-w-4xl table-fixed text-sm rounded overflow-hidden">
+            <thead>
+                <tr class="font-medium">
+                    <td class="border bg-gray-100 p-2 w-auto">Name</td>
+                    <td class="border bg-gray-100 p-2 w-auto">Value</td>
+                    <td class="border bg-gray-100 p-2 w-16"></td>
+                    <td class="p-2 w-32" v-if="editTemplate"></td>
+                </tr>
+            </thead>
+            <tbody class="bg-white">
+                <tr v-for="(item, itemIdx) in editable.settings.env"  :key="item.index">
+                    <td class="px-4 py-4 border w-auto align-top">
+                        <FormRow
+                            class="font-mono"
+                            v-model="item.name"
+                            :error="item.error"
+                            :disabled="item.encrypted"
+                            :type="(editTemplate || item.policy === undefined)?'text':'uneditable'"></FormRow>
+                        <!-- <ff-text-input  v-model="item.name" :disabled="item.encrypted"  /> -->
+                    </td>
+                    <td class="px-4 py-4 border w-auto align-top" :class="{'align-middle':item.encrypted}">
+                        <div class="w-full" v-if="!item.encrypted">
+                            <FormRow
+                                class="font-mono"
+                                v-model="item.value"
+                                :type="(editTemplate || item.policy === undefined || item.policy)?'text':'uneditable'"></FormRow>
+                        </div>
+                        <div v-else class="pt-1 text-gray-400"><LockClosedIcon class="inline w-4" /> encrypted</div>
+                    </td>
+                    <td class="border w-16 align-middle">
+                        <div v-if="(editTemplate|| item.policy === undefined )" class="flex justify-center ">
+                            <ff-button kind="tertiary" @click="removeEnv(itemIdx)" size="small">
+                                <template v-slot:icon>
+                                    <TrashIcon />
+                                </template>
+                            </ff-button>
+                        </div>
+                    </td>
+                    <td v-if="editTemplate" class="px-4 py-4 align-middle">
+                        <LockSetting :editTemplate="editTemplate" v-model="item.policy"></LockSetting>
+                    </td>
+                </tr>
+                <tr v-if="editable.settings.env && editable.settings.env.length > 0"><td :colspan="editTemplate?4:3" class="p-4"></td></tr>
+                <tr class="">
+                    <td class="px-4 pt-4 border w-auto align-top">
+                        <FormRow class="font-mono" v-model="input.name" :error="input.error"></FormRow>
+                    </td>
+                    <td class="px-4 pt-4 pb-3 border w-auto align-top space-y-3">
+                        <FormRow class="font-mono" v-model="input.value"></FormRow>
+                        <!-- <FormRow id="encrypt-env-var" v-model="input.encrypt" type="checkbox"> <span class="text-gray-500"><LockClosedIcon class="inline w-4" /> encrypt</span></FormRow> -->
+                    </td>
+                    <td class="pb-2 pt-4 border w-16 text-center align-top">
+                        <ff-button kind="primary" @click="addEnv()" :disabled="!addEnabled" size="small">
+                            <template v-slot:icon>
+                                <PlusSmIcon />
+                            </template>
+                        </ff-button>
+                    </td>
+                    <td class="p-2" v-if="editTemplate"></td>
+                </tr>
+            </tbody>
+        </table>
+    </form>
+
+</template>
+
+<script>
+
+import FormRow from '@/components/FormRow'
+import FormHeading from '@/components/FormHeading'
+import LockSetting from '../components/LockSetting'
+import ChangeIndicator from '../components/ChangeIndicator'
+import { TrashIcon, PlusSmIcon, LockClosedIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'TemplateEnvironmentEditor',
+    props: ['editTemplate', 'modelValue'],
+    emits: ['update:modelValue'],
+    data () {
+        return {
+            addedCount: 0,
+            input: {},
+            envVarNames: {}
+        }
+    },
+    computed: {
+        editable: {
+            get () { return this.modelValue },
+            set (localValue) { this.$emit('update:modelValue', localValue) }
+        },
+        addEnabled () {
+            return this.input.name !== undefined && !this.input.error
+        }
+    },
+    watch: {
+        'input.name' () {
+            if (/ /.test(this.input.name)) {
+                this.input.error = 'Invalid name'
+            } else if (this.envVarNames[this.input.name]) {
+                this.input.error = 'Duplicate name'
+            } else {
+                this.input.error = ''
+            }
+        },
+        'editable' () {
+            if (this.editable) {
+                this.editable.settings.env.forEach(field => {
+                    this.envVarNames[field.name] = field
+                })
+            }
+        },
+        'editable.settings.env': {
+            deep: true,
+            handler (v) {
+                v.forEach(field => {
+                    if (/ /.test(field.name)) {
+                        field.error = 'Invalid name'
+                    } else if (field.policy === undefined && (this.envVarNames[field.name] && field.index !== this.envVarNames[field.name].index)) {
+                        field.error = 'Duplicate name'
+                    } else {
+                        field.error = ''
+                    }
+                })
+            }
+        }
+    },
+    methods: {
+        addEnv () {
+            const field = {
+                index: 'add-' + this.addedCount++,
+                name: this.input.name,
+                value: this.input.value,
+                encrypted: this.input.encrypt,
+                policy: this.editTemplate ? false : undefined
+            }
+            this.envVarNames[field.name] = field
+            this.editable.settings.env.push(field)
+            this.input.name = ''
+            this.input.encrypt = false
+            this.input.value = ''
+        },
+        removeEnv (index) {
+            const field = this.editable.settings.env[index]
+            delete this.envVarNames[field.name]
+            this.editable.settings.env.splice(index, 1)
+        }
+    },
+    components: {
+        FormRow,
+        FormHeading,
+        LockSetting,
+        ChangeIndicator,
+        TrashIcon,
+        PlusSmIcon,
+        LockClosedIcon
+    }
+}
+</script>

--- a/frontend/src/pages/admin/Template/utils.js
+++ b/frontend/src/pages/admin/Template/utils.js
@@ -122,7 +122,20 @@ function prepareTemplateForEdit (template) {
         }
         result.editable.changed.policy[field] = false
     })
+    // `template.settings.env` has to be handled separately
 
+    result.editable.settings.env = []
+    result.original.settings.envMap = {}
+    result.original.settings.env = []
+    result.editable.changed.env = false
+    if (template.settings.env) {
+        template.settings.env.forEach((envVarDefinition, idx) => {
+            envVarDefinition.index = idx
+            result.editable.settings.env.push(Object.assign({}, envVarDefinition))
+            result.original.settings.env.push(Object.assign({}, envVarDefinition))
+            result.original.settings.envMap[envVarDefinition.name] = envVarDefinition
+        })
+    }
     return result
 }
 

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -13,6 +13,7 @@ import AdminStacks from '@/pages/admin/Stacks/index.vue'
 import AdminTemplates from '@/pages/admin/Templates/index.vue'
 import AdminTemplate from '@/pages/admin/Template/index.vue'
 import AdminTemplateSettings from '@/pages/admin/Template/Settings.vue'
+import AdminTemplateEnvironment from '@/pages/admin/Template/sections/Environment.vue'
 import AdminTemplatePalette from '@/pages/admin/Template/sections/Palette.vue'
 import AdminCreateUser from '@/pages/admin/Users/createUser.vue'
 import { AdjustmentsIcon } from '@heroicons/vue/outline'
@@ -70,6 +71,7 @@ export default [
                 component: AdminTemplate,
                 children: [
                     { path: 'settings', component: AdminTemplateSettings },
+                    { path: 'environment', component: AdminTemplateEnvironment },
                     { path: 'palette', component: AdminTemplatePalette }
                 ]
             }

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -15,7 +15,7 @@ import { Roles } from '@core/lib/roles'
 
 const sideNavigation = [
     { name: 'General', path: './general' },
-    // { name: "Environment", path: "./environment" },
+    { name: 'Environment', path: './environment' },
     { name: 'Editor', path: './editor' },
     { name: 'Palette', path: './palette' },
     { name: 'Danger', path: './danger' }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test:system": "mocha test/system/**/*_spec.js",
         "cover": "npm run cover:unit && npm run cover:system && npm run cover:report",
         "cover:unit": "nyc --silent npm run test:unit",
-        "cover:system": "nyc --silent npm run test:system",
+        "cover:system": "nyc --silent --no-clean npm run test:system",
         "cover:report": "nyc report --reporter=text --reporter html",
         "dev:local": "cd ../flowforge-nr-launcher && npm install ../flowforge-nr-storage ../flowforge-nr-auth ../flowforge-nr-audit-logger && cd ../flowforge-driver-localfs && npm install ../flowforge-nr-launcher && cd ../flowforge && npm install ../flowforge-driver-localfs ../forge-ui-components",
         "install-stack": "mkdir -p var/stacks/${npm_config_vers} && npm install --prefix var/stacks/${npm_config_vers} node-red@${npm_config_vers}"

--- a/test/unit/forge/db/controllers/ProjectTemplate_spec.js
+++ b/test/unit/forge/db/controllers/ProjectTemplate_spec.js
@@ -1,0 +1,197 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+// const FF_UTIL = require('flowforge-test-utils')
+// const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Project Template controller', function () {
+    // Use standard test data.
+    let app
+    beforeEach(async function () {
+        app = await setup()
+    })
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('Validate Settings', function () {
+        it('only allows settings from the known list', async function () {
+            const result = app.db.controllers.ProjectTemplate.validateSettings({
+                disableEditor: true,
+                httpAdminRoot: '/foo',
+                codeEditor: 'monaco',
+                palette: {
+                    allowInstall: true,
+                    nodesExcludes: 'ex.js',
+                    NOT_ALLOWED: true
+                },
+                modules: {
+                    allowInstall: true,
+                    NOT_ALLOWED: true
+                },
+                env: ['ONE'],
+                NOT_ALLOWED: true
+            })
+
+            result.should.have.property('disableEditor', true)
+            result.should.have.property('httpAdminRoot', '/foo')
+            result.should.have.property('codeEditor', 'monaco')
+            result.should.have.property('palette')
+            result.palette.should.have.property('allowInstall', true)
+            result.palette.should.have.property('nodesExcludes', 'ex.js')
+            result.should.have.property('modules')
+            result.modules.should.have.property('allowInstall', true)
+            result.should.have.property('env')
+            result.env.should.have.length(1)
+            result.env[0].should.eql('ONE')
+
+            result.should.not.have.property('NOT_ALLOWED')
+            result.palette.should.not.have.property('NOT_ALLOWED')
+            result.modules.should.not.have.property('NOT_ALLOWED')
+        })
+
+        it('only passes through settings a template policy allows', async function () {
+            const templateProperties = {
+                name: 'template',
+                active: true,
+                description: '',
+                settings: {
+                    env: [
+                        { name: 'ALLOWED', value: '', policy: true },
+                        { name: 'NOT_ALLOWED', value: '', policy: false }
+                    ]
+                },
+                policy: {
+                    disableEditor: true,
+                    palette: {
+                        nodesExcludes: true
+                    }
+                }
+            }
+            const template = await app.db.models.ProjectTemplate.create(templateProperties)
+            const result = app.db.controllers.ProjectTemplate.validateSettings({
+                disableEditor: true,
+                httpAdminRoot: '/foo',
+                codeEditor: 'monaco',
+                palette: {
+                    allowInstall: true,
+                    nodesExcludes: 'ex.js'
+                },
+                modules: {
+                    allowInstall: true
+                },
+                env: [
+                    { name: 'ALLOWED', value: '123' },
+                    { name: 'NOT_ALLOWED', value: '456' }
+                ],
+                NOT_ALLOWED: true
+            }, template)
+
+            result.should.have.property('disableEditor', true)
+            result.should.not.have.property('httpAdminRoot', '/foo')
+            result.should.not.have.property('codeEditor', 'monaco')
+            result.should.have.property('palette')
+            result.palette.should.not.have.property('allowInstall', true)
+            result.palette.should.have.property('nodesExcludes', 'ex.js')
+            result.should.not.have.property('modules')
+            result.should.not.have.property('NOT_ALLOWED')
+            result.palette.should.not.have.property('NOT_ALLOWED')
+
+            result.should.have.property('env')
+            result.env.should.have.length(1)
+            result.env[0].name.should.eql('ALLOWED')
+            result.env[0].value.should.eql('123')
+        })
+        describe('httpAdminRoot', function () {
+            it('normalises httpAdminRoot', async function () {
+                app.db.controllers.ProjectTemplate.validateSettings({
+                    httpAdminRoot: 'foo'
+                }).should.have.property('httpAdminRoot', '/foo')
+
+                app.db.controllers.ProjectTemplate.validateSettings({
+                    httpAdminRoot: 'foo/'
+                }).should.have.property('httpAdminRoot', '/foo')
+
+                app.db.controllers.ProjectTemplate.validateSettings({
+                    httpAdminRoot: '/'
+                }).should.have.property('httpAdminRoot', '')
+
+                app.db.controllers.ProjectTemplate.validateSettings({
+                    httpAdminRoot: ''
+                }).should.have.property('httpAdminRoot', '')
+            })
+            it('rejects invalid values', async function () {
+                should(() => {
+                    app.db.controllers.ProjectTemplate.validateSettings({
+                        httpAdminRoot: '1 2 3'
+                    })
+                }).throw()
+            })
+        })
+
+        describe('palette.nodeExcludes', function () {
+            it('normalises palette.nodeExcludes', async function () {
+                app.db.controllers.ProjectTemplate.validateSettings({
+                    palette: {
+                        nodesExcludes: ' one.js , two.js, three.js,four.js ,five.js'
+                    }
+                }).palette.should.have.property('nodesExcludes', 'one.js,two.js,three.js,four.js,five.js')
+            })
+            it('rejects invalid values', async function () {
+                should(() => {
+                    app.db.controllers.ProjectTemplate.validateSettings({
+                        palette: {
+                            nodesExcludes: ' one.html'
+                        }
+                    })
+                }).throw()
+
+                should(() => {
+                    app.db.controllers.ProjectTemplate.validateSettings({
+                        palette: {
+                            nodesExcludes: '(!@)£.js'
+                        }
+                    })
+                }).throw()
+            })
+        })
+    })
+
+    describe('mergeSettings', function () {
+        it('merges new settings in a project', async function () {
+            const originalSettings = {
+                disableEditor: true,
+                httpAdminRoot: '/foo',
+                codeEditor: 'monaco',
+                palette: {
+                    allowInstall: true,
+                    nodesExcludes: 'ex.js'
+                },
+                modules: {
+                    allowInstall: true
+                },
+                env: [{ name: 'one', value: 'a' }]
+            }
+
+            const result = app.db.controllers.ProjectTemplate.mergeSettings(originalSettings, {
+                disableEditor: false,
+                palette: {
+                    nodesExcludes: 'new.js'
+                },
+                env: [{ name: 'two', value: 'b' }]
+            })
+
+            result.should.have.property('disableEditor', false)
+            result.should.have.property('httpAdminRoot', '/foo')
+            result.should.have.property('codeEditor', 'monaco')
+            result.should.have.property('palette')
+            result.palette.should.have.property('allowInstall', true)
+            result.palette.should.have.property('nodesExcludes', 'new.js')
+            result.should.have.property('modules')
+            result.modules.should.have.property('allowInstall', true)
+            result.should.have.property('env')
+            result.env.should.have.length(1)
+            result.env[0].name.should.eql('two')
+        })
+    })
+})

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -1,0 +1,77 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+// const FF_UTIL = require('flowforge-test-utils')
+// const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Project controller', function () {
+    // Use standard test data.
+    let app
+    beforeEach(async function () {
+        app = await setup()
+    })
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('getRuntimeSettings', function () {
+        it('generates runtime settings object', async function () {
+            const template = await app.db.models.ProjectTemplate.create({
+                name: 'defaultTemplate',
+                active: true,
+                settings: {
+                    disableEditor: true,
+                    httpAdminRoot: '/foo',
+                    codeEditor: 'monaco',
+                    palette: {
+                        allowInstall: true,
+                        nodesExcludes: 'ex.js'
+                    },
+                    modules: {
+                        allowInstall: true
+                    },
+                    env: [
+                        { name: 'one', value: 'a' },
+                        { name: 'two', value: 'b' }
+                    ]
+                },
+                policy: {}
+            })
+            const project = await app.db.models.Project.create({
+                name: 'testProject',
+                type: '',
+                url: ''
+            })
+            await project.setProjectTemplate(template)
+
+            await project.updateSetting('settings', {
+                httpAdminRoot: '/bar',
+                palette: {
+                    nodesExcludes: 'updated.js'
+                },
+                env: [
+                    { name: 'one', value: 'project-a' },
+                    { name: 'three', value: 'c' }
+                ]
+            })
+
+            const reloadedProject = await app.db.models.Project.byId(project.id)
+
+            const result = await app.db.controllers.Project.getRuntimeSettings(reloadedProject)
+
+            result.should.have.property('disableEditor', true)
+            result.should.have.property('httpAdminRoot', '/bar')
+            result.should.have.property('codeEditor', 'monaco')
+            result.should.have.property('palette')
+            result.palette.should.have.property('allowInstall', true)
+            result.palette.should.have.property('nodesExcludes', 'updated.js')
+            result.should.have.property('modules')
+            result.modules.should.have.property('allowInstall', true)
+            result.should.have.property('env')
+
+            result.env.should.have.property('one', 'project-a')
+            result.env.should.have.property('two', 'b')
+            result.env.should.have.property('three', 'c')
+        })
+    })
+})


### PR DESCRIPTION
Delivers #225 

Walk-through video: https://youtu.be/vaIbxbe59ek

 - Adds `env` as a property of both Templates and Project Settings
 - Allows Template to predefine env vars - and whether a project can modify the value of any of them.
 - Allows Projects to define their own env vars (and modify any the template allows to be modified)

 - Refactored the ProjectTemplate controller and added a Project controller to centralise handling of project setting updates
 - Added unit tests for the controllers

This PR does *not* cover:
 - support for encrypted env vars. That will be a separate story.