### PR TITLE
Add ProjectSnapshots

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto')
+
 /**
  * inflightProjectState - when projects are transitioning between states, there
  * is no need to store that in the database. But we do need to know it so the
@@ -68,5 +70,75 @@ module.exports = {
 
         result.env = env
         return result
+    },
+
+    exportProject: async function (app, project, components) {
+        components = components || {
+            flows: true,
+            credentials: true,
+            settings: true,
+            envVars: true
+        }
+        const projectExport = {}
+        if (components.flows) {
+            const flows = await app.db.models.StorageFlow.byProject(project.id)
+            projectExport.flows = !flows ? [] : JSON.parse(flows.flow)
+            if (components.credentials) {
+                const origCredentials = await app.db.models.StorageCredentials.byProject(project.id)
+                if (origCredentials) {
+                    const encryptedCreds = JSON.parse(origCredentials.credentials)
+                    if (components.credentialSecret) {
+                        const settings = JSON.parse((await app.db.models.StorageSettings.byProject(project.id))?.settings || '{}')
+                        // const newCredentialSecrect = components.credentialSecret || crypto.randomBytes(32).toString('hex')
+                        projectExport.credentials = recryptCreds(encryptedCreds, settings._credentialSecret, components.credentialSecret)
+                    } else {
+                        projectExport.credentials = encryptedCreds
+                    }
+                }
+            }
+        }
+        if (components.settings || components.envVars) {
+            const settings = await app.db.controllers.Project.getRuntimeSettings(project)
+            const envVars = settings.env
+            delete settings.env
+            if (components.settings) {
+                projectExport.settings = settings
+            }
+            if (components.envVars) {
+                projectExport.env = envVars
+            }
+        }
+        const NRSettings = await app.db.models.StorageSettings.byProject(project.id)
+        if (NRSettings) {
+            projectExport.modules = {}
+            try {
+                const nodeList = JSON.parse(NRSettings.settings).nodes || {}
+                Object.entries(nodeList).forEach(([key, value]) => {
+                    projectExport.modules[key] = value.version
+                })
+            } catch (err) {}
+        }
+        return projectExport
     }
+}
+
+function recryptCreds (original, oldKey, newKey) {
+    const newHash = crypto.createHash('sha256').update(newKey).digest()
+    const oldHash = crypto.createHash('sha256').update(oldKey).digest()
+    return encryptCreds(newHash, decryptCreds(oldHash, original))
+}
+
+function decryptCreds (key, cipher) {
+    let flows = cipher.$
+    const initVector = Buffer.from(flows.substring(0, 32), 'hex')
+    flows = flows.substring(32)
+    const decipher = crypto.createDecipheriv('aes-256-ctr', key, initVector)
+    const decrypted = decipher.update(flows, 'base64', 'utf8') + decipher.final('utf8')
+    return JSON.parse(decrypted)
+}
+
+function encryptCreds (key, plain) {
+    const initVector = crypto.randomBytes(16)
+    const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
+    return { $: initVector.toString('hex') + cipher.update(JSON.stringify(plain), 'utf8', 'base64') + cipher.final('base64') }
 }

--- a/forge/db/controllers/ProjectSnapshot.js
+++ b/forge/db/controllers/ProjectSnapshot.js
@@ -1,0 +1,26 @@
+module.exports = {
+    /**
+     * Creates a snapshot of the current state of a project
+     * @param {*} app
+     * @param {*} project
+     */
+    createSnapshot: async function (app, project, user, options) {
+        const projectExport = await app.db.controllers.Project.exportProject(project)
+        const snapshot = await app.db.models.ProjectSnapshot.create({
+            name: options.name || '',
+            settings: {
+                settings: projectExport.settings || {},
+                env: projectExport.env || {},
+                modules: projectExport.modules || {}
+            },
+            flows: {
+                flows: projectExport.flows,
+                credentials: projectExport.credentials
+            },
+            ProjectId: project.id,
+            UserId: user.id
+        })
+        await snapshot.save()
+        return snapshot
+    }
+}

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -18,7 +18,8 @@ const modelTypes = [
     'Invitation',
     'AuditLog',
     'Project',
-    'ProjectTemplate'
+    'ProjectTemplate',
+    'ProjectSnapshot'
 ]
 
 async function init (app) {

--- a/forge/db/migrations/20220517-01-add-project-snapshot.js
+++ b/forge/db/migrations/20220517-01-add-project-snapshot.js
@@ -1,0 +1,37 @@
+/**
+ * Add ProjectSnapshots table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.createTable('ProjectSnapshots', {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            name: { type: DataTypes.STRING, allowNull: false },
+            settings: { type: DataTypes.TEXT },
+            flows: { type: DataTypes.TEXT },
+            createdAt: { type: DataTypes.DATE },
+            updatedAt: { type: DataTypes.DATE },
+            ProjectId: {
+                type: DataTypes.UUID,
+                allowNull: false,
+                references: { model: 'Projects', key: 'id' },
+                onDelete: 'CASCADE',
+                onUpdate: 'CASCADE'
+            },
+            UserId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: { model: 'Users', key: 'id' },
+                onDelete: 'SET NULL',
+                onUpdate: 'CASCADE'
+            }
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -63,6 +63,7 @@ module.exports = {
         this.hasMany(M.ProjectSettings)
         this.belongsTo(M.ProjectStack)
         this.belongsTo(M.ProjectTemplate)
+        this.hasMany(M.ProjectSnapshot)
     },
     hooks: function (M) {
         return {

--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -1,0 +1,80 @@
+/**
+ * A Project Snapshot definition
+ * @namespace forge.db.models.ProjectSnapshot
+ */
+const { DataTypes, Op } = require('sequelize')
+
+module.exports = {
+    name: 'ProjectSnapshot',
+    schema: {
+        name: { type: DataTypes.STRING, allowNull: false, unique: true },
+        settings: {
+            type: DataTypes.TEXT,
+            set (value) {
+                this.setDataValue('settings', JSON.stringify(value))
+            },
+            get () {
+                const rawValue = this.getDataValue('settings') || '{}'
+                return JSON.parse(rawValue)
+            }
+        },
+        flows: {
+            type: DataTypes.TEXT,
+            set (value) {
+                this.setDataValue('flows', JSON.stringify(value))
+            },
+            get () {
+                const rawValue = this.getDataValue('flows') || '{}'
+                return JSON.parse(rawValue)
+            }
+        }
+    },
+    meta: {
+        links: false
+    },
+    associations: function (M) {
+        this.belongsTo(M.Project)
+        this.belongsTo(M.User)
+    },
+    finders: function (M) {
+        const self = this
+        return {
+            static: {
+                byId: async function (id) {
+                    if (typeof id === 'string') {
+                        id = M.ProjectSnapshot.decodeHashid(id)
+                    }
+                    return self.findOne({
+                        where: { id }
+                    })
+                },
+                forProject: async (projectId, pagination = {}) => {
+                    const limit = parseInt(pagination.limit) || 30
+                    const where = {
+                        ProjectId: projectId
+                    }
+                    if (pagination.cursor) {
+                        where.id = { [Op.gt]: M.ProjectSnapshot.decodeHashid(pagination.cursor) }
+                    }
+                    const { count, rows } = await this.findAndCountAll({
+                        where,
+                        order: [['id', 'ASC']],
+                        limit,
+                        attributes: ['hashid', 'id', 'name', 'createdAt', 'updatedAt'],
+                        include: {
+                            model: M.User,
+                            attributes: ['hashid', 'id', 'username', 'avatar']
+                        }
+                    })
+                    return {
+                        meta: {
+                            next_cursor: rows.length === limit ? rows[rows.length - 1].hashid : undefined
+                        },
+                        count: count,
+                        snapshots: rows
+                    }
+                }
+            }
+        }
+    }
+}

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -53,6 +53,7 @@ const modelTypes = [
     'ProjectSettings',
     'ProjectStack',
     'ProjectTemplate',
+    'ProjectSnapshot',
     'AccessToken',
     'AuthClient',
     'Device',

--- a/forge/db/views/ProjectSnapshot.js
+++ b/forge/db/views/ProjectSnapshot.js
@@ -1,0 +1,19 @@
+module.exports = {
+    snapshot: function (app, snapshot) {
+        if (snapshot) {
+            const result = snapshot.toJSON()
+            const filtered = {
+                id: result.hashid,
+                name: result.name,
+                createdAt: result.createdAt,
+                updatedAt: result.updatedAt
+            }
+            if (snapshot.User) {
+                filtered.user = app.db.views.User.shortProfile(snapshot.User)
+            }
+            return filtered
+        } else {
+            return null
+        }
+    }
+}

--- a/forge/db/views/index.js
+++ b/forge/db/views/index.js
@@ -18,7 +18,8 @@ const modelTypes = [
     'Invitation',
     'AuditLog',
     'ProjectStack',
-    'ProjectTemplate'
+    'ProjectTemplate',
+    'ProjectSnapshot'
 ]
 
 async function init (app) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -1,6 +1,8 @@
 const crypto = require('crypto')
 const ProjectActions = require('./projectActions')
 const ProjectDevices = require('./projectDevices')
+const ProjectSnapshots = require('./projectSnapshots')
+
 /**
  * Instance api routes
  *
@@ -62,6 +64,7 @@ module.exports = async function (app) {
         app.register(ProjectDevices, { prefix: '/:projectId/devices' })
     }
     app.register(ProjectActions, { prefix: '/:projectId/actions' })
+    app.register(ProjectSnapshots, { prefix: '/:projectId/snapshots' })
 
     /**
      * Get the details of a given project
@@ -688,45 +691,10 @@ module.exports = async function (app) {
      * @name /api/v1/project/:id/export
      * @memberof forge.routes.api.project
      */
-    // app.post('/:projectId/export', async (request, reply) => {
-    //     const components = request.body.components
-    //     reply.header('content-disposition', 'attachment; filename="project.json"')
-    //     const projectExport = {}
-    //     if (components.flows) {
-    //         const flows = await app.db.models.StorageFlow.byProject(request.project.id)
-    //         projectExport.flows = !flows ? [] : JSON.parse(flows.flow)
-
-    //         if (components.creds) {
-    //             const origCredentials = await app.db.models.StorageCredentials.byProject(request.project.id)
-    //             if (origCredentials) {
-    //                 const encryptedCreds = JSON.parse(origCredentials.credentials)
-    //                 const settings = JSON.parse((await app.db.models.StorageSettings.byProject(request.project.id)).settings)
-    //                 const key = crypto.createHash('sha256').update(settings._credentialSecret).digest()
-    //                 const plainText = decryptCreds(key, encryptedCreds)
-    //                 const newKey = crypto.createHash('sha256').update(components.creds).digest()
-    //                 const newCreds = encryptCreds(newKey, plainText)
-
-    //                 projectExport.credentials = newCreds
-    //             }
-    //         }
-    //     }
-    //     if (components.envVars) {
-    //         const settings = await app.db.controllers.Project.getRuntimeSettings(request.project)
-    //         if (components.envVarsKo) {
-    //             projectExport.envVars = {}
-    //             Object.keys(settings.env).forEach(key => {
-    //                 projectExport.envVars[key] = ''
-    //             })
-    //         } else {
-    //             if (settings.env) {
-    //                 projectExport.envVars = settings.env
-    //             }
-    //         }
-    //     }
-    //     const NRSettings = await app.db.models.StorageSettings.byProject(request.project.id)
-    //     if (NRSettings) {
-    //         projectExport.nodes = JSON.parse(NRSettings.settings).nodes
-    //     }
+    // app.get('/:projectId/export', async (request, reply) => {
+    //     const components = request.body?.components
+    //     // reply.header('content-disposition', 'attachment; filename="project.json"')
+    //     const projectExport = await app.db.controllers.Project.exportProject(request.project, components)
     //     reply.send(projectExport)
     // })
 

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -1,0 +1,75 @@
+/**
+ * Project Snapshot api routes
+ *
+ * request.project will be defined for any route defined in here
+ *
+ * - /api/v1/project/:projectId/snapshots/
+ *
+ * @namespace project
+ * @memberof forge.routes.api
+ */
+module.exports = async function (app) {
+    app.addHook('preHandler', async (request, reply) => {
+        if (request.params.snapshotId !== undefined) {
+            if (request.params.snapshotId) {
+                try {
+                    request.snapshot = await app.db.models.ProjectSnapshot.byId(request.params.snapshotId)
+                    if (!request.snapshot) {
+                        reply.code(404).type('text/html').send('Not Found')
+                        return
+                    }
+                } catch (err) {
+                    reply.code(404).type('text/html').send('Not Found')
+                }
+            } else {
+                reply.code(404).type('text/html').send('Not Found')
+            }
+        }
+    })
+    // app.addHook('preHandler', app.needsPermission('project:change-status'))
+
+    /**
+     * Get list of all project snapshots
+     */
+    app.get('/', async (request, reply) => {
+        const paginationOptions = app.getPaginationOptions(request)
+        const snapshots = await app.db.models.ProjectSnapshot.forProject(request.project.id, paginationOptions)
+        snapshots.snapshots = snapshots.snapshots.map(s => app.db.views.ProjectSnapshot.snapshot(s))
+        reply.send(snapshots)
+    })
+
+    /**
+     * Get details of a snapshot - metadata only
+     */
+    app.get('/:snapshotId', async (request, reply) => {
+        reply.send(app.db.views.ProjectSnapshot.snapshot(request.snapshot))
+    })
+
+    /**
+     * Delete a snapshot
+     */
+    app.delete('/:snapshotId', {
+        preHandler: app.needsPermission('project:snapshot:delete')
+    }, async (request, reply) => {
+        await request.snapshot.destroy()
+        reply.send({ status: 'okay' })
+    })
+
+    /**
+     * Create a snapshot
+     */
+    app.post('/', {
+        preHandler: app.needsPermission('project:snapshot:create')
+    }, async (request, reply) => {
+        // TODO: permission check
+        const snapShot = await app.db.controllers.ProjectSnapshot.createSnapshot(
+            request.project,
+            request.session.User,
+            {
+                name: request.body.name || ''
+            }
+        )
+        snapShot.User = request.session.User
+        reply.send(app.db.views.ProjectSnapshot.snapshot(snapShot))
+    })
+}

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -23,6 +23,8 @@ const defaultPermissions = {
     // Project Editor
     'project:flows:view': { description: 'View Project Flows', role: Roles.Member },
     'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member },
+    'project:snapshot:create': { description: 'Create Project Snapshot', role: Roles.Owner },
+    'project:snapshot:delete': { description: 'Delete Project Snapshot', role: Roles.Owner },
     // Templates
     'template:create': { description: 'Create a Template', role: Roles.Admin },
     'template:delete': { description: 'Delete a Template', role: Roles.Admin },

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -74,4 +74,10 @@ describe('Project controller', function () {
             result.env.should.have.property('three', 'c')
         })
     })
+
+    describe('exportProject', function () {
+        it('', async function () {
+            //
+        })
+    })
 })

