### PR TITLE
Rebrand Dialog Boxes

### DIFF
--- a/frontend/src/pages/admin/Stacks/dialogs/AdminStackDeleteDialog.vue
+++ b/frontend/src/pages/admin/Stacks/dialogs/AdminStackDeleteDialog.vue
@@ -1,67 +1,32 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Delete stack</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        <span v-if="!deleteDisabled">
-                                            Are you sure you want to delete this stack?
-                                        </span>
-                                        <span v-else>
-                                            You cannot delete a stack that is still being used by projects.
-                                        </span>
-                                    </p>
-                                </div>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button class="ml-4" :disabled="deleteDisabled" @click="confirm()">Delete</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Delete Stack" @close="close">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <div class="mt-2 space-y-2">
+                    <p>
+                        <span v-if="!deleteDisabled">
+                            Are you sure you want to delete this stack?
+                        </span>
+                        <span v-else>
+                            You cannot delete a stack that is still being used by projects.
+                        </span>
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button kind="danger" :disabled="deleteDisabled" @click="confirm()">Delete</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 export default {
     name: 'AdminStackDeleteDialog',
-
-    components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle
-    },
+    emits: ['deleteStack'],
     data () {
         return {
             deleteDisabled: false,

--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -16,7 +16,7 @@
         </div>
     </form>
     <AdminStackEditDialog @stackCreated="stackCreated" @stackUpdated="stackUpdated" ref="adminStackEditDialog"/>
-    <AdminStackDeleteDialog @deleteStack="deleteStack"  ref="adminStackDeleteDialog"/>
+    <AdminStackDeleteDialog @deleteStack="deleteStack" ref="adminStackDeleteDialog"/>
 
 </template>
 

--- a/frontend/src/pages/admin/Template/dialogs/AdminTemplateSaveDialog.vue
+++ b/frontend/src/pages/admin/Template/dialogs/AdminTemplateSaveDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Stack" @close="close">
+    <ff-dialog :open="isOpen" header="Update Template" @close="close">
         <template v-slot:default>
             <form class="space-y-6">
                 <div class="space-y-2">
@@ -17,24 +17,9 @@
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 export default {
     name: 'AdminTemplateSaveDialog',
-
-    components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle
-    },
     methods: {
         confirm () {
             this.$emit('saveTemplate')

--- a/frontend/src/pages/admin/Template/dialogs/AdminTemplateSaveDialog.vue
+++ b/frontend/src/pages/admin/Template/dialogs/AdminTemplateSaveDialog.vue
@@ -1,43 +1,18 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Save template</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        Are you sure you want to save this template?
-                                    </p>
-                                    <p class="text-sm text-gray-500">
-                                        Any projects using this template will need to be manually restarted to pick up any changes.
-                                    </p>
-                                </div>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close">Cancel</ff-button>
-                                    <ff-button class="ml-4" @click="confirm">Save Template</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Delete Stack" @close="close">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <div class="space-y-2">
+                    <p>Are you sure you want to save this template?</p>
+                    <p>Any projects using this template will need to be manually restarted to pick up any changes.</p>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close">Cancel</ff-button>
+            <ff-button kind="primary" @click="confirm">Save Template</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>

--- a/frontend/src/pages/admin/Templates/dialogs/AdminTemplateDeleteDialog.vue
+++ b/frontend/src/pages/admin/Templates/dialogs/AdminTemplateDeleteDialog.vue
@@ -1,67 +1,31 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Delete template</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        <span v-if="!deleteDisabled">
-                                            Are you sure you want to delete this template?
-                                        </span>
-                                        <span v-else>
-                                            You cannot delete a template that is still being used by projects.
-                                        </span>
-                                    </p>
-                                </div>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close">Cancel</ff-button>
-                                    <ff-button kind="danger" class="ml-4" :disabled="deleteDisabled" @click="confirm">Delete</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Delete Stack" @close="close">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <div class="mt-2 space-y-2">
+                    <p class="text-sm text-gray-500">
+                        <span v-if="!deleteDisabled">
+                            Are you sure you want to delete this template?
+                        </span>
+                        <span v-else>
+                            You cannot delete a template that is still being used by projects.
+                        </span>
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close">Cancel</ff-button>
+            <ff-button kind="danger" class="ml-4" :disabled="deleteDisabled" @click="confirm">Delete</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 export default {
     name: 'AdminStackDeleteDialog',
-
-    components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle
-    },
     data () {
         return {
             deleteDisabled: false,

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -1,52 +1,30 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6">Edit user</DialogTitle>
-                            <form class="space-y-6 mt-2">
-                                <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
-                                <FormRow v-model="input.name" :placeholder="input.username">Name</FormRow>
-                                <FormRow v-model="input.email" :error="errors.email">Email</FormRow>
-                                <FormRow id="admin" :disabled="adminLocked" v-model="input.admin" type="checkbox">Administrator
-                                    <template v-slot:append>
-                                        <ff-button v-if="adminLocked" kind="danger" size="small" @click="unlockAdmin()">
-                                            <template v-slot:icon>
-                                                <LockClosedIcon />
-                                            </template>
-                                        </ff-button>
-                                    </template>
-                                </FormRow>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button :disabled="!formValid" class="ml-4" @click="confirm()">Save</ff-button>
-                                </div>
-                                <hr />
-                                <FormHeading class="text-red-700">Danger Zone</FormHeading>
-                                <div>
-                                    <ff-button kind="danger" @click="expirePassword">Expire password</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Edit User" @close="close">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
+                <FormRow v-model="input.name" :placeholder="input.username">Name</FormRow>
+                <FormRow v-model="input.email" :error="errors.email">Email</FormRow>
+                <FormRow id="admin" :disabled="adminLocked" v-model="input.admin" type="checkbox">Administrator
+                    <template v-slot:append>
+                        <ff-button v-if="adminLocked" kind="danger" size="small" @click="unlockAdmin()">
+                            <template v-slot:icon>
+                                <LockClosedIcon />
+                            </template>
+                        </ff-button>
+                    </template>
+                </FormRow>
+                <FormHeading class="text-red-700">Danger Zone</FormHeading>
+                <div>
+                    <ff-button kind="danger" @click="expirePassword">Expire password</ff-button>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button :disabled="!formValid" @click="confirm()">Save</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
@@ -54,13 +32,6 @@ import usersApi from '@/api/users'
 import { LockClosedIcon } from '@heroicons/vue/outline'
 
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import FormHeading from '@/components/FormHeading'
 import FormRow from '@/components/FormRow'
@@ -69,11 +40,6 @@ export default {
     name: 'AdminUserEditDialog',
 
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow,
         FormHeading,
         LockClosedIcon

--- a/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
@@ -52,7 +52,6 @@ export default {
             },
             async show (project) {
                 this.project = project
-                console.log(this.project)
                 this.input.stack = this.project.stack.id
                 isOpen.value = true
                 const stackList = await stacksApi.getStacks()

--- a/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
@@ -1,52 +1,22 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Change project stack</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        Select the new stack you want to use for this project:
-                                    </p>
-                                </div>
-                                <FormRow :options="stacks" v-model="input.stack">Stack</FormRow>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button class="ml-4" @click="confirm()">Change stack</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
-                </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+    <ff-dialog header="Change Project Stack" :open="isOpen">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <p >
+                    Select the new stack you want to use for this project:
+                </p>
+                <FormRow :options="stacks" v-model="input.stack">Stack</FormRow>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button class="ml-4" @click="confirm()">Change Stack</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import stacksApi from '@/api/stacks'
 
@@ -54,13 +24,7 @@ import FormRow from '@/components/FormRow'
 
 export default {
     name: 'ChangeStackDialog',
-
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow
     },
     data () {
@@ -88,6 +52,7 @@ export default {
             },
             async show (project) {
                 this.project = project
+                console.log(this.project)
                 this.input.stack = this.project.stack.id
                 isOpen.value = true
                 const stackList = await stacksApi.getStacks()

--- a/frontend/src/pages/project/Settings/dialogs/ConfirmProjectDeleteDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ConfirmProjectDeleteDialog.vue
@@ -1,68 +1,34 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Delete project</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        Are you sure you want to delete this project? Once deleted, there is no going back.
-                                    </p>
-                                    <p class="text-sm text-gray-500">
-                                        Enter the project name to continue.
-                                        <code class="block">{{ project.name }}</code>
-                                    </p>
-                                </div>
-                                <FormRow v-model="input.projectName" id="projectName">Name</FormRow>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog header="Delete Project" :open="isOpen">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <div class="mt-2 space-y-2">
+                    <p>
+                        Are you sure you want to delete this project? Once deleted, there is no going back.
+                    </p>
+                    <p>
+                        Enter the project name to continue.
+                        <code class="block">{{ project?.name }}</code>
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+                <FormRow v-model="input.projectName" id="projectName">Name</FormRow>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import FormRow from '@/components/FormRow'
 
 export default {
     name: 'ConfirmProjectDeleteDialog',
-
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow
     },
     data () {

--- a/frontend/src/pages/project/Settings/dialogs/ExportProjectDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ExportProjectDialog.vue
@@ -1,52 +1,24 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Export project</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        Select project components to export:
-                                    </p>
-                                </div>
-                                <ExportProjectComponents id="exportSettings" v-model="parts" showSecret="true"/>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button class="ml-4" @click="confirm()">Export project</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog header="Export Project" :open="isOpen">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <div class="mt-2 space-y-2">
+                    <p class="text-sm text-gray-500">
+                        Select project components to export:
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+                <ExportProjectComponents id="exportSettings" v-model="parts" showSecret="true"/>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button class="ml-4" @click="confirm()">Export project</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 // import FormRow from '@/components/FormRow'
 import ExportProjectComponents from '../../components/ExportProjectComponents'
@@ -54,11 +26,6 @@ import ExportProjectComponents from '../../components/ExportProjectComponents'
 export default {
     name: 'ExportProjectDialog',
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         ExportProjectComponents
     },
     data () {

--- a/frontend/src/pages/project/Settings/dialogs/ExportToProjectDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ExportToProjectDialog.vue
@@ -1,62 +1,33 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Export to Existing Project</DialogTitle>
-                            <form class="space-y-6">
-                                <FormRow>
-                                    Select the components to copy over to the new project
-                                    <template #input>
-                                        <ExportProjectComponents id="exportSettings" v-model="parts" showTemplate="true" showSettings="true" />
-                                    </template>
-                                </FormRow>
-                                <FormRow v-model="input.target" :options="projects">
-                                    <template v-slot:default>Target Project</template>
-                                </FormRow>
-
-                                <FormRow type="checkbox" v-model="input.exportConfirm">
-                                    Confirm export
-                                    <template v-slot:description>
-                                        The target project will be restarted once the export is complete.
-                                    </template>
-                                </FormRow>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button :disabled="!exportEnabled" class="ml-4" @click="confirm()">Export To Existing Project</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
-                </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+    <ff-dialog header="Export to Existing Project" :open="isOpen">
+        <template v-slot:default>
+            <form class="space-y-6">
+                <FormRow>
+                    Select the components to copy over to the new project
+                    <template #input>
+                        <ExportProjectComponents id="exportSettings" v-model="parts" showTemplate="true" showSettings="true" />
+                    </template>
+                </FormRow>
+                <FormRow v-model="input.target" :options="projects">
+                    <template v-slot:default>Target Project</template>
+                </FormRow>
+                <FormRow type="checkbox" v-model="input.exportConfirm">
+                    Confirm export
+                    <template v-slot:description>
+                        The target project will be restarted once the export is complete.
+                    </template>
+                </FormRow>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button :disabled="!exportEnabled" class="ml-4" @click="confirm()">Export To Existing Project</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import teamApi from '@/api/team'
 
@@ -66,11 +37,6 @@ import ExportProjectComponents from '../../components/ExportProjectComponents'
 export default {
     name: 'DuplicateProjectDialog',
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow,
         ExportProjectComponents
     },

--- a/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
+++ b/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
@@ -1,55 +1,35 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild as="template" enter="duration-300 ease-out" enter-from="opacity-0 scale-95" enter-to="opacity-100 scale-100" leave="duration-200 ease-in" leave-from="opacity-100 scale-100" leave-to="opacity-0 scale-95">
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6">Change role</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <template v-if="ownerCount < 2 && isOwner">
-                                        <p class="text-sm text-gray-500">You cannot change the role for <span class="font-bold">{{user.username}}</span> as
-                                            they are the only owner of the team.</p>
-                                    </template>
-                                    <template v-else>
-                                        <p class="text-sm text-gray-500">
-                                            Select a role for <span class="font-bold">{{user.username}}</span>:
-                                        </p>
-                                        <FormRow id="role-owner" :value="Roles.Owner" v-model="input.role" type="radio">Owner
-                                            <template v-slot:description>Owners can add and remove members to the team and create projects</template>
-                                        </FormRow>
-                                        <FormRow id="role-member" :value="Roles.Member" v-model="input.role" type="radio">Member
-                                            <template v-slot:description>Members can access the team projects</template>
-                                        </FormRow>
-                                    </template>
-                                </div>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" class="ml-4" @click="close()">Cancel</ff-button>
-                                    <ff-button :disabled="ownerCount < 2 && isOwner" class="ml-4" @click="confirm()">Change</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Change Role" @close="close">
+        <template v-slot:default v-if="user">
+            <form class="space-y-6">
+                <div class="mt-2 space-y-2">
+                    <template v-if="ownerCount < 2 && isOwner">
+                        <p class="text-sm text-gray-500">You cannot change the role for <span class="font-bold">{{ user.username }}</span> as
+                            they are the only owner of the team.</p>
+                    </template>
+                    <template v-else>
+                        <p class="text-sm text-gray-500">
+                            Select a role for <span class="font-bold">{{ user.username }}</span>:
+                        </p>
+                        <FormRow id="role-owner" :value="Roles.Owner" v-model="input.role" type="radio">Owner
+                            <template v-slot:description>Owners can add and remove members to the team and create projects</template>
+                        </FormRow>
+                        <FormRow id="role-member" :value="Roles.Member" v-model="input.role" type="radio">Member
+                            <template v-slot:description>Members can access the team projects</template>
+                        </FormRow>
+                    </template>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" class="ml-4" @click="close()">Cancel</ff-button>
+            <ff-button :disabled="ownerCount < 2 && isOwner" class="ml-4" @click="confirm()">Change</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import FormRow from '@/components/FormRow'
 import teamApi from '@/api/team'
@@ -57,15 +37,10 @@ import { Roles, RoleNames } from '@core/lib/roles'
 
 export default {
     name: 'ChangeTeamRoleDialog',
-
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow
     },
+    emits: ['roleUpdated'],
     data () {
         return {
             ownerCount: 0,
@@ -92,7 +67,7 @@ export default {
     },
     computed: {
         isOwner: function () {
-            return this.user.role === Roles.Owner
+            return this.user?.role === Roles.Owner
         }
     },
     setup () {

--- a/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
@@ -1,67 +1,33 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild
-                        as="template"
-                        enter="duration-300 ease-out"
-                        enter-from="opacity-0 scale-95"
-                        enter-to="opacity-100 scale-100"
-                        leave="duration-200 ease-in"
-                        leave-from="opacity-100 scale-100"
-                        leave-to="opacity-0 scale-95"
-                    >
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Delete team</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <p class="text-sm text-gray-500">
-                                        Are you sure you want to delete this team? Once deleted, there is no going back.
-                                    </p>
-                                    <p class="text-sm text-gray-500">
-                                        Enter the team name <code class="block">{{team.name}}</code> to continue.
-                                    </p>
-                                </div>
-                                <FormRow v-model="input.teamName" id="projectName">Name</FormRow>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                                    <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Delete Team" @close="close">
+        <template v-slot:default>
+            <form class="space-y-6" v-if="team">
+                <div class="space-y-6">
+                    <p>
+                        Are you sure you want to delete this team? Once deleted, there is no going back.
+                    </p>
+                    <p>
+                        Enter the team name <code class="block">{{team.name}}</code> to continue.
+                    </p>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+                <FormRow v-model="input.teamName" id="projectName">Name</FormRow>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
+            <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import FormRow from '@/components/FormRow'
 
 export default {
     name: 'ConfirmProjectDeleteDialog',
-
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow
     },
     data () {
@@ -75,7 +41,7 @@ export default {
     },
     watch: {
         'input.teamName': function () {
-            this.formValid = this.team.name === this.input.teamName
+            this.formValid = this.team?.name === this.input.teamName
         }
     },
     methods: {

--- a/frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue
@@ -1,62 +1,34 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild as="template" enter="duration-300 ease-out" enter-from="opacity-0 scale-95" enter-to="opacity-100 scale-100" leave="duration-200 ease-in" leave-from="opacity-100 scale-100" leave-to="opacity-0 scale-95">
-                        <div class="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6 text-red-700">Remove user from team</DialogTitle>
-                            <form class="space-y-6">
-                                <div class="mt-2 space-y-2">
-                                    <template v-if="ownerCount < 2 && user.role === 'owner'">
-                                        <p class="text-sm text-gray-500">You cannot remove <span class="font-bold">{{user.username}}</span> as
-                                            they are the only owner of the team.</p>
-                                    </template>
-                                    <template v-else>
-                                        <p class="text-sm text-gray-500">
-                                            Are you sure you want to remove <span class="font-bold">{{user.username}}</span> from the team <span class="font-bold">{{team.name}}</span>?
-                                        </p>
-                                    </template>
-                                </div>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" class="forge-button-secondary ml-4" @click="close()">Cancel</ff-button>
-                                    <ff-button kind="danger" :disabled="ownerCount < 2 && user.role === 'owner'" class="ml-4" @click="confirm()">Remove</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Remove User" @close="close">
+        <template v-slot:default v-if="user">
+            <form class="space-y-6">
+                <div class="mt-2 space-y-2">
+                    <template v-if="ownerCount < 2 && user.role === 'owner'">
+                        <p class="text-sm text-gray-500">You cannot remove <span class="font-bold">{{user.username}}</span> as
+                            they are the only owner of the team.</p>
+                    </template>
+                    <template v-else>
+                        <p class="text-sm text-gray-500">
+                            Are you sure you want to remove <span class="font-bold">{{user.username}}</span> from the team <span class="font-bold">{{team.name}}</span>?
+                        </p>
+                    </template>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" class="forge-button-secondary ml-4" @click="close()">Cancel</ff-button>
+            <ff-button kind="danger" :disabled="user && ownerCount < 2 && user.role === 'owner'" class="ml-4" @click="confirm()">Remove</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 
 import teamApi from '@/api/team'
 
 export default {
     name: 'ConfirmTeamUserRemoveDialog',
-
-    components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle
-    },
     data () {
         return {
             ownerCount: 0,

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -1,53 +1,31 @@
 <template>
-    <TransitionRoot appear :show="isOpen" as="template">
-        <Dialog as="div" @close="close">
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="min-h-screen px-4 text-center">
-                    <DialogOverlay class="fixed inset-0 bg-black opacity-50" />
-                    <span class="inline-block h-screen align-middle" aria-hidden="true">
-                        &#8203;
-                    </span>
-                    <TransitionChild as="template" enter="duration-300 ease-out" enter-from="opacity-0 scale-95" enter-to="opacity-100 scale-100" leave="duration-200 ease-in" leave-from="opacity-100 scale-100" leave-to="opacity-0 scale-95">
-                        <div class="inline-block w-full max-w-lg p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-lg rounded">
-                            <DialogTitle as="h3" class="text-lg font-medium leading-6">Add team members</DialogTitle>
-                            <form class="space-y-6" @submit.enter.prevent="">
-                                <div class="mt-2 space-y-2">
-                                    <template v-if="!responseErrors">
-                                        <p class="text-sm text-gray-500">
-                                            Invite a user to join the team.
-                                        </p>
-                                        <FormRow id="userInfo" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')"></FormRow>
-                                    </template>
-                                    <template v-else>
-                                        <ul>
-                                            <li class="text-sm" v-for="(value, name) in responseErrors" :key="name">
-                                                <span class="font-medium">{{name}}</span>: <span>{{value}}</span>
-                                            </li>
-                                        </ul>
-                                    </template>
-                                </div>
-                                <div class="mt-4 flex flex-row justify-end">
-                                    <ff-button kind="secondary" @click="close">Cancel</ff-button>
-                                    <ff-button :disabled="responseErrors || !input.userInfo.trim() || errors.userInfo" class="ml-4" @click="confirm">Invite</ff-button>
-                                </div>
-                            </form>
-                        </div>
-                    </TransitionChild>
+    <ff-dialog :open="isOpen" header="Invite Team Member" @close="close">
+        <template v-slot:default>
+            <form class="space-y-6" @submit.enter.prevent="">
+                <div class="space-y-2">
+                    <template v-if="!responseErrors">
+                        <p>Invite a user to join the team.</p>
+                        <FormRow id="userInfo" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')"></FormRow>
+                    </template>
+                    <template v-else>
+                        <ul>
+                            <li class="text-sm" v-for="(value, name) in responseErrors" :key="name">
+                                <span class="font-medium">{{name}}</span>: <span>{{value}}</span>
+                            </li>
+                        </ul>
+                    </template>
                 </div>
-            </div>
-        </Dialog>
-    </TransitionRoot>
+            </form>
+        </template>
+        <template v-slot:actions>
+            <ff-button kind="secondary" @click="close">Cancel</ff-button>
+            <ff-button :disabled="responseErrors || !input.userInfo.trim() || errors.userInfo" class="ml-4" @click="confirm">Invite</ff-button>
+        </template>
+    </ff-dialog>
 </template>
 
 <script>
 import { ref } from 'vue'
-import {
-    TransitionRoot,
-    TransitionChild,
-    Dialog,
-    DialogOverlay,
-    DialogTitle
-} from '@headlessui/vue'
 import { mapState } from 'vuex'
 import FormRow from '@/components/FormRow'
 import teamApi from '@/api/team'
@@ -55,11 +33,6 @@ import teamApi from '@/api/team'
 export default {
     name: 'InviteMemberDialog',
     components: {
-        TransitionRoot,
-        TransitionChild,
-        Dialog,
-        DialogOverlay,
-        DialogTitle,
         FormRow
     },
     props: ['team'],


### PR DESCRIPTION
- Replace all instances of `headlessui/Dialog` with `ff-dialog`.
- Ensure dialog components define their relevant `emits:` property (required for Vue 3.0)
- Add in object validation for template injection (was previously covered by `<Transition>` from `headless`
- Improve form validation in `AdminStackEditDialog.vue`