### PR TITLE
Limit access to Project Settings

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -335,7 +335,7 @@ module.exports = async function (app) {
         preHandler: (request, reply, done) => {
             // check accessToken is project scope
             if (request.session.ownerType !== 'project') {
-                reply.code(401).send('Permission Denied')
+                reply.code(401).send({ err: 'unauthorised' })
             } else {
                 done()
             }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -331,7 +331,16 @@ module.exports = async function (app) {
      * @name /api/v1/project/:id/settings
      * @memberof forge.routes.api.project
      */
-    app.get('/:projectId/settings', async (request, reply) => {
+    app.get('/:projectId/settings', {
+        preHandler: (request, reply, done) => {
+            // check accessToken is project scope
+            if (request.session.ownerType !== 'project') {
+                reply.code(401).send('Permission Denied')
+            } else {
+                done()
+            }
+        }
+    }, async (request, reply) => {
         if (request.project.state === 'suspended') {
             reply.code(400).send({ error: 'Project suspended' })
             return

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -1,0 +1,59 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('Project API', function () {
+    let app
+    const TestObjects = {}
+    beforeEach(async function () {
+        app = await setup()
+
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        // TestObjects.tokens.alice = (await app.db.controllers.AccessToken.createTokenForPasswordReset(TestObjects.alice)).token
+        TestObjects.tokens.project = (await app.project.refreshAuthTokens()).token
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    it('Get Project Settings', async function () {
+        this.timeout(10000)
+        const settingsURL = `/api/v1/projects/${app.project.id}/settings`
+        const response = await app.inject({
+            method: 'GET',
+            url: settingsURL,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project}`
+            }
+        })
+        const newSettings = response.json()
+        should(newSettings).have.property('storageURL')
+        should(newSettings).have.property('forgeURL')
+    })
+
+    it('Get Project Settings with Alice\'s session', async function () {
+        this.timeout(10000)
+        const settingsURL = `/api/v1/projects/${app.project.id}/settings`
+        const response = await app.inject({
+            method: 'GET',
+            url: settingsURL,
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        should(response).have.property('statusCode')
+        should(response.statusCode).eqls(401)
+    })
+})

--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -47,20 +47,6 @@ describe('Storage API', function () {
         should(newSettings).have.property('forgeURL')
     })
 
-    it('Get Flow', async function () {
-        this.timeout(10000)
-        const flowURL = `/storage/${project.id}/flows`
-        const response = await app.inject({
-            method: 'GET',
-            url: flowURL,
-            headers: {
-                authorization: `Bearer ${tokens.token}`
-            }
-        })
-        const flow = response.json()
-        should(flow).eqls([])
-    })
-
     it('Save Flow', async function () {
         this.timeout(10000)
         const newFlow = [{ id: '1', type: 'tab', label: 'tab1', disabled: false, info: '' }]


### PR DESCRIPTION
This limits access to the /project/:id/settings endpoint to tokens with the type `project`

fixes https://github.com/flowforge/security/issues/1