### PR TITLE
docs: Link to change stack docs

### DIFF
--- a/docs/install/docker/stacks.md
+++ b/docs/install/docker/stacks.md
@@ -54,5 +54,5 @@ docker build node-red-container -t flowforge/node-red-dashboard:2.2.2
 You would then enter `flowforge/node-red-dashboard:2.2.2` in the `container` section
 of the Stack configuration.
 
-*Note:* with the 0.3 release, it is not possible to change the Stack being used
-by a project. That will come in a future release.
+Stacks can be changed on a per project basis, see also the
+[user stack documentation](../../user/changestack.md).


### PR DESCRIPTION
Outdated copy stated stacks can't be changed. This is no longer true, so
link to the docs that tell users how to change them.