### PR TITLE
Allow admin users to access team membership management options

### DIFF
--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -1,7 +1,7 @@
 <template>
     <FormHeading>
         Team Members
-        <template v-slot:tools v-if="isOwner">
+        <template v-slot:tools v-if="canModifyMembers">
             <ff-button kind="secondary" size="small" @click="inviteMember">
                 <template v-slot:icon-left><PlusSmIcon class="w-4" /></template>
                 Add member
@@ -15,7 +15,7 @@
 
     <ChangeTeamRoleDialog @roleUpdated="roleUpdated" ref="changeTeamRoleDialog" />
     <ConfirmTeamUserRemoveDialog @userRemoved="userRemoved" ref="confirmTeamUserRemoveDialog" />
-    <InviteMemberDialog :team="team" v-if="isOwner" ref="inviteMemberDialog" />
+    <InviteMemberDialog :team="team" v-if="canModifyMembers" ref="inviteMemberDialog" />
 </template>
 
 <script>
@@ -42,7 +42,7 @@ export default {
             userCount: 0,
             userColumns: [],
             ownerCount: 0,
-            isOwner: false
+            canModifyMembers: false
         }
     },
     watch: {
@@ -78,14 +78,14 @@ export default {
             this.ownerCount = 0
 
             const currentUser = this.users.find(user => user.username === this.$store.state.account.user.username)
-            this.isOwner = currentUser && currentUser.role === Roles.Owner
+            this.canModifyMembers = this.$store.state.account.user.admin || (currentUser && (currentUser.role === Roles.Owner))
 
             this.userColumns = [
                 { name: 'User', class: ['flex-grow'], component: { is: markRaw(UserCell) } },
                 { name: 'Role', class: ['w-40'], component: { is: markRaw(UserRoleCell) } }
             ]
 
-            if (this.isOwner) {
+            if (this.canModifyMembers) {
                 if (this.users) {
                     this.users.forEach(u => {
                         if (u.role === Roles.Owner) {

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -47,7 +47,7 @@ export default {
         },
         async fetchData () {
             if (this.team && this.teamMembership) {
-                if (this.teamMembership.role !== Roles.Owner) {
+                if (this.teamMembership.role !== Roles.Owner && this.teamMembership.role !== Roles.Admin) {
                     useRouter().push({ path: `/team/${useRoute().params.team_slug}/members/general` })
                     return
                 }

--- a/frontend/src/pages/team/Members/index.vue
+++ b/frontend/src/pages/team/Members/index.vue
@@ -8,6 +8,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import SectionSideMenu from '@/components/SectionSideMenu'
 import { Roles } from '@core/lib/roles'
 
@@ -18,6 +20,9 @@ import { Roles } from '@core/lib/roles'
 export default {
     name: 'TeamUsers',
     props: ['team', 'teamMembership'],
+    computed: {
+        ...mapState('account', ['user'])
+    },
     components: {
         SectionSideMenu
     },
@@ -37,7 +42,7 @@ export default {
             this.sideNavigation = [
                 { name: 'Members', path: './general' }
             ]
-            if (this.teamMembership && this.teamMembership.role === Roles.Owner) {
+            if (this.user.admin || (this.teamMembership && this.teamMembership.role === Roles.Owner)) {
                 this.sideNavigation.push({ name: 'Invitations', path: './invitations' })
             }
         }


### PR DESCRIPTION
Closes #355

This fixes the permissions checks on the Team Members page so that an Admin user can:
 - access the Invitations tab
 - invite new members
 - access the 'change/remove' options

The forge API already has the appropriate permissions in place to allow admin to do these things - the fix was just in the logic that hid the options for non-owners.