### PR TITLE
docs: Update codeblock names

### DIFF
--- a/docs/install/docker/stacks.md
+++ b/docs/install/docker/stacks.md
@@ -17,7 +17,7 @@ as it's base and then add the required FlowForge components.
 
 If you wanted to pin at Node-RED v2.2.2 you would change the first line to:
 
-```Dockerfile
+```docker
 FROM nodered/node-red:2.2.2
 
 ARG REGISTRY

--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -62,7 +62,7 @@ xcode-select --install
     ```
    
    For Windows:
-    ```console
+    ```
     mkdir c:\flowforge
     ```
 
@@ -79,7 +79,7 @@ xcode-select --install
     ```
 
    For Windows:
-    ```console
+    ```
     cd c:\temp
     tar -xf flowforge-installer-x.y.z.zip
     xcopy /E /I flowforge-installer-x.y.z c:\flowforge
@@ -94,7 +94,7 @@ xcode-select --install
     ```
 
    For Windows:
-    ```console
+    ```
     cd c:\flowforge
     install.bat
     ```


### PR DESCRIPTION
For syntax highlighting the blocks should have a recognized name by
Prism.JS. This change updates all docs to be in line with that package.