### PR TITLE
Allow admin to delete users

### DIFF
--- a/forge/db/models/TeamMember.js
+++ b/forge/db/models/TeamMember.js
@@ -33,6 +33,20 @@ module.exports = {
     finders: function (M) {
         return {
             static: {
+                getTeamsOwnedBy: async (userId) => {
+                    if (typeof userId === 'string') {
+                        userId = M.User.decodeHashid(userId)
+                    }
+                    return this.findAll({
+                        where: {
+                            UserId: userId,
+                            role: Roles.Owner
+                        },
+                        include: {
+                            model: M.Team
+                        }
+                    })
+                },
                 getTeamMembership: async (userId, teamId, includeTeam) => {
                     if (typeof teamId === 'string') {
                         teamId = M.Team.decodeHashid(teamId)

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -308,7 +308,7 @@ module.exports = async function (app) {
     app.delete('/:projectId', { preHandler: app.needsPermission('project:delete') }, async (request, reply) => {
         try {
             await app.containers.remove(request.project)
-            request.project.destroy()
+            await request.project.destroy()
             await app.db.controllers.AuditLog.projectLog(
                 request.project.id,
                 request.session.User.id,

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -58,7 +58,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.users
      */
     app.put('/:userId', async (request, reply) => {
-        sharedUser.updateUser(app, request.user, request, reply)
+        await sharedUser.updateUser(app, request.user, request, reply)
     })
 
     /**

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -11,7 +11,23 @@ const sharedUser = require('./shared/users')
 module.exports = async function (app) {
     // Lets assume all apis that access bulk users are admin only.
     app.addHook('preHandler', app.verifyAdmin)
-
+    app.addHook('preHandler', async (request, reply) => {
+        if (request.params.userId !== undefined) {
+            if (request.params.userId) {
+                try {
+                    request.user = await app.db.models.User.byId(request.params.userId)
+                    if (!request.user) {
+                        reply.code(404).type('text/html').send('Not Found')
+                        return
+                    }
+                } catch (err) {
+                    reply.code(404).type('text/html').send('Not Found')
+                }
+            } else {
+                reply.code(404).type('text/html').send('Not Found')
+            }
+        }
+    })
     /**
      * Get a list of all known users
      * @name /api/v1/users
@@ -27,32 +43,22 @@ module.exports = async function (app) {
 
     /**
      * Get a user's settings
-     * @name /api/v1/users/:id
+     * @name /api/v1/users/:userId
      * @static
      * @memberof forge.routes.api.users
      */
-    app.get('/:id', async (request, reply) => {
-        const user = await app.db.models.User.byId(request.params.id)
-        if (user) {
-            reply.send(app.db.views.User.userProfile(user))
-        } else {
-            reply.code(404).type('text/html').send('Not Found')
-        }
+    app.get('/:userId', async (request, reply) => {
+        reply.send(app.db.views.User.userProfile(request.user))
     })
 
     /**
      * Update user settings
-     * @name /api/v1/users/:id
+     * @name /api/v1/users/:userId
      * @static
      * @memberof forge.routes.api.users
      */
-    app.put('/:id', async (request, reply) => {
-        const user = await app.db.models.User.byId(request.params.id)
-        if (user) {
-            sharedUser.updateUser(app, user, request, reply)
-        } else {
-            reply.code(404).type('text/html').send('Not Found')
-        }
+    app.put('/:userId', async (request, reply) => {
+        sharedUser.updateUser(app, request.user, request, reply)
     })
 
     /**
@@ -102,6 +108,21 @@ module.exports = async function (app) {
                 responseMessage = err.toString()
             }
             reply.code(400).send({ error: responseMessage })
+        }
+    })
+
+    /**
+     * Delete a user
+     * @name /api/v1/users/:userId
+     * @static
+     * @memberof forge.routes.api.users
+     */
+    app.delete('/:userId', async (request, reply) => {
+        try {
+            await request.user.destroy()
+            reply.send({ status: 'okay' })
+        } catch (err) {
+            reply.code(400).send({ error: err.toString() })
         }
     })
 }

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -97,7 +97,7 @@ module.exports = fp(async function (app, opts, done) {
     async function verifySession (request, reply) {
         if (request.sid) {
             request.session = await app.db.controllers.Session.getOrExpire(request.sid)
-            if (request.session) {
+            if (request.session && request.session.User) {
                 return
             }
         }

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -7,6 +7,12 @@ const create = async (options) => {
     })
 }
 
+const deleteUser = async (userId) => {
+    return client.delete(`/api/v1/users/${userId}`).then(res => {
+        return res.data
+    })
+}
+
 const getUsers = (cursor, limit) => {
     const url = paginateUrl('/api/v1/users', cursor, limit)
     return client.get(url).then(res => res.data)
@@ -21,5 +27,6 @@ const updateUser = async (userId, options) => {
 export default {
     create,
     getUsers,
+    deleteUser,
     updateUser
 }

--- a/frontend/src/pages/admin/Users/General.vue
+++ b/frontend/src/pages/admin/Users/General.vue
@@ -15,7 +15,7 @@
         <div v-if="nextCursor">
             <a v-if="!loading" @click.stop="loadItems" class="forge-button-inline">Load more...</a>
         </div>
-        <AdminUserEditDialog @userUpdated="userUpdated" ref="adminUserEditDialog"/>
+        <AdminUserEditDialog @userUpdated="userUpdated" @userDeleted="userDeleted" ref="adminUserEditDialog"/>
 
     </form>
 </template>
@@ -63,6 +63,12 @@ export default {
                     this.users[i] = user
                     break
                 }
+            }
+        },
+        userDeleted (userId) {
+            const index = this.users.findIndex(u => u.id === userId)
+            if (index > -1) {
+                this.users.splice(index, 1)
             }
         },
         loadItems: async function () {

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -8,6 +8,7 @@
                 <FormRow id="admin" :disabled="adminLocked" v-model="input.admin" type="checkbox">Administrator
                     <template v-slot:append>
                         <ff-button v-if="adminLocked" kind="danger" size="small" @click="unlockAdmin()">
+                            Unlock
                             <template v-slot:icon>
                                 <LockClosedIcon />
                             </template>
@@ -15,8 +16,35 @@
                     </template>
                 </FormRow>
                 <FormHeading class="text-red-700">Danger Zone</FormHeading>
-                <div>
-                    <ff-button kind="danger" @click="expirePassword">Expire password</ff-button>
+                <div class="flex items-center space-x-2">
+                    <FormRow :error="errors.expirePassword">
+                        <template #input>
+                            <div class="flex items-center space-x-2">
+                                <ff-button :disabled="expirePassLocked"  :kind="expirePassLocked?'secondary':'danger'" @click="expirePassword">Expire password</ff-button>
+                                <ff-button v-if="expirePassLocked" kind="danger" size="small" @click="unlockExpirePassword()">
+                                    Unlock
+                                    <template v-slot:icon>
+                                        <LockClosedIcon />
+                                    </template>
+                                </ff-button>
+                            </div>
+                        </template>
+                    </FormRow>
+                </div>
+                <div class="flex items-center space-x-2">
+                    <FormRow :error="errors.deleteUser">
+                        <template #input>
+                            <div class="flex items-center space-x-2">
+                                <ff-button :disabled="deleteLocked" :kind="deleteLocked?'secondary':'danger'" @click="deleteUser">Delete user</ff-button>
+                                <ff-button v-if="deleteLocked" kind="danger" size="small" @click="unlockDelete()">
+                                    Unlock
+                                    <template v-slot:icon>
+                                        <LockClosedIcon />
+                                    </template>
+                                </ff-button>
+                            </div>
+                        </template>
+                    </FormRow>
                 </div>
             </form>
         </template>
@@ -49,7 +77,9 @@ export default {
             input: {},
             errors: {},
             user: null,
-            adminLocked: true
+            adminLocked: true,
+            deleteLocked: true,
+            expirePassLocked: true
         }
     },
     watch: {
@@ -77,6 +107,12 @@ export default {
     methods: {
         unlockAdmin () {
             this.adminLocked = false
+        },
+        unlockDelete () {
+            this.deleteLocked = false
+        },
+        unlockExpirePassword () {
+            this.expirePassLocked = false
         },
         confirm () {
             const opts = {}
@@ -120,11 +156,19 @@ export default {
                 this.isOpen = false
             }
         },
+        deleteUser () {
+            usersApi.deleteUser(this.user.id).then((response) => {
+                this.isOpen = false
+                this.$emit('userDeleted', this.user.id)
+            }).catch(err => {
+                this.errors.deleteUser = err.response.data.error
+            })
+        },
         expirePassword () {
             usersApi.updateUser(this.user.id, { password_expired: true }).then((response) => {
                 this.isOpen = false
             }).catch(err => {
-                console.log(err.response.data)
+                this.errors.expirePassword = err.response.data.error
             })
         }
     },
@@ -142,6 +186,9 @@ export default {
                 this.input.email = user.email
                 this.input.admin = user.admin
                 this.adminLocked = true
+                this.deleteLocked = true
+                this.expirePassLocked = true
+                this.errors = {}
                 isOpen.value = true
             }
         }

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -1,0 +1,189 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Users API', async function () {
+    let app
+    const TestObjects = {}
+
+    beforeEach(async function () {
+        app = await setup({}, { features: { devices: true } })
+
+        // alice : admin, team owner
+        // bob : admin, team owner
+        // chris (team owner)
+        // dave <-- the only user who can be cleanly deleted
+
+        // ATeam ( alice  (owner), bob (owner), chris)
+        // BTeam ( bob (owner), chris, dave)
+        // CTeam ( chris (owner), dave)
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword', admin: true })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.dave = await app.db.models.User.create({ username: 'dave', name: 'Dave Vader', email: 'dave@example.com', password: 'ddPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam' })
+        TestObjects.CTeam = await app.db.models.Team.create({ name: 'CTeam' })
+
+        // Alice set as ATeam owner in setup()
+        await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+        await TestObjects.ATeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+        await TestObjects.BTeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+        await TestObjects.BTeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+        await TestObjects.BTeam.addUser(TestObjects.dave, { through: { role: Roles.Member } })
+        await TestObjects.CTeam.addUser(TestObjects.chris, { through: { role: Roles.Owner } })
+        await TestObjects.CTeam.addUser(TestObjects.dave, { through: { role: Roles.Member } })
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+        await login('dave', 'ddPassword')
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+    describe('Delete a user', async function () {
+        // DELETE /api/v1/users/:userId
+
+        it('Cannot delete an admin user', async function () {
+            // Alice cannot delete Bob
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.bob.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('error')
+        })
+
+        it('Admin cannot delete themselves', async function () {
+            // Alice cannot delete Alice
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.alice.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('error')
+        })
+
+        it('Cannot delete a team owner', async function () {
+            // Alice cannot delete Chris
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.chris.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('error')
+        })
+
+        it('Non-admin cannot delete user', async function () {
+            // Chris cannot delete Dave
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.dave.hashid}`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(401)
+            const result = response.json()
+            result.should.have.property('error', 'unauthorized')
+        })
+
+        it('A deleted user can no longer access the API with an existing session token', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.dave }
+            })
+            response.statusCode.should.equal(200)
+            await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.dave.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const postDeleteResponse = await app.inject({
+                method: 'GET',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.dave }
+            })
+            postDeleteResponse.statusCode.should.equal(401)
+        })
+
+        it('Deleting a user removes pending invites for them', async function () {
+            // Alice invites Dave to TeamA
+            // Delete Dave
+            await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'dave'
+                }
+            })
+            const inviteListA = (await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })).json()
+            inviteListA.should.have.property('count', 1)
+
+            await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.dave.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const inviteListB = (await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })).json()
+            inviteListB.should.have.property('count', 0)
+        })
+
+        it('Deleting a user removes them from all teams they are in', async function () {
+            // Dave is in BTeam and CTeam
+            // - delete Dave - check the member lists
+
+            const countTeamMembers = async (teamId) => {
+                return (await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${teamId}/members`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })).json().count
+            }
+            ;(await countTeamMembers(TestObjects.BTeam.hashid)).should.equal(3)
+            ;(await countTeamMembers(TestObjects.CTeam.hashid)).should.equal(2)
+
+            await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${TestObjects.dave.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+
+            ;(await countTeamMembers(TestObjects.BTeam.hashid)).should.equal(2)
+            ;(await countTeamMembers(TestObjects.CTeam.hashid)).should.equal(1)
+        })
+    })
+})


### PR DESCRIPTION
Closes #338 

This PR implements the runtime API updates to allow an admin user to delete another user.

The UI changes to support this option will be added shortly - until then, this is a draft PR.

Rules:
 - Only an admin can delete users
 - A user cannot be deleted if:
    - they own a team
    - they are an admin

This also deletes any pending team invitations for the user (either sent by, or sent to).

It does *not* delete any active Node-RED editor sessions - that requires some changes in Node-RED to support remove invalidation of sessions.