### PR TITLE
Rebrand the "Setup" workflow

### DIFF
--- a/frontend/src/SetupApp.vue
+++ b/frontend/src/SetupApp.vue
@@ -1,19 +1,8 @@
 <template>
-    <div class="min-h-screen flex flex-col bg-gray-300 ">
-        <div class="flex-grow mx-auto flex bg-gray-50 pt-4 pb-12">
-            <div class="sm:max-w-xl w-screen space-y-2">
-                <div class="max-w-xs mx-auto w-full mb-4">
-                    <Logo/>
-                    <h2 class="mt-2 text-center text-3xl font-bold text-gray-900">
-                        <span>FLOW</span><span class="font-light">FORGE</span>
-                    </h2>
-                </div>
-                <component :is="views[step]" :state="state" @next="next"></component>
-            </div>
-        </div>
-        <div class="w-full bg-gray-800 flex-grow-0">
-            <PageFooter />
-        </div>
+    <div class="min-h-screen flex flex-col">
+        <ff-layout-box class="ff-setup">
+            <component :is="views[step]" :state="state" @next="next"></component>
+        </ff-layout-box>
     </div>
 </template>
 
@@ -27,6 +16,8 @@ import Options from '@/pages/setup/Options'
 import CreateAdminUser from '@/pages/setup/CreateAdminUser'
 import License from '@/pages/setup/License'
 import Final from '@/pages/setup/Final'
+
+import FFLayoutBox from '@/layouts/Box'
 
 // To add more views in the setup dialogs, add them to this list.
 // Just make sure 'Final' is the last one.
@@ -58,7 +49,12 @@ export default {
         PageFooter,
         Logo,
         CreateAdminUser,
-        License
+        License,
+        'ff-layout-box': FFLayoutBox
     }
 }
 </script>
+
+<style lang="scss">
+@import "./stylesheets/common.scss";
+</style>

--- a/frontend/src/pages/setup/CreateAdminUser.vue
+++ b/frontend/src/pages/setup/CreateAdminUser.vue
@@ -25,7 +25,7 @@
             </ff-button>
         </template>
         <template v-else>
-            <p class="text-gray-700 mt-10 text-center">You have already created an admin user.</p>
+            <p class="text-center">You have already created an admin user.</p>
             <div class="flex justify-center">
                 <ff-button @click="next()" class="mt-3">
                     Next

--- a/frontend/src/pages/setup/Final.vue
+++ b/frontend/src/pages/setup/Final.vue
@@ -1,7 +1,7 @@
 <template>
-    <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-4">
-        <p class="text-gray-700 text-lg mt-10 text-center">Well done - that's all we need to get started.</p>
-        <p class="text-gray-700 text-center">All of these settings can be modified under the Admin Settings section of the platform.</p>
+    <form>
+        <p class="text-lg text-center">Well done - that's all we need to get started.</p>
+        <p class="text-center">All of these settings can be modified under the Admin Settings section of the platform.</p>
         <div class="flex justify-center">
             <ff-button @click="done()" class="mt-6">
                 Login to FlowForge

--- a/frontend/src/pages/setup/License.vue
+++ b/frontend/src/pages/setup/License.vue
@@ -1,23 +1,23 @@
 <template>
-    <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-4  pt-4">
+    <form>
         <FormHeading>2. Upload License</FormHeading>
         <template v-if="!state.license">
-            <p class="text-sm text-gray-700">FlowForge Community Edition is Open Source and can be used freely without a license.</p>
-            <p class="text-sm text-gray-700">If you have a FlowForge Enterprise Edition license, upload it here.</p>
-            <FormRow v-model="input.license" :error="errors.license">License</FormRow>
-            <div>
-                <ff-button kind="secondary" @click="next()" class="mt-6">
+            <p class="mt-4">FlowForge Community Edition is Open Source and can be used freely without a license.</p>
+            <p>If you have a FlowForge Enterprise Edition license, upload it here.</p>
+            <FormRow class="mt-6" v-model="input.license" :error="errors.license">License Key</FormRow>
+            <div class="flex mt-8">
+                <ff-button kind="tertiary" @click="next()">
                     Continue with FlowForge CE
                 </ff-button>
-                <ff-button :disabled="!formValid" @click="addLicense()" class="mt-6">
+                <ff-button :disabled="!formValid" @click="addLicense()">
                     Next
                 </ff-button>
             </div>
         </template>
         <template v-else>
