### PR TITLE
Add missing steps to dev:local

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "cover:unit": "nyc --silent npm run test:unit",
         "cover:system": "nyc --silent --no-clean npm run test:system",
         "cover:report": "nyc report --reporter=text --reporter html",
-        "dev:local": "cd ../flowforge-nr-launcher && npm install ../flowforge-nr-storage ../flowforge-nr-auth ../flowforge-nr-audit-logger && cd ../flowforge-driver-localfs && npm install ../flowforge-nr-launcher && cd ../flowforge && npm install ../flowforge-driver-localfs ../forge-ui-components",
+        "dev:local": "cd ../flowforge-nr-launcher && npm install ../flowforge-nr-storage ../flowforge-nr-auth ../flowforge-nr-audit-logger && cd ../flowforge-driver-localfs && npm install ../flowforge-nr-launcher && cd ../flowforge && npm install ../flowforge-driver-localfs ../forge-ui-components && cd ../forge-ui-components && npm install && npm run build && cd ../flowforge-nr-storage && npm install && cd ../flowforge-nr-audit-logger && npm install && cd ../flowforge-nr-auth && npm install",
         "install-stack": "node scripts/install-stack.js --"
     },
     "bin": {


### PR DESCRIPTION
As discussed on slack: https://flowforgeworkspace.slack.com/archives/C032Q63FGG1/p1652345077573039 

In short: adds the following to the end of `dev:local`...

```bash
npm i ../forge-ui-components 
npm run build
npm i ../flowforge-nr-storage
npm i ../flowforge-nr-audit-logger
npm i ../flowforge-nr-auth
```

This ensures symlinked packages have a `node_modules` folder and `forge-ui-components` is built