### PR TITLE
docs: Start admin user management documentation

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,6 +1,5 @@
 # Administering FlowForge
 
-
 ## Getting started
 
  - [Understanding the FlowForge Architecture](../contribute/architecture.md)
@@ -9,6 +8,7 @@
  - [First Run Setup](../install/first-run.md) - create your admin user
  - [FlowForge Concepts](../user/concepts.md)
  - [Usage Telemetry](/docs/admin/telemetry.md)
+ - [User management](/docs/admin/user_management.md)
 
 ## Administering FlowForge
 

--- a/docs/admin/user_management.md
+++ b/docs/admin/user_management.md
@@ -1,0 +1,23 @@
+# User management
+
+## User registration
+
+Depending on where FlowForge is installed, users should or should not be allowed 
+to sign up to the service. User registration can be configured in the admin panel.
+Go to "Admin Settings" > "Settings" and select or deselect "Allow new users to register on the login screen".
+
+## Creating new users
+
+To add new users to the platform go to "Admin Settings" > "Users" and click the
+"New User" button. Fill out the form, and provide the new user with their password.
+
+To require users to change their password the next time they log in, use the "Expire Password" option
+on the "Edit User" dialog.
+
+## Deleting a user
+
+Users can only be removed if they don't own any teams and projects. As such the
+user should delete any projects and ensure their teams have alternative owners. They
+can either do this themselves or an Admin user can do it for them.
+
+Once all teams and projects are removed, the user can be removed using the option in the "Edit User" dialog.


### PR DESCRIPTION
There's some internal knowledge that floated in Slack captures around
how to manage users that is should be documented outside of Slack for
the wider community. This change kicks off that process with how admin
can create and delete users.