### PR TITLE
Change back button for Team Create page

### DIFF
--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -42,7 +42,6 @@ import NavItem from '@/components/NavItem'
 import SideNavigation from '@/components/SideNavigation'
 import { ChevronLeftIcon } from '@heroicons/vue/solid'
 
-
 export default {
     name: 'AdminCreateUser',
     mixins: [Breadcrumbs],

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -2,8 +2,8 @@
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
             <template v-slot:back>
-                <router-link :to="{name: 'Projects', params: {team_slug: team.slug}}">
-                    <nav-item :icon="icons.chevronLeft" label="Back to Projects"></nav-item>
+                <router-link :to="{name: 'Home'}">
+                    <nav-item :icon="icons.chevronLeft" label="Back to Dashboard"></nav-item>
                 </router-link>
             </template>
         </SideNavigation>


### PR DESCRIPTION
The back button on the Team Create page says 'Back to Projects' and takes you to the current team's projects page. This has been copied over from the Project Create page where it makes sense.

But for Team Create, the back action should be something else.

This PR changes the text to Back to Dashboard, and takes you back to Home.

<img width="668" alt="image" src="https://user-images.githubusercontent.com/51083/166949890-fd98353a-8522-425c-adc5-0a5745d59746.png">


(also fixes up the lint error that #541 slipped in)