-            <p class="text-gray-700 mt-10 text-center">You have already applied a FlowForge Enterprise Edition license.</p>
-            <p class="text-gray-700 mt-10 text-center">To apply a different license, complete this setup then login as the administrator and go to Admin Settings.</p>
-            <ff-button @click="next()" class="mt-6 ml-0">
+            <p class="text-center">You have already applied a FlowForge Enterprise Edition license.</p>
+            <p class="text-center">To apply a different license, complete this setup then login as the administrator and go to Admin Settings.</p>
+            <ff-button @click="next()">
                 Next
             </ff-button>
         </template>

--- a/frontend/src/pages/setup/Start.vue
+++ b/frontend/src/pages/setup/Start.vue
@@ -1,7 +1,7 @@
 <template>
-    <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-4">
-        <p class="text-gray-700 text-lg mt-10 text-center">Welcome to your shiny new FlowForge platform.</p>
-        <p class="text-gray-700 text-center">Let's get it setup for you to start using.</p>
+    <form class="">
+        <p class="text-center">Welcome to your shiny new FlowForge platform.</p>
+        <p class="text-center">Let's get it setup for you to start using.</p>
         <div class="flex justify-center">
             <ff-button @click="done()" class="mt-6">Start setup</ff-button>
         </div>

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -21,7 +21,6 @@
     max-width: 1024px;
     height: 60%;
     padding: 128px 0;
-    margin-bottom: 64px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -56,6 +55,9 @@
         margin-bottom: 4px;
         font-size: 0.75rem;
     }
+    p {
+        margin-bottom: 1rem;
+    }
     a {
         color: $ff-teal-400;
     }
@@ -76,29 +78,29 @@
 
     .ff-actions {
         margin-top: 18px;
-        .ff-btn {
-            text-transform: uppercase;
-            width: 100%;
-            margin-bottom: 6px;
+    }
+    .ff-btn {
+        text-transform: uppercase;
+        width: 100%;
+        margin-bottom: 6px;
+    }
+    .ff-btn.ff-btn--primary {
+        background-color: $ff-teal-600;
+        color: white;
+        &:hover {
+            background-color: $ff-teal-700;
         }
-        .ff-btn.ff-btn--primary {
-            background-color: $ff-teal-600;
+        &:disabled {
+            background-color: $ff-grey-400;
+            color: $ff-grey-300;
+        }
+    }
+    .ff-btn.ff-btn--tertiary {
+        color: $ff-teal-500;
+        font-weight: normal;
+        &:hover {
+            background-color: transparent;
             color: white;
-            &:hover {
-                background-color: $ff-teal-700;
-            }
-            &:disabled {
-                background-color: $ff-grey-400;
-                color: $ff-grey-300;
-            }
-        }
-        .ff-btn.ff-btn--tertiary {
-            color: $ff-teal-500;
-            font-weight: normal;
-            &:hover {
-                background-color: transparent;
-                color: white;
-            }
         }
     }
 }


### PR DESCRIPTION
Closes #500

`Start.vue`
<img width="1728" alt="Screenshot 2022-04-22 at 11 32 07" src="https://user-images.githubusercontent.com/99246719/164695808-a63b5ce9-5972-4afd-94d1-dda90c2018b4.png">

`CreateAdminUser.vue`
<img width="1728" alt="Screenshot 2022-04-22 at 11 30 52" src="https://user-images.githubusercontent.com/99246719/164695645-239fab5f-1d32-41be-b4fe-b28c5e954ab9.png">

`License.vue`
<img width="1728" alt="Screenshot 2022-04-22 at 11 32 34" src="https://user-images.githubusercontent.com/99246719/164696090-5b06f359-4508-45ce-b9f9-96bb23aeb8c1.png">

`Options.vue`
<img width="1728" alt="Screenshot 2022-04-22 at 11 33 15" src="https://user-images.githubusercontent.com/99246719/164696524-4323b033-ec11-49e6-b8d6-c4353a95a2cc.png">

`Final.vue`
<img width="1728" alt="Screenshot 2022-04-22 at 11 33 34" src="https://user-images.githubusercontent.com/99246719/164696740-e4469712-be34-4030-9eab-334bceb70906.png">

