### PR TITLE
Add unit tests for team member/invite apis

### DIFF
--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -82,7 +82,6 @@ module.exports = async function (app) {
             }
             reply.send({ status: 'okay' })
         } catch (err) {
-            console.log(err)
             reply.code(400).send({ error: 'cannot remove only owner' })
         }
     })
@@ -107,7 +106,6 @@ module.exports = async function (app) {
                 }
                 reply.send({ status: 'okay' })
             } catch (err) {
-                console.log(err)
                 reply.code(403).type('text/html').send('Forbidden')
             }
         } else {

--- a/test/node_modules/flowforge-test-utils/forge/postoffice/localTransport.js
+++ b/test/node_modules/flowforge-test-utils/forge/postoffice/localTransport.js
@@ -2,26 +2,20 @@
  * A custom transport for nodemailer that captures mail sent so it can be
  * checked.
  */
-class LocalTransport {
+ class LocalTransport {
     constructor(opts = {}) {
+        this.name = 'FlowForgeInternalTestTransport'
+        this.version = '0.1.0'
         this.opts = opts
-        this.messages = [];
+        this.messages = []
     }
-    getTransport() {
-        return {
-            name: 'FlowForgeInternalTestTransport',
-            version: '0.1.0',
-            send: (mail, callback) => {
-                this.messages.push(mail.data);
-                callback(null, true);
-            }
-        }
+    send(mail, callback) {
+        this.messages.push(mail.data);
+        callback(null, true);
     }
-
     getMessageQueue() {
         return this.messages
     }
-
     count() {
         return this.messages.length
     }

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -1,0 +1,176 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Team Invitations API', function () {
+    let app
+    const TestObjects = {}
+
+    beforeEach(async function () {
+        app = await setup()
+
+        // alice : admin
+        // bob
+        // chris
+
+        // ATeam ( alice  (owner), bob )
+        // BTeam ( bob (owner) )
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam' })
+
+        // Alice set as ATeam owner in setup()
+        await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Member } })
+        await TestObjects.BTeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('Create an invitation', async function () {
+        // POST /api/v1/teams/:teamId/invitations
+
+        it('team owner can invite user to team', async () => {
+            // Alice invite Chris to ATeam
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'chris'
+                }
+            })
+            const result = response.json()
+            result.should.have.property('status', 'okay')
+            app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+        })
+
+        it('team member cannot invite user to team', async () => {
+            // Bob cannot invite Chris to ATeam
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.bob },
+                payload: {
+                    user: 'chris'
+                }
+            })
+            response.statusCode.should.equal(403)
+        })
+
+        it('admin can invite user to team they are not in', async () => {
+            // Alice can invite Chris to BTeam
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'chris'
+                }
+            })
+            const result = response.json()
+            result.should.have.property('status', 'okay')
+            app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+        })
+
+        it('team owner can invite multiple users to team', async () => {
+            // Bob invite Alice,Chris to ATeam
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.bob },
+                payload: {
+                    user: 'chris , alice'
+                }
+            })
+            const result = response.json()
+            result.should.have.property('status', 'okay')
+            app.config.email.transport.getMessageQueue().should.have.lengthOf(2)
+        })
+
+        it('owner cannot invite existing team user to team', async () => {
+            // Alice cannot invite Bob to ATeam
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'bob'
+                }
+            })
+            const result = response.json()
+            result.should.have.property('status', 'error')
+            result.message.should.have.property('bob', 'Already a member of the team')
+            app.config.email.transport.getMessageQueue().should.have.lengthOf(0)
+        })
+
+        it('owner can request invites for existing and new users', async () => {
+            // Alice invites Bob and Chris to ATeam - mixed result
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'bob, chris'
+                }
+            })
+            const result = response.json()
+            result.should.have.property('status', 'error')
+            result.message.should.have.property('bob', 'Already a member of the team')
+            // But an email is still sent to chris
+            app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+        })
+
+        describe('external users', async function () {
+            it('team owner cannot invite external user if disabled', async () => {
+                // Alice cannot invite dave@example.com to ATeam
+                const response = await app.inject({
+                    method: 'POST',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                    cookies: { sid: TestObjects.tokens.alice },
+                    payload: {
+                        user: 'dave@example.com'
+                    }
+                })
+                const result = response.json()
+                result.should.have.property('status', 'error')
+                result.message.should.have.property('dave@example.com', 'External invites not permitted')
+
+                app.config.email.transport.getMessageQueue().should.have.lengthOf(0)
+            })
+        })
+    })
+
+    describe('List team invitations', async function () {
+        // GET /api/v1/teams/:teamId/invitations
+
+    })
+
+    describe('Delete an invitation team member', async function () {
+        // DELETE /api/v1/teams/:teamId/invitations/:invitationId
+    })
+})

