### PR TITLE
Add a $1 charge when setting up team billing

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -3,7 +3,7 @@ module.exports.init = function (app) {
 
     return {
         createSubscriptionSession: async (team) => {
-            const session = await stripe.checkout.sessions.create({
+            const sub = {
                 mode: 'subscription',
                 line_items: [{
                     price: app.config.billing.stripe.team_price,
@@ -19,7 +19,16 @@ module.exports.init = function (app) {
                 payment_method_types: ['card'],
                 success_url: `${app.config.base_url}/team/${team.slug}/overview?billing_session={CHECKOUT_SESSION_ID}`,
                 cancel_url: `${app.config.base_url}/team/${team.slug}/overview`
-            })
+            }
+
+            if (app.config.billing?.stripe?.activation_price) {
+                sub.line_items.push({
+                    price: app.config.billing.stripe.activation_price,
+                    quantity: 1
+                })
+            }
+
+            const session = await stripe.checkout.sessions.create(sub)
             app.log.info(`Creating Subscription for team ${team.hashid}`)
             return session
         },

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -146,7 +146,7 @@ module.exports = async function (app) {
                         app.log.info(`Crediting activation fee to ${invoice}`)
                     }
                 }
-                break;
+                break
             case 'charge.failed':
                 // TODO: This needs work, we need to count failures and susspend projects
                 // after we hit a threshold (should track a charge.sucess to reset?)

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -133,15 +133,16 @@ module.exports = async function (app) {
                         }
                     })
                     if (activation) {
+                        // refund the actication test charge
                         await stripe.creditNote.create({
                             invoice: invoice.id,
                             lines: [{
                                 type: 'invoice_line_item',
-                                invoice_line_item: invoiceItem,
-                                amount: 100
+                                invoice_line_item: invoiceItem.id,
+                                amount: invoiceItem.amount
                             }],
                             memo: 'Activation check credit',
-                            credit_ammount: 100
+                            credit_ammount: invoiceItem.amount
                         })
                         app.log.info(`Crediting activation fee to ${invoice}`)
                     }


### PR DESCRIPTION
This means that billing fails for bad cards up front. The $1 is added to the account as credit as soon as the charge completes.

Uses the config item billing.stripe.actiavation_price as a feature flag
```yaml
billing:
  stripe:
    activation_price: price_......
```