### PR TITLE
Improve docs for first time developer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ npm run build
 npm start
 ```
 
-If you're actively developing for the FlowForge core, then use `npm run serve` to run the application
+If you are actively developing the FlowForge core, then use `npm run serve` to run the application
 with automatic rebuilds of the front-end, and restarts of the application when
 it is modified.
 
-If you intend on developing for the additional repositories, please refer to [the docs](https://github.com/flowforge/flowforge/tree/dev-docs#readme) 
+If you intend on developing the additional repositories, please refer to [the docs](https://flowforge.com/docs/contribute/) 
 for detailed developer setup instructions.
 
 
@@ -41,7 +41,7 @@ for detailed developer setup instructions.
 ├── bin
 ├── config               - build config files
 ├── docs
-├── etc                  - FlowForge platofrom configuration files
+├── etc                  - FlowForge platform configuration files
 ├── forge
 │   ├── config
 │   ├── containers

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm run build
 npm start
 ```
 
-If you're actively developing for the flowforge core, then use `npm run serve` to run the application
+If you're actively developing for the FlowForge core, then use `npm run serve` to run the application
 with automatic rebuilds of the front-end, and restarts of the application when
 it is modified.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ with automatic rebuilds of the front-end, and restarts of the application when
 it is modified.
 
 If you intend on developing for the additional repositories, please refer to [the docs](https://github.com/flowforge/flowforge/tree/dev-docs#readme) 
-for detailed developer setup instructions
+for detailed developer setup instructions.
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ npm install
 # Build the front end
 npm run build
 
-
 # Start the application
 npm start
 ```
 
-If you're actively developing, then use `npm run serve` to run the application
+If you're actively developing for the flowforge core, then use `npm run serve` to run the application
 with automatic rebuilds of the front-end, and restarts of the application when
 it is modified.
+
+If you intend on developing for the additional repositories, please refer to [the docs](https://github.com/flowforge/flowforge/tree/dev-docs#readme) 
+for detailed developer setup instructions
 
 
 

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -54,7 +54,7 @@ want to begin.
 
 ### Instructions
 1. [Clone the repository](#clone-the-flowforgeflowforge-repository)
-1. [Install dependencies](#)
+1. [Install dependencies](#install-flowforgeflowforge-dependencies)
 1. [Running FlowForge](#running-flowforge)
 1. [Create a Stack](#create-a-stack)
 1. [Configuring FlowForge](#configuring-flowforge)
@@ -227,8 +227,8 @@ There are 2 other "Run and Debug" entries in the menu...
 * "Debug Current Test" - this will enable you to step debug a test (starts debugging the currently open test file)
 
 #### 
- ```javascript
- {
+```javascript
+{
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
@@ -273,4 +273,4 @@ There are 2 other "Run and Debug" entries in the menu...
         }
     ]
 }
- ```
+```

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -64,7 +64,7 @@ want to begin.
 
 ### Clone the `flowforge/flowforge` repository
 
-```console
+```
 git clone https://github.com/flowforge/flowforge
 ```
 
@@ -77,7 +77,7 @@ There are 2 options here...
 
 > **NOTE:**  
 > If running on MacOS 12.3 or newer you may get an error around `node-gyp` 
-> being unable to build sqllite3. This is because MacOS no longer includes
+> being unable to build sqlite3. This is because MacOS no longer includes
 > python2.7. The solution is to run the command `npm config set python python3`
 > to alias to python3 and then run `npm install` again
 
@@ -87,9 +87,9 @@ There are 2 options here...
 
 
 After cloning the core repository, you will need to install 
-`flowforge/flowforge` dependancies
+`flowforge/flowforge` dependencies
 
-```console
+```
 cd flowforge
 npm install
 ```
@@ -101,12 +101,12 @@ components.
 #### OPTION 2 Source Code
 
 After cloning the core repository, you will need to install 
-`flowforge/flowforge` dependancies
+`flowforge/flowforge` dependencies
 
 Instead of using NPM, you can instead run from the latest source code.
 You can check out all the required projects in the same directory
 
-```console
+```
 cd flowforge
 git clone https://github.com/flowforge/flowforge-driver-localfs.git
 git clone https://github.com/flowforge/flowforge-nr-launcher.git
@@ -118,10 +118,10 @@ npm run dev:local
 npm run build
 ```
 
-This will install all the dependancies from source code, create all the required symlinks to the relevent projects and install the necessary npm dependancies.
+This will install all the dependencies from source code, create all the required symlinks to the relevant projects and install the necessary npm dependencies.
 
 > **Note**
-> The `npm run dev:local` script will modifiy `package.json` in the 
+> The `npm run dev:local` script will modify `package.json` in the 
 `flowforge`, `flowforge-nr-launcher` and `flowforge-driver-localfs` projects. 
 > DO NOT check modifications into git.
 
@@ -130,7 +130,7 @@ You will need to setup the version(s) of Node-RED you want to use in your stacks
 
 From the flowforge directory run
 
-```console
+```
 npm run install-stack --vers=2.2.2
 ```
 Where `2.2.2` is the version of Node-RED you want to use in the stack
@@ -139,7 +139,7 @@ Where `2.2.2` is the version of Node-RED you want to use in the stack
 
 A number of `npm` tasks are defined in the `package.json` file. To get started from the flowforge directory use:
 
-```console
+```
 npm run serve
 ```
 
@@ -213,7 +213,7 @@ tests using `nyc` to generate code coverage information.
  - `npm run cover:system` - runs the system tests with code coverage enabled. It
   does *not* generate the report.
  - `npm run cover:report` - generates a report of the code coverage. This is 
-  printed to the console and generates a browseable HTML copy under `coverage/index.html`
+  printed to the console and generates a browsable HTML copy under `coverage/index.html`
 
 ### VSCode Tips
 

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -42,7 +42,7 @@ want to begin.
 
 ### FlowForge Code Structure
 
-```console
+```
 /
 ├── config   - developer tools configuration files  
 ├── docs     - documentation

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -104,16 +104,18 @@ After cloning the core repository, you will need to install
 `flowforge/flowforge` dependencies
 
 Instead of using NPM, you can instead run from the latest source code.
-You can check out all the required projects in the same directory
+You can check out all the required projects in the same directory along 
+side the newly cloned `flowforge` directory. The following commands will
+setup everything for you...
 
 ```
-cd flowforge
 git clone https://github.com/flowforge/flowforge-driver-localfs.git
 git clone https://github.com/flowforge/flowforge-nr-launcher.git
 git clone https://github.com/flowforge/flowforge-nr-storage.git
 git clone https://github.com/flowforge/flowforge-nr-auth.git
 git clone https://github.com/flowforge/flowforge-nr-audit-logger.git
 git clone https://github.com/flowforge/forge-ui-components.git
+cd flowforge
 npm run dev:local
 npm run build
 ```
@@ -123,12 +125,12 @@ This will install all the dependencies from source code, create all the required
 > **Note**
 > The `npm run dev:local` script will modify `package.json` in the 
 `flowforge`, `flowforge-nr-launcher` and `flowforge-driver-localfs` projects. 
-> DO NOT check modifications into git.
+> DO NOT check these modifications into git.
 
 ### Create a Stack
 You will need to setup the version(s) of Node-RED you want to use in your stacks.
 
-From the flowforge directory run
+From the `flowforge` directory run
 
 ```
 npm run install-stack --vers=2.2.2

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -14,6 +14,7 @@ This guide assumes you have a working development environment including:
    - Linux: `apt-get install build-essential`
    - MacOS: `xcode-select --install`
    - Windows: installed as part of the official node.js installer
+     - ☑️ Automatically install the necessary tools must be checked
  - Git
 
 ### Project Repositories
@@ -41,7 +42,7 @@ want to begin.
 
 ### FlowForge Code Structure
 
-```
+```console
 /
 ├── config   - developer tools configuration files  
 ├── docs     - documentation
@@ -51,66 +52,85 @@ want to begin.
 └── test     - test material
 ```
 
-### Installing code dependencies
+### Instructions
+1. [Clone the repository](#clone-the-flowforgeflowforge-repository)
+1. [Install dependencies](#)
+1. [Running FlowForge](#running-flowforge)
+1. [Create a Stack](#create-a-stack)
+1. [Configuring FlowForge](#configuring-flowforge)
+1. [Mocking email](#mocking-email)
+1. [Testing](#testing)
+1. [VSCode Tips](#vscode-tips)
 
+### Clone the `flowforge/flowforge` repository
 
-After cloning the core repository, you will need to install the dependencies by running
+```console
+git clone https://github.com/flowforge/flowforge
 ```
+
+### Install `flowforge/flowforge` dependencies
+
+Once the core project is cloned, you will need to install its depenedancies.
+There are 2 options here...
+* [OPTION 1](#option-1-npm) - Install `flowforge/flowforge` dependencies from NPM
+* [OPTION 2](#option-2-source-code) - Install `flowforge/flowforge` dependencies from GitHub
+
+> **NOTE:**  
+> If running on MacOS 12.3 or newer you may get an error around `node-gyp` 
+> being unable to build sqllite3. This is because MacOS no longer includes
+> python2.7. The solution is to run the command `npm config set python python3`
+> to alias to python3 and then run `npm install` again
+
+
+
+#### OPTION 1 NPM
+
+
+After cloning the core repository, you will need to install 
+`flowforge/flowforge` dependancies
+
+```console
+cd flowforge
 npm install
 ```
 
-**Note** If running on MacOS 12.3 or newer you may get an error around node-gyp being unable to build sqllite3.
-This is because MacOS no longer includes python2.7.
-The solution is to run the command `npm config set python python3` to alias to python3 and then run `npm install` again
+By default this will install the latest released versions of the FlowForge
+components. 
 
-By default this will install the latest released versions of the FlowForge components. If
-you want to run from the latest source code then you can check out all the required 
-projects in the same directory
 
-- flowforge/flowforge
-- flowforge/forge-ui-components
-- flowforge/flowforge-driver-localfs
-- flowforge/flowforge-nr-launcher
-- flowforge/flowforge-nr-storage
-- flowforge/flowforge-nr-auth
-- flowforge/flowforge-nr-audit-logger
+#### OPTION 2 Source Code
 
-Then in the flowforge directory run
-```
+After cloning the core repository, you will need to install 
+`flowforge/flowforge` dependancies
+
+Instead of using NPM, you can instead run from the latest source code.
+You can check out all the required projects in the same directory
+
+```console
+cd flowforge
+git clone https://github.com/flowforge/flowforge-driver-localfs.git
+git clone https://github.com/flowforge/flowforge-nr-launcher.git
+git clone https://github.com/flowforge/flowforge-nr-storage.git
+git clone https://github.com/flowforge/flowforge-nr-auth.git
+git clone https://github.com/flowforge/flowforge-nr-audit-logger.git
+git clone https://github.com/flowforge/forge-ui-components.git
 npm run dev:local
-```
-This will create all the required symlinks to the relevent projects.
-
-Next in the `forge-ui-components`  directory run
-```
-npm install
 npm run build
 ```
 
-In the `flowforge-nr-auth` directory run
-```
-npm install
-```
+This will install all the dependancies from source code, create all the required symlinks to the relevent projects and install the necessary npm dependancies.
 
-In the `flowforge-nr-audit-logger` directory run
-```
-npm install
-```
-
-In the `flowforge-nr-storage` directory run
-```
-npm install
-```
-
-**Note**: do not check in the modified `package.json` that will be created in the 
-`flowforge`, `flowforge-nr-launcher` or `flowforge-driver-localfs` projects.
+> **Note**
+> The `npm run dev:local` script will modifiy `package.json` in the 
+`flowforge`, `flowforge-nr-launcher` and `flowforge-driver-localfs` projects. 
+> DO NOT check modifications into git.
 
 ### Create a Stack
 You will need to setup the version(s) of Node-RED you want to use in your stacks.
 
 From the flowforge directory run
 
-```
+```console
 npm run install-stack --vers=2.2.2
 ```
 Where `2.2.2` is the version of Node-RED you want to use in the stack
@@ -119,7 +139,7 @@ Where `2.2.2` is the version of Node-RED you want to use in the stack
 
 A number of `npm` tasks are defined in the `package.json` file. To get started from the flowforge directory use:
 
-```
+```console
 npm run serve
 ```
 
@@ -194,3 +214,63 @@ tests using `nyc` to generate code coverage information.
   does *not* generate the report.
  - `npm run cover:report` - generates a report of the code coverage. This is 
   printed to the console and generates a browseable HTML copy under `coverage/index.html`
+
+### VSCode Tips
+
+To step debug in VSCode
+1. Open `launch.json` config and enter the JavaScript below
+2. Choose `Start-Watch` from the "Run and Debug" menu
+3. Press ▶️ or <kbd>F5</kbd> to start debugging
+
+There are 2 other "Run and Debug" entries in the menu...
+* "Attach by Process ID" - this will allow you to attach to a launched driver
+* "Debug Current Test" - this will enable you to step debug a test (starts debugging the currently open test file)
+
+#### 
+ ```javascript
+ {
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "npm run start-watch",
+            "name": "Start-Watch",
+            "request": "launch",
+            "type": "node-terminal",
+            "env": {
+                "NODE_ENV": "development"
+            }
+        },
+        {
+            "name": "Attach by Process ID",
+            "processId": "${command:PickProcess}",
+            "request": "attach",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Current Test",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+              "--no-warnings",
+              "-u",
+              "bdd",// set to bdd, not tdd
+              "--timeout",
+              "999999",
+              "--colors",
+              "${file}"
+            ],
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ]
+}
+ ```

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -70,7 +70,7 @@ git clone https://github.com/flowforge/flowforge
 
 ### Install `flowforge/flowforge` dependencies
 
-Once the core project is cloned, you will need to install its depenedancies.
+Once the core project is cloned, you will need to install its dependencies.
 There are 2 options here...
 * [OPTION 1](#option-1-npm) - Install `flowforge/flowforge` dependencies from NPM
 * [OPTION 2](#option-2-source-code) - Install `flowforge/flowforge` dependencies from GitHub

--- a/docs/contribute/adding-template-settings.md
+++ b/docs/contribute/adding-template-settings.md
@@ -1,6 +1,6 @@
 # Adding Template Settings
 
-Withing FlowForge, each Project is created from a Template. The Template defines
+Within FlowForge, each Project is created from a Template. The Template defines
 a set of preconfigured options for the Project. This includes runtime settings - 
 values that you would normally expect to set in your Node-RED settings.js file.
 
@@ -90,5 +90,3 @@ In the `flowforge-nr-launcher` repo...
 1. Edit `lib/runtimeSettings.js` to include the new setting in the generate settings.js
    file. Note that you must handle the case where the new setting is not present - 
    either by applying a sensible default, or omitting the value.
-
-

--- a/docs/contribute/architecture.md
+++ b/docs/contribute/architecture.md
@@ -11,7 +11,7 @@ These can be deployed in one of 2 ways
 
    ![LocalFS Architecture](./images/ff-localfs.png)
 
- - Using a Container Orchestation platform (Kubernetes/Docker Compose)
+ - Using a Container Orchestration platform (Kubernetes/Docker Compose)
 
    ![Container Architecture](./images/ff-containers.png)
 
@@ -41,15 +41,15 @@ This driver runs Projects in separate containers and each instance is accessed b
 
 State is stored in a provided PostgreSQL database.
 
-Project containers are segragrated into their own namespace (currently hardcoded to `flowforge`)
+Project containers are segregated into their own namespace (currently hardcoded to `flowforge`)
 
 The driver uses the [@kubernetes/client-node](https://www.npmjs.com/package/@kubernetes/client-node) to interact with the cluster.
 
-The driver will create the required Service and Ingres Kubernetes resources to expose each instance via what ever Ingress Controller the underlying Kubernetes cluster provideds.
+The driver will create the required Service and Ingres Kubernetes resources to expose each instance via what ever Ingress Controller the underlying Kubernetes cluster provides.
 
 #### Docker-Compose
 
-This driver runs Projects in seperate containers and each instance is accessed by a dedicated hostname via a HTTP Ingres proxy.
+This driver runs Projects in separate containers and each instance is accessed by a dedicated hostname via a HTTP Ingres proxy.
 
 State is stored in a provided PostgreSQL database.
 

--- a/docs/contribute/architecture.md
+++ b/docs/contribute/architecture.md
@@ -72,7 +72,7 @@ This is a small application that handles downloading the Project specific settin
 
 The launcher presents a HTTP API (it defaults to the Node-RED port + 1000) that allows the FlowForge Management Application to start/stop/restart the Node-RED instance as well as query it's current state and retrieve the console logs.
 
-The launcher projet can be found [here](https://github.com/flowforge/flowforge-nr-launcher)
+The launcher project can be found [here](https://github.com/flowforge/flowforge-nr-launcher)
 
 ### Node-RED Instance
 

--- a/docs/contribute/workflows/invite-external-user.md
+++ b/docs/contribute/workflows/invite-external-user.md
@@ -10,17 +10,17 @@ sequenceDiagram
     participant Runtime
     participant DB
     Note over TeamOwner: TeamOwner wants to invite an external user to a team
-    TeamOwner->>UI: Opens Add Team Mambers dialog
+    TeamOwner->>UI: Opens Add Team Members dialog
     TeamOwner->>UI: Enters User email, clicks okay
     UI->>+Runtime: POST /api/v1/teams/:teamId/invitations
-    Runtime->>DB: Create Invitiation
+    Runtime->>DB: Create Invitation
     Runtime->>UserEmail: Send email containing link to /account/create?email={email}`
     Runtime->>DB: Update audit log
     Runtime-->>-UI: { status: 'okay' }
     Note over TeamOwner: TeamOwner role complete
     UserEmail-->>InvitedUser: Email received
     InvitedUser->>+UI: Opens /account/create?email={email}
-    UI->>UI: Prefills email field of signup page
+    UI->>UI: Prefills email field of sign-up page
     InvitedUser->>UI: Enters details on sign-up page
     InvitedUser->>UI: Clicks Sign-up
     UI->>+Runtime: POST /account/register

--- a/docs/contribute/workflows/project-states.md
+++ b/docs/contribute/workflows/project-states.md
@@ -5,7 +5,7 @@ direction TB
 ConStarting: Container Starting
 ConRunning: Container Running
 ConStopped: Container Stopped
-ConRemoved: Contianer Removed
+ConRemoved: Container Removed
 ProjStateSus: project.state = suspended
 NRStopped: Node-RED Stopped
 NRStarted: Node-RED Started

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -60,7 +60,7 @@ See [here](./email_providers.md) for example configuration with common email pro
 By default, the platform will send anonymous usage information back to us at FlowForge Inc.
 This can be disabled via the Admin Settings in the UI, or turned off in the configuration file.
 
-Additionally, you can configure your own instance of FlowForge to report back to you on how users are using FlowForge. FlowForge is designed to work with [Plausible](https://plausible.io/). You can setup your own account, and pass the releavnt domain to the `yml` in the telemetry configuration
+Additionally, you can configure your own instance of FlowForge to report back to you on how users are using FlowForge. FlowForge is designed to work with [Plausible](https://plausible.io/). You can setup your own account, and pass the relevant domain to the `yml` in the telemetry configuration
 
 For more information about this feature, see [here](/docs/admin/telemetry.md)
 

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -2,7 +2,7 @@
 
 This version of the FlowForge platform is intended for running in the Docker Container management system. Typically suited for small/medium on premise deployments.
 
-### Prerequistes
+### Prerequisites
 
 #### Docker Compose
 
@@ -49,7 +49,7 @@ This container holds the FlowForge App and the Docker Driver
 
 ##### flowforge/node-red
 
-This is a basic Node-RED image with the FlowForge Lanucher and the required Node-RED plugins to talk to the FlowForge Platform.
+This is a basic Node-RED image with the FlowForge Launcher and the required Node-RED plugins to talk to the FlowForge Platform.
 
 This is the container you can customise for your deployment.
 

--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -3,7 +3,7 @@
 This version of the FlowForge platform is intended for running on a single machine
 for a smaller deployment (e.g. evaluation or home user).
 
-### Prerequistes
+### Prerequisites
 
 #### Operating System
 
@@ -13,7 +13,7 @@ The install script has been tested against the following operating systems:
  - Debian Buster/Bullseye
  - Fedora 35
  - Ubuntu 20.04
- - CentOS 8/RHEL 8/Amzon Linux 2
+ - CentOS 8/RHEL 8/Amazon Linux 2
  - MacOS Big Sur
  - Windows 10
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -3,4 +3,4 @@
  - [FlowForge Concepts](concepts.md) - Understand the core concepts of the FlowForge platform
  - [Environment Variables](envvar.md) - How to manage Environment Variables in your projects
  - [Change Project Stack](changestack.md) - How to change a projects stack, for example to upgrade Node-RED
- - [Logs](logs.md) - The Logs avaible in the FlowForge application.
+ - [Logs](logs.md) - The Logs available in the FlowForge application.

--- a/docs/user/changestack.md
+++ b/docs/user/changestack.md
@@ -11,7 +11,7 @@ Before changing a stack you should ensure that you have a backup of your data fr
 
 - From the project page  select the `Settings` tab then  the `Danger` section.
 - Click the `Change Project Stack` Button
-- When prompted select your new stack from the availble list 
+- When prompted select your new stack from the available list 
 - Click `Change Stack`
 
 Your project will now restart on the new stack

--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -38,7 +38,7 @@ comes to create a new project, they chose from the available stacks.
 
 A Project Template describes properties of Node-RED itself. It is how many of the
 settings a user familiar with Node-RED would be used to modifying in their settings
-file. But it can also be used to customise the palette of nodes that are preinstalled,
+file. But it can also be used to customise the palette of nodes that are pre-installed,
 provide a set of default flows and change the look and feel of the editor.
 
 A template can also specify [Environment Variables](envvar) which can then have their values as editable for each project or locked.

--- a/docs/user/envvar.md
+++ b/docs/user/envvar.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-Environment Variables allow you to manage variables used in your Node-RED flows from the FlowForge application, you can read more on how to access enironment variables inside Node-RED [in the Node-RED Docs](https://nodered.org/docs/user-guide/environment-variables)
+Environment Variables allow you to manage variables used in your Node-RED flows from the FlowForge application, you can read more on how to access environment variables inside Node-RED [in the Node-RED Docs](https://nodered.org/docs/user-guide/environment-variables)
 
 An Environment Variable consists of a name and a value.
 


### PR DESCRIPTION
Improve docs for first time developer setup...
* adds a TOC with links to sections for simple stepwise "how to"
* tested on windows by following the steps to the letter
* adds VSCode tips for step debugging
* adds link from front page README to the main contribute documentation