### PR TITLE
Add exportCredentials function on Project controller to handle re-encryption

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -1,4 +1,3 @@
-const crypto = require('crypto')
 /**
  * Device Live api routes
  *
@@ -65,7 +64,7 @@ module.exports = async function (app) {
                     // to the Device secret
                     const projectSecret = await (await snapshot.getProject()).getCredentialSecret()
                     const deviceSecret = request.device.credentialSecret
-                    result.credentials = recryptCreds(result.credentials, projectSecret, deviceSecret)
+                    result.credentials = app.db.controllers.Project.exportCredentials(result.credentials, projectSecret, deviceSecret)
                 }
                 reply.send(result)
             } else {
@@ -73,26 +72,4 @@ module.exports = async function (app) {
             }
         }
     })
-}
-
-// TODO: These are getting copied around way too much. Need to be centralised.
-function recryptCreds (original, oldKey, newKey) {
-    const newHash = crypto.createHash('sha256').update(newKey).digest()
-    const oldHash = crypto.createHash('sha256').update(oldKey).digest()
-    return encryptCreds(newHash, decryptCreds(oldHash, original))
-}
-
-function decryptCreds (key, cipher) {
-    let flows = cipher.$
-    const initVector = Buffer.from(flows.substring(0, 32), 'hex')
-    flows = flows.substring(32)
-    const decipher = crypto.createDecipheriv('aes-256-ctr', key, initVector)
-    const decrypted = decipher.update(flows, 'base64', 'utf8') + decipher.final('utf8')
-    return JSON.parse(decrypted)
-}
-
-function encryptCreds (key, plain) {
-    const initVector = crypto.randomBytes(16)
-    const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
-    return { $: initVector.toString('hex') + cipher.update(JSON.stringify(plain), 'utf8', 'base64') + cipher.final('base64') }
 }


### PR DESCRIPTION
This PR adds `app.db.controllers.Project.exportCredentials` that can be used to re-encrypt a credentials object.

This removes the duplicate code in this area.

There are no tests to add as this functionality is already covered by existing tests - this is an internal refactoring.