### PR TITLE
Fix `stripe.invoice` should be `stripe.invoices`

### DIFF
--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -125,7 +125,7 @@ module.exports = async function (app) {
             case 'charge.succeeded':
                 // gate on config setting
                 if (app.config.billing?.stripe?.activation_price) {
-                    invoice = await stripe.invoice.retrieve(event.data.object.invoice)
+                    invoice = await stripe.invoices.retrieve(event.data.object.invoice)
                     invoice.lines.data.forEach(item => {
                         if (item.price.id === app.config.billing?.stripe?.activation_price) {
                             activation = true


### PR DESCRIPTION
This should fix 500 errors being reported in Stripe for callbacks with `charge.succeeded` events.

Will publish `0.4.1` once merged