--- a/test/unit/forge/routes/api/teamMembers_spec.js
+++ b/test/unit/forge/routes/api/teamMembers_spec.js
@@ -1,0 +1,451 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Team Members API', function () {
+    let app
+    const TestObjects = {}
+    beforeEach(async function () {
+        app = await setup()
+
+        // alice : admin
+        // bob
+        // chris
+
+        // ATeam ( alice  (owner), bob (owner), chris)
+        // BTeam ( bob (owner), chris)
+        // CTeam ( chris (owner) )
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam' })
+        TestObjects.CTeam = await app.db.models.Team.create({ name: 'CTeam' })
+
+        // Alice set as ATeam owner in setup()
+        await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+        await TestObjects.ATeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+        await TestObjects.BTeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+        await TestObjects.BTeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+        await TestObjects.CTeam.addUser(TestObjects.chris, { through: { role: Roles.Owner } })
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    function verifyMembers (result, expectedMembers) {
+        result.should.have.property('count', expectedMembers.length)
+        result.should.have.property('members')
+        result.members.should.have.lengthOf(expectedMembers.length)
+        for (let i = 0; i < expectedMembers.length; i++) {
+            result.members[i].should.have.property('id', expectedMembers[i].id)
+            result.members[i].should.have.property('role', expectedMembers[i].role)
+        }
+    }
+
+    describe('List team members', async function () {
+        // GET /api/v1/teams/:teamId/members
+
+        it('team owner, non-admin', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            const result = response.json()
+            verifyMembers(result, [
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+
+        it('team member, non-admin', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            const result = response.json()
+            verifyMembers(result, [
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+
+        it('non-team member, admin', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const result = response.json()
+            verifyMembers(result, [
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+
+        it('non-team member, non-admin should 404', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.eql(404)
+        })
+    })
+
+    describe('Add team member', async function () {
+        // POST /api/v1/teams/:teamId/members
+        // Endpoint not implemented
+    })
+
+    describe('Remove team member', async function () {
+        // DELETE /api/v1/teams/:teamId/members/:userId
+
+        it('owner can remove member', async function () {
+            // Alice remove Chris from ATeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.alice.hashid, role: Roles.Owner },
+                { id: TestObjects.bob.hashid, role: Roles.Owner }
+            ])
+        })
+
+        it('owner can remove other owner', async function () {
+            // Alice remove Bob from ATeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.alice.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+
+        it('member cannot remove user', async function () {
+            // Chris fails to remove Bob from ATeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(403)
+        })
+
+        it('admin (non-member) can remove member', async function () {
+            // Alice remove Chris from BTeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.bob.hashid, role: Roles.Owner }
+            ])
+        })
+
+        it('non-admin non-member cannot remove member', async function () {
+            await app.db.models.User.create({ username: 'dave', name: 'Dave Vader', email: 'dave@example.com', password: 'ddPassword' })
+            await ('dave', 'ddPassword')
+
+            // Dave cannot remove Chris from BTeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.dave }
+            })
+            response.statusCode.should.equal(401)
+        })
+
+        it('owner can remove self if another owner exists', async function () {
+            // Alice remove Alice from ATeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.alice.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+
+        it('owner cannot remove self if only owner', async function () {
+            // Bob cannot remove Bob from BTeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(400)
+        })
+
+        it('admin cannot remove only owner from team', async function () {
+            // Alice cannot remove Bob from BTeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(400)
+        })
+    })
+
+    describe('Change team member role', async function () {
+        // PUT /api/v1/teams/:teamId/members/:userId
+
+        it('owner can change member to owner', async function () {
+            // Bob changes Chris to BTeam owner
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob },
+                payload: {
+                    role: Roles.Owner
+                }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Owner }
+            ])
+        })
+
+        it('owner can change 2nd owner to member', async function () {
+            // Alice changes Bob to ATeam member
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Member
+                }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.alice.hashid, role: Roles.Owner },
+                { id: TestObjects.bob.hashid, role: Roles.Member },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+        it('owner can change own role to member if 2nd owner exists', async function () {
+            // Alice changes Alice to ATeam member
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.alice.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Member
+                }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.alice.hashid, role: Roles.Member },
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Member }
+            ])
+        })
+        it('owner cannot change own role to member if no 2nd owner exists', async function () {
+            // Bob cannot change self to member of BTeam
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob },
+                payload: {
+                    role: Roles.Member
+                }
+            })
+            response.statusCode.should.equal(403)
+        })
+        it('member cannot change own role to owner', async function () {
+            // Chris cannot change self to owner of BTeam
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.chris },
+                payload: {
+                    role: Roles.Owner
+                }
+            })
+            response.statusCode.should.equal(403)
+        })
+        it('member cannot change other member role', async function () {
+            // Alice changes Bob to Member - then Bob tries to change Chris to Owner
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Member
+                }
+            })
+            response.statusCode.should.equal(200)
+
+            const response2 = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob },
+                payload: {
+                    role: Roles.Owner
+                }
+            })
+            response2.statusCode.should.equal(403)
+        })
+
+        it('admin can change member to owner', async function () {
+            // Alice changes Chris to BTeam owner
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Owner
+                }
+            })
+            response.statusCode.should.equal(200)
+
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.bob.hashid, role: Roles.Owner },
+                { id: TestObjects.chris.hashid, role: Roles.Owner }
+            ])
+        })
+        it('admin can change owner to member if 2nd owner exists', async function () {
+            // First set Chris as BTeam owner - then check Alice can make Bob member
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Owner
+                }
+            })
+            response.statusCode.should.equal(200)
+
+            const response2 = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Member
+                }
+            })
+            response2.statusCode.should.equal(200)
+            const checkMemberList = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            verifyMembers(checkMemberList.json(), [
+                { id: TestObjects.bob.hashid, role: Roles.Member },
+                { id: TestObjects.chris.hashid, role: Roles.Owner }
+            ])
+        })
+        it('admin cannot change owner to member if no 2nd owner exists', async function () {
+            // Alice cannot change Bob to member of BTeam
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    role: Roles.Member
+                }
+            })
+            response.statusCode.should.equal(403)
+        })
+
+        it('non-admin non-member cannot modify member', async function () {
+            await app.db.models.User.create({ username: 'dave', name: 'Dave Vader', email: 'dave@example.com', password: 'ddPassword' })
+            await ('dave', 'ddPassword')
+
+            // Dave cannot make Chris owner of BTeam
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/members/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.dave },
+                payload: {
+                    role: Roles.Owner
+                }
+            })
+            response.statusCode.should.equal(401)
+        })
+    })
+})

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -1,0 +1,80 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+// const FF_UTIL = require('flowforge-test-utils')
+// const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Team API', function () {
+    let app
+    const TestObjects = {}
+    beforeEach(async function () {
+        app = await setup()
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('Get team details', async function () {
+        // GET /api/v1/teams/:teamId
+        // - Must be admin or team owner/member
+    })
+
+    describe('Get team details by slug', async function () {
+        // GET /api/v1/teams/:teamId?slug=<teamSlug>
+        // - Must be admin or team owner/member
+    })
+
+    describe('Get list of teams', async function () {
+        // GET /api/v1/teams/:teamId
+        // - Admin only
+    })
+
+    describe('Get list of a teams projects', async function () {
+        // GET /api/v1/teams/:teamId/projects
+        // - Admin/Owner/Member
+    })
+
+    describe('Create team', async function () {
+        // POST /api/v1/teams
+        // - Admin/Owner/Member
+    })
+
+    describe('Delete team', async function () {
+        // DELETE /api/v1/teams/:teamId
+        // - Admin/Owner/Member
+        // - should fail if team owns projects
+    })
+
+    describe('Edit team details', async function () {
+        // PUT /api/v1/teams/:teamId
+    })
+
+    describe('Get current users membership', async function () {
+        // GET /api/v1/teams/:teamId/user
+    })
+
+    describe('Get team audit-log', async function () {
+        // GET /api/v1/teams/:teamId/audit-log
+    })
+})

