### PR TITLE
Fix 404 in Stripe Billing callback for charge.failed

### DIFF
--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -43,6 +43,17 @@ module.exports = {
                             attributes: ['id', 'name', 'slug', 'links']
                         }
                     })
+                },
+                byCustomer: async function(customer) {
+                    return self.findOne({
+                        where: {
+                            customer: customer
+                        },
+                        include: {
+                            model: M.Team,
+                            attributes: ['id', 'name', 'slug', 'links']
+                        }
+                    })
                 }
             }
         }

--- a/forge/ee/index.js
+++ b/forge/ee/index.js
@@ -7,7 +7,7 @@ module.exports = fp(async function (app, opts, next) {
     // Load ee only if enabled in the license
     if (app.license.active()) {
         app.log.info('Loading EE Features')
-        require('./db/index.js').init(app)
+        await require('./db/index.js').init(app)
         await app.register(require('./routes'), { prefix: '/ee', logLevel: 'warn' })
         await app.register(require('./lib'))
     }

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -82,8 +82,14 @@ module.exports = async function (app) {
                     return
                 }
             } else {
-                response.status(404).type('text/html').send('Not Found')
-                return
+                if (event.type === 'charge.failed') {
+                    const sub = await app.db.models.Subscription.byCustomer(customer)
+                    team = sub?.Team
+                }
+                if (!team) {
+                    response.status(404).type('text/html').send('Not Found')
+                    return
+                }
             }
 
             switch (event.type) {
@@ -100,8 +106,8 @@ module.exports = async function (app) {
                 break
             case 'checkout.session.expired':
                 // should remove the team here
-                console.log('checkout.session.expired')
-                console.log(event)
+                app.log.info('checkout.session.expired')
+                // console.log(event)
                 break
             case 'customer.subscription.created':
 

--- a/forge/licensing/index.js
+++ b/forge/licensing/index.js
@@ -18,7 +18,11 @@ module.exports = fp(async function (app, opts, next) {
 
     // TODO: load license from local file or app.config.XYZ
 
-    const userLicense = await app.settings.get('license')
+    let userLicense = await app.settings.get('license')
+
+    if (!userLicense) {
+        userLicense = app.config.license
+    }
 
     // if (!userLicense) {
     //     console.log("No user-provided license found - using development license")

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -1,0 +1,104 @@
+const should = require('should')
+const setup = require('../setup')
+
+describe('Stripe Callbacks', function () {
+    let app
+
+    const callbackURL = '/ee/billing/callback'
+
+    // const chargeFailedPayload = '{\n' +
+    // '    "id": "evt_123456790",\n' +
+    // '    "object": "event",\n' +
+    // '    "data": {\n' +
+    // '        "object": {\n' +
+    // '            "id": "ch_1234567890",\n' +
+    // '            "customer": "cus_1234567890"\n' +
+    // '        }\n' +
+    // '    },\n' +
+    // '    "type": "charge.failed"\n' +
+    // '}'
+
+    beforeEach(async function () {
+        app = await setup()
+    })
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    it('Receive charge.failed callback', async function () {
+        const response = await app.inject({
+            method: 'POST',
+            url: callbackURL,
+            headers: {
+                // "stripe-signature" : "",
+                'content-type': 'application/json'
+            },
+            payload: {
+                id: 'evt_123456790',
+                object: 'event',
+                data: {
+                    object: {
+                        id: 'ch_1234567890',
+                        customer: 'cus_1234567890'
+                    }
+                },
+                type: 'charge.failed'
+            }
+        })
+        should(response).have.property('statusCode', 200)
+    })
+
+    it('Receive charge.failed callback for unknown customer', async function () {
+        const response = await app.inject({
+            method: 'POST',
+            url: callbackURL,
+            headers: {
+                // "stripe-signature" : "",
+                'content-type': 'application/json'
+            },
+            payload: {
+                id: 'evt_123456790',
+                object: 'event',
+                data: {
+                    object: {
+                        id: 'ch_1234567890',
+                        customer: 'cus_0987654321'
+                    }
+                },
+                type: 'charge.failed'
+            }
+        })
+        should(response).have.property('statusCode', 404)
+    })
+
+    it('Recieve checkout.session.completed callback', async function () {
+        const response = await (app.inject({
+            method: 'POST',
+            url: callbackURL,
+            headers: {
+                'content-type': 'application/json'
+            },
+            payload: {
+                id: 'evt_123456790',
+                object: 'event',
+                data: {
+                    object: {
+                        id: 'cs_1234567890',
+                        object: 'checkout.session',
+                        customer: 'cus_0987654321',
+                        subscription: 'sub_0987654321',
+                        client_reference_id: app.team.hashid
+                    }
+                },
+                type: 'checkout.session.completed'
+            }
+        }))
+        should(response).have.property('statusCode', 200)
+        const sub = await app.db.models.Subscription.byCustomer('cus_0987654321')
+        should(sub.customer).equal('cus_0987654321')
+        should(sub.subscription).equal('sub_0987654321')
+        const team = sub.Team
+        should(team.name).equal('ATeam')
+    })
+})

--- a/test/unit/forge/ee/routes/setup.js
+++ b/test/unit/forge/ee/routes/setup.js
@@ -1,0 +1,61 @@
+const FF_UTIL = require('flowforge-test-utils')
+const Forge = FF_UTIL.require('forge/forge.js')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
+
+module.exports = async function (settings = {}, config = {}) {
+    config = {
+        ...config,
+        telemetry: { enabled: false },
+        logging: {
+            level: 'warn'
+        },
+        db: {
+            type: 'sqlite',
+            storage: ':memory:'
+        },
+        email: {
+            enabled: true,
+            transport: new LocalTransport()
+        },
+        driver: {
+            type: 'stub'
+        },
+        license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkJlbiBIYXJkaWxsIiwibmJmIjoxNjQ4MTY2NDAwLCJleHAiOjE2Nzk3ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjQ4MjA1MDA3fQ.2swXs50ZJgiQLA9MeoKIepN6BJGGnDqIUQ0FuKUadVjTcUzFekId5RaTpedi14f2iA7qC1w50Ym2egaBFSg1JA',
+        billing: {
+            stripe: {
+                key: 1234
+            }
+        }
+    }
+
+    const forge = await Forge({ config })
+
+    await forge.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
+    const userAlice = await forge.db.models.User.create({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })
+    const team1 = await forge.db.models.Team.create({ name: 'ATeam' })
+    await team1.addUser(userAlice, { through: { role: Roles.Owner } })
+    const templateProperties = {
+        name: 'template1',
+        active: true,
+        description: '',
+        settings: {},
+        policy: {}
+    }
+    const template = await forge.db.models.ProjectTemplate.create(templateProperties)
+    template.setOwner(userAlice)
+    await template.save()
+    // const stackProperties = {
+    //     name: 'stack1',
+    //     active: true,
+    //     properties: { nodered: '2.2.2' }
+    // }
+    // const stack = await forge.db.models.ProjectStack.create(stackProperties)
+    const subscription = 'sub_1234567890'
+    const customer = 'cus_1234567890'
+    await forge.db.controllers.Subscription.createSubscription(team1, subscription, customer)
+
+    forge.team = team1
+
+    return forge
+}


### PR DESCRIPTION
This uses the customer id to look up the session to find the team.

This will need further work to actually do something when a charge fails (suspend all projects under that team? probably after multiple fails)

Also adds start of billing unit tests

fixes #454 