### PR TITLE
Add description to snapshots and improve UX

### DIFF
--- a/forge/db/controllers/ProjectSnapshot.js
+++ b/forge/db/controllers/ProjectSnapshot.js
@@ -8,6 +8,7 @@ module.exports = {
         const projectExport = await app.db.controllers.Project.exportProject(project)
         const snapshot = await app.db.models.ProjectSnapshot.create({
             name: options.name || '',
+            description: options.description || '',
             settings: {
                 settings: projectExport.settings || {},
                 env: projectExport.env || {},

--- a/forge/db/migrations/20220526-01-add-description-to-snapshots.js
+++ b/forge/db/migrations/20220526-01-add-description-to-snapshots.js
@@ -1,0 +1,16 @@
+/**
+ * Add description ProjectSnapshots table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.addColumn('ProjectSnapshots', 'description', {
+            type: DataTypes.TEXT,
+            default: '',
+            allowNull: true
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -8,6 +8,7 @@ module.exports = {
     name: 'ProjectSnapshot',
     schema: {
         name: { type: DataTypes.STRING, allowNull: false },
+        description: { type: DataTypes.TEXT, allowNull: true, default: '' },
         settings: {
             type: DataTypes.TEXT,
             set (value) {
@@ -64,7 +65,7 @@ module.exports = {
                         where,
                         order: [['id', 'DESC']],
                         limit,
-                        attributes: ['hashid', 'id', 'name', 'createdAt', 'updatedAt'],
+                        attributes: ['hashid', 'id', 'name', 'description', 'createdAt', 'updatedAt'],
                         include: {
                             model: M.User,
                             attributes: ['hashid', 'id', 'username', 'avatar']

--- a/forge/db/views/ProjectSnapshot.js
+++ b/forge/db/views/ProjectSnapshot.js
@@ -5,6 +5,7 @@ module.exports = {
             const filtered = {
                 id: result.hashid,
                 name: result.name,
+                description: result.description || '',
                 createdAt: result.createdAt,
                 updatedAt: result.updatedAt
             }

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -66,7 +66,8 @@ module.exports = async function (app) {
             request.project,
             request.session.User,
             {
-                name: request.body.name || ''
+                name: request.body.name || '',
+                description: request.body.description || ''
             }
         )
         snapShot.User = request.session.User

--- a/frontend/src/components/tables/cells/UserCell.vue
+++ b/frontend/src/components/tables/cells/UserCell.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="flex align-center">
-        <div class="flex flex-col justify-center"><img class="rounded-md mr-3 w-6 inline" :src="avatar"/></div>
+    <div class="flex items-center">
+        <div class="flex flex-col justify-center"><img class="rounded-md mr-2 w-6 inline" :src="avatar"/></div>
         <div class="inline-flex flex-col">
-            <div>{{ name }}</div>
-            <div class="text-xs text-gray-500">{{username}}</div>
+            <div v-if="name">{{ name }}</div>
+            <div v-if="username" class="text-xs text-gray-500">{{username}}</div>
         </div>
     </div>
 </template>

--- a/frontend/src/pages/project/Snapshots/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/project/Snapshots/dialogs/SnapshotCreateDialog.vue
@@ -3,11 +3,14 @@
         <template v-slot:default>
             <form class="space-y-6 mt-2">
                 <FormRow v-model="input.name" :error="errors.name">Name</FormRow>
+                <FormRow>Description
+                    <template #input><textarea v-model="input.description" rows="8" class="ff-input ff-text-input" style="height: auto"></textarea></template>
+                </FormRow>
             </form>
         </template>
         <template v-slot:actions>
             <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button class="ml-4" @click="confirm()">
+            <ff-button class="ml-4" :disabled="!formValid" @click="confirm()">
                 <span>Create</span>
             </ff-button>
         </template>
@@ -31,23 +34,27 @@ export default {
     emits: ['snapshotCreated'],
     data () {
         return {
+            submitted: false,
             input: {
-                name: ''
+                name: '',
+                description: ''
             },
             errors: {}
         }
     },
     computed: {
         formValid () {
-            return (this.input.name)
+            return !this.submitted && !!(this.input.name)
         }
     },
     mounted () {
     },
     methods: {
         confirm () {
+            this.submitted = true
             const opts = {
-                name: this.input.name
+                name: this.input.name,
+                description: this.input.description
             }
             snapshotApi.create(this.project.id, opts).then((response) => {
                 this.isOpen = false
@@ -71,6 +78,8 @@ export default {
             },
             show () {
                 this.input.name = ''
+                this.input.description = ''
+                this.submitted = false
                 this.errors = {}
                 isOpen.value = true
             }

--- a/frontend/src/pages/project/routes.js
+++ b/frontend/src/pages/project/routes.js
@@ -43,6 +43,7 @@ export default [
                 ]
             },
             {
+                name: 'ProjectDevices',
                 path: 'devices',
                 component: ProjectDevices,
                 meta: {


### PR DESCRIPTION
This PR adds a 'description' field to the snapshot model - allowing the user to provide more than just a single line ('name').

It also tidies up the Snapshot and Device tables to improve the presentation and UX.

Snapshot table:

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/51083/170522569-53328fe1-0a48-464a-813b-51e3addb0138.png">

 - Rather than lots of columns, I've reduced it down to a more compact style.
 - Emphasises the snapshot title, whilst keeping the id available for reference
 - If the snapshot has a description it can be expanded to read:
    <img width="200" alt="image" src="https://user-images.githubusercontent.com/51083/170522851-44c7a06c-88f2-4d1d-a2af-eff272bb2e12.png">
 - The active snapshot for devices is more clearly indicated
 - Shows the user who created the snapshot


Device table:

<img width="874" alt="image" src="https://user-images.githubusercontent.com/51083/170523064-b90c865a-ab1d-45d2-a1ee-525a3ded1e49.png">

 - Follows a similar style to the snapshot table
 - Rather than list the current and target snapshot, just shows the current snapshot and highlights if it needs updating.