--- a/test/unit/forge/routes/setup.js
+++ b/test/unit/forge/routes/setup.js
@@ -29,6 +29,7 @@ module.exports = async function (settings = {}, config = {}) {
     const userAlice = await forge.db.models.User.create({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })
     const team1 = await forge.db.models.Team.create({ name: 'ATeam' })
     await team1.addUser(userAlice, { through: { role: Roles.Owner } })
+
     const templateProperties = {
         name: 'template1',
         active: true,
@@ -51,23 +52,5 @@ module.exports = async function (settings = {}, config = {}) {
     await project1.setProjectTemplate(template)
 
     forge.project = project1
-
-    await forge.db.models.StorageFlow.create({
-        flow: JSON.stringify([]),
-        ProjectId: project1.id
-    })
-    await forge.db.models.StorageCredentials.create({
-        credentials: JSON.stringify({}),
-        ProjectId: project1.id
-    })
-    await forge.db.models.StorageSettings.create({
-        settings: JSON.stringify({}),
-        ProjectId: project1.id
-    })
-    await forge.db.models.StorageSession.create({
-        sessions: JSON.stringify({}),
-        ProjectId: project1.id
-    })
-
     return forge
 }

--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -9,6 +9,23 @@ describe('Storage API', function () {
         app = await setup()
         project = app.project
         tokens = await project.refreshAuthTokens()
+
+        await app.db.models.StorageFlow.create({
+            flow: JSON.stringify([]),
+            ProjectId: project.id
+        })
+        await app.db.models.StorageCredentials.create({
+            credentials: JSON.stringify({}),
+            ProjectId: project.id
+        })
+        await app.db.models.StorageSettings.create({
+            settings: JSON.stringify({}),
+            ProjectId: project.id
+        })
+        await app.db.models.StorageSession.create({
+            sessions: JSON.stringify({}),
+            ProjectId: project.id
+        })
     })
 
     afterEach(async function () {


### PR DESCRIPTION
Clearing some debt around unit testing.

 - Fairly complete coverage of the team membership apis in anticipation of the stories around Admin being able to modify users.
 - Some initial coverage for team invitations

Hopefully will be a useful template for other parts of the API.