### PR TITLE
Ensure deviceLive endpoints are accessed by valid Device Token

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -12,14 +12,13 @@ const crypto = require('crypto')
  * @memberof forge.routes.api
  */
 module.exports = async function (app) {
-    // app.addHook('preHandler', (request, reply, done) => {
-    //     // check accessToken is device scope
-    //     if (request.session.ownerType !== 'device') {
-    //         reply.code(401).send({ error: 'unauthorised' })
-    //     } else {
-    //         done()
-    //     }
-    // })
+    app.addHook('preHandler', (request, reply, done) => {
+        if (request.session.ownerType !== 'device' || request.session.ownerId !== ('' + request.device.id)) {
+            reply.code(401).send({ error: 'unauthorised' })
+        } else {
+            done()
+        }
+    })
 
     /**
      * Devices post to /state at regular intervals. This acts as a heartbeat.


### PR DESCRIPTION
This ensures the token used to access the live endpoints is a device token for the right device.

Note: `request.session.ownerId` is a String as it could be a project id (uuid) or a device id (int). To safely compare to `request.device.id` (which is a number), this coerces it to a String.