### PR TITLE
Encode palette.denyList as an array rather than string

### DIFF
--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -107,8 +107,7 @@ module.exports = {
             const paletteNodeExcludes = result.palette.nodesExcludes
             delete result.palette.nodesExcludes
             if (
-                typeof paletteNodeExcludes === 'string' &&
-        paletteNodeExcludes.length > 0
+                typeof paletteNodeExcludes === 'string' && paletteNodeExcludes.length > 0
             ) {
                 const parts = paletteNodeExcludes
                     .split(',')
@@ -128,22 +127,15 @@ module.exports = {
         if (result.palette?.denyList !== undefined) {
             const paletteDenyList = result.palette.denyList
             delete result.palette.denyList
-            if (
-                typeof paletteDenyList === 'string' &&
-                paletteDenyList.length > 0
-            ) {
-                const parts = paletteDenyList
-                    .split(',')
-                    .map((fn) => fn.trim())
-                    .filter((fn) => fn.length > 0)
-                if (parts.length > 0) {
-                    for (let i = 0; i < parts.length; i++) {
-                        const fn = parts[i]
+            if (Array.isArray(paletteDenyList)) {
+                if (paletteDenyList.length > 0) {
+                    for (let i = 0; i < paletteDenyList.length; i++) {
+                        const fn = paletteDenyList[i]
                         if (!/^((@[a-z0-9-~][a-z0-9-._~]*\/)?([a-z0-9-~][a-z0-9-._~]*|\*))(@([~^><]|<=|>=)?((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?))?$/i.test(fn)) {
                             throw new Error('Invalid settings.palette.denyList')
                         }
                     }
-                    result.palette.denyList = parts.join(',')
+                    result.palette.denyList = paletteDenyList
                 }
             }
         }

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -28,7 +28,6 @@ module.exports = async function (app) {
      */
     app.get('/:templateId', async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
-        console.log(template)
         if (template) {
             reply.send(app.db.views.ProjectTemplate.template(template))
         } else {


### PR DESCRIPTION
Modifies how palette.denyList is stored in the template so it is stored as an Array rather than csv.

This is the format used in the NR settings file, and will allow for a more flexible UI in the future.

To do this, have added the concept of a property encoder/decoder that can map the value in the template to the value that is edited. This lets us map to/from a CSV string.