### PR TITLE
frontend: Admin created users default to no team

### DIFF
--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -42,7 +42,7 @@ export default {
                 password: '',
                 password_confirm: '',
                 isAdmin: false,
-                createDefaultTeam: true
+                createDefaultTeam: false
             },
             errors: {}
         }


### PR DESCRIPTION
Users created by the admin might get a personal team. This is the
default before this change. The default is now false after this commit,
as there's a possibility of billing being enabled. That creates a
requirement for payment details for first-time users and a sub optimal
onboarding experience.