--- a/test/unit/forge/routes/api/projectSnapshots_spec.js
+++ b/test/unit/forge/routes/api/projectSnapshots_spec.js
@@ -1,0 +1,270 @@
+const should = require('should') // eslint-disable-line
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+const crypto = require('crypto')
+
+const setup = require('../setup')
+
+function encryptCredentials (key, plain) {
+    const initVector = crypto.randomBytes(16)
+    const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
+    return { $: initVector.toString('hex') + cipher.update(JSON.stringify(plain), 'utf8', 'base64') + cipher.final('base64') }
+}
+// function decryptCredentials (key, cipher) {
+//     let flows = cipher.$
+//     const initVector = Buffer.from(flows.substring(0, 32), 'hex')
+//     flows = flows.substring(32)
+//     const decipher = crypto.createDecipheriv('aes-256-ctr', key, initVector)
+//     const decrypted = decipher.update(flows, 'base64', 'utf8') + decipher.final('utf8')
+//     return JSON.parse(decrypted)
+// }
+
+describe('Project Snapshots API', function () {
+    let app
+    const TestObjects = {}
+    beforeEach(async function () {
+        app = await setup()
+
+        TestObjects.project1 = app.project
+
+        // alice : admin
+        // bob
+        // chris
+
+        // ATeam ( alice (owner), bob )
+
+        // project1 owned by ATeam
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Member } })
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+
+        // TestObjects.tokens.alice = (await app.db.controllers.AccessToken.createTokenForPasswordReset(TestObjects.alice)).token
+        TestObjects.tokens.project = (await app.project.refreshAuthTokens()).token
+
+        TestObjects.template1 = app.template
+        TestObjects.stack1 = app.stack
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    // This is copy/paste from project_spec.js - consider moving out to utils
+    async function addFlowsToProject (id, token, flows, creds, key, settings) {
+        await app.inject({
+            method: 'POST',
+            url: `/storage/${id}/flows`,
+            payload: flows,
+            headers: {
+                authorization: `Bearer ${token}`
+            }
+        })
+        const hashKey = crypto.createHash('sha256').update(key).digest()
+        await app.inject({
+            method: 'POST',
+            url: `/storage/${id}/credentials`,
+            payload: encryptCredentials(hashKey, creds),
+            headers: {
+                authorization: `Bearer ${token}`
+            }
+        })
+        await app.inject({
+            method: 'POST',
+            url: `/storage/${id}/settings`,
+            payload: { _credentialSecret: key },
+            headers: {
+                authorization: `Bearer ${token}`
+            }
+        })
+        await app.inject({
+            method: 'PUT',
+            url: `/api/v1/projects/${id}`,
+            payload: {
+                settings
+            },
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+    }
+
+    async function createSnapshot (projectId, name, token) {
+        return await app.inject({
+            method: 'POST',
+            url: `/api/v1/projects/${projectId}/snapshots`,
+            payload: {
+                name
+            },
+            cookies: { sid: token }
+        })
+    }
+    async function listProjectSnapshots (projectId, token) {
+        return await app.inject({
+            method: 'GET',
+            url: `/api/v1/projects/${projectId}/snapshots`,
+            cookies: { sid: token }
+        })
+    }
+    describe('Create project snapshot', function () {
+        it('Non-owner cannot create project snapshot', async function () {
+            // Bob (non-owner) cannot create in ATeam
+            const response = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.bob)
+            response.statusCode.should.equal(403)
+        })
+
+        it('Non-member cannot create project snapshot', async function () {
+            // Chris (non-member) cannot create in ATeam
+            const response = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.chris)
+            // 404 as a non member should not know the resource exists
+            response.statusCode.should.equal(404)
+        })
+
+        it('Create a project snapshot - empty state', async function () {
+            const response = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.alice)
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id')
+            result.should.have.property('name', 'test-project-snapshot-01')
+            result.should.have.property('createdAt')
+            result.should.have.property('updatedAt')
+            result.should.have.property('user')
+            result.user.should.have.property('id', TestObjects.alice.hashid)
+
+            const snapshotObj = await app.db.models.ProjectSnapshot.byId(result.id)
+            const snapshot = snapshotObj.toJSON()
+            snapshot.flows.should.have.property('flows')
+            snapshot.flows.flows.should.have.lengthOf(0)
+            snapshot.flows.should.not.have.property('credentials')
+            snapshot.settings.should.have.property('settings')
+            snapshot.settings.should.have.property('env')
+            snapshot.settings.should.have.property('modules')
+        })
+
+        it('Create a project snapshot - capture real state', async function () {
+            await addFlowsToProject(TestObjects.project1.id,
+                TestObjects.tokens.project,
+                [{ id: 'node1' }],
+                { testCreds: 'abc' },
+                'key1',
+                {
+                    httpAdminRoot: '/test-red',
+                    env: [
+                        { name: 'one', value: 'a' },
+                        { name: 'two', value: 'b' }
+                    ]
+                }
+            )
+            const response = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.alice)
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id')
+            result.should.have.property('name', 'test-project-snapshot-01')
+            result.should.have.property('createdAt')
+            result.should.have.property('updatedAt')
+            result.should.have.property('user')
+            result.user.should.have.property('id', TestObjects.alice.hashid)
+
+            const snapshotObj = await app.db.models.ProjectSnapshot.byId(result.id)
+            const snapshot = snapshotObj.toJSON()
+            snapshot.flows.should.have.property('flows')
+            snapshot.flows.flows.should.have.lengthOf(1)
+            snapshot.flows.flows[0].should.have.property('id', 'node1')
+            snapshot.flows.should.have.property('credentials')
+            snapshot.flows.credentials.should.have.property('$')
+            snapshot.settings.should.have.property('settings')
+            snapshot.settings.settings.should.have.property('httpAdminRoot', '/test-red')
+            snapshot.settings.should.have.property('env')
+            snapshot.settings.env.should.have.property('one', 'a')
+            snapshot.settings.env.should.have.property('two', 'b')
+            snapshot.settings.should.have.property('modules')
+        })
+    })
+
+    describe('Get snapshot information', function () {
+        it('Non-member cannot get project snapshot', async function () {
+            // Chris (non-member) cannot create in ATeam
+
+            // First alice creates one
+            const snapshotResponse = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.alice)
+            const result = snapshotResponse.json()
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/projects/${TestObjects.project1.id}/snapshots/${result.id}`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            // 404 as a non member should not know the resource exists
+            response.statusCode.should.equal(404)
+        })
+        it('Get snapshot', async function () {
+            // First alice creates one
+            const snapshotResponse = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.alice)
+            const snapshotResult = snapshotResponse.json()
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/projects/${TestObjects.project1.id}/snapshots/${snapshotResult.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            const result = response.json()
+            result.should.have.property('id', snapshotResult.id)
+        })
+    })
+
+    describe('Delete a snapshot', function () {
+        it('Non-owner cannot delete a project snapshot', async function () {
+            // Bob (non-owner) cannot delete in ATeam
+
+            // First alice creates one
+            const snapshotResponse = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.alice)
+            const result = snapshotResponse.json()
+
+            // Then bob tries to delete it
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/projects/${TestObjects.project1.id}/snapshots/${result.id}`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(403)
+        })
+        it('Team owner can delete a project snapshot', async function () {
+            // Alice (owner) can delete in ATeam
+
+            // First alice creates one
+            const snapshotResponse = await createSnapshot(TestObjects.project1.id, 'test-project-snapshot-01', TestObjects.tokens.alice)
+            const result = snapshotResponse.json()
+
+            // Then alice tries to delete it
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/projects/${TestObjects.project1.id}/snapshots/${result.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+
+            const snapshotList = (await listProjectSnapshots(TestObjects.project1.id, TestObjects.tokens.alice)).json()
+            snapshotList.should.have.property('snapshots')
+            snapshotList.snapshots.should.have.lengthOf(0)
+        })
+    })
+})


### PR DESCRIPTION
This implements the platform side of ProjectSnapshots as defined in [Epic #587](https://github.com/flowforge/flowforge/issues/587#issuecomment-1129775673)

 - database model
 - HTTP API

It does *not* add anything to the UI at this stage.

### Remaining work:

 - Add policy around snapshot retention. Currently no limits are applied, or pruning of old snapshots.


