### PR TITLE
Hide projectCount from none admin users

### DIFF
--- a/forge/db/views/ProjectStack.js
+++ b/forge/db/views/ProjectStack.js
@@ -1,5 +1,5 @@
 module.exports = {
-    stack: function (app, stack) {
+    stack: function (app, stack, count) {
         if (stack) {
             const result = stack.toJSON()
             const filtered = {
@@ -7,8 +7,10 @@ module.exports = {
                 name: result.name,
                 active: result.active,
                 properties: result.properties || {},
-                createdAt: result.createdAt,
-                projectCount: result.projectCount
+                createdAt: result.createdAt
+            }
+            if (count) {
+                filtered.projectCount = result.projectCount
             }
             return filtered
         } else {

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -16,7 +16,7 @@ module.exports = async function (app) {
     app.get('/', async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const stacks = await app.db.models.ProjectStack.getAll(paginationOptions)
-        stacks.stacks = stacks.stacks.map(s => app.db.views.ProjectStack.stack(s))
+        stacks.stacks = stacks.stacks.map(s => app.db.views.ProjectStack.stack(s, request.session.User.admin))
         reply.send(stacks)
     })
 
@@ -29,7 +29,7 @@ module.exports = async function (app) {
     app.get('/:stackId', async (request, reply) => {
         const stack = await app.db.models.ProjectStack.byId(request.params.stackId)
         if (stack) {
-            reply.send(app.db.views.ProjectStack.stack(stack))
+            reply.send(app.db.views.ProjectStack.stack(stack, request.session.User.admin))
         } else {
             reply.code(404).type('text/html').send('Not Found')
         }
@@ -120,7 +120,7 @@ module.exports = async function (app) {
                 stack.properties = request.body.properties
             }
             await stack.save()
-            reply.send(app.db.views.ProjectStack.stack(stack))
+            reply.send(app.db.views.ProjectStack.stack(stack, request.session.User.admin))
         }
     })
 }


### PR DESCRIPTION
The view for the stack now takes a boolean to decide if it should include the `projectCount`

Fixes https://github.com/flowforge/security/issues/2