### PR TITLE
Standardise on SectionTopMenu for project header element

### DIFF
--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -13,21 +13,27 @@
         </SideNavigation>
     </Teleport>
     <main>
-        <div class="flex flex-col sm:flex-row mb-2">
-            <div class="flex-grow space-x-6 items-center inline-flex">
-                <router-link :to="navigation[0]?navigation[0].path:''" class="inline-flex items-center">
-                    <div class="text-gray-800 text-xl font-bold">{{ project.name }}</div>
-                </router-link>
-                <ProjectStatusBadge :status="project.meta.state" :pendingStateChange="project.pendingStateChange" v-if="project.meta" />
-            </div>
-            <div class="text-right space-x-4">
-                <a v-if="editorAvailable" :href="project.url" target="_blank" class="forge-button-secondary">
-                    Editor <ExternalLinkIcon class="w-5 ml-1 py-1" />
-                </a>
-                <DropdownMenu buttonClass="forge-button" alt="Open actions menu" :options="options">Actions</DropdownMenu>
-            </div>
-        </div>
-        <hr />
+        <SectionTopMenu>
+            <template #hero>
+                <div class="flex-grow space-x-6 items-center inline-flex">
+                    <router-link :to="navigation[0]?navigation[0].path:''" class="inline-flex items-center">
+                        <div class="text-gray-800 text-xl font-bold">{{project.name}}</div>
+                    </router-link>
+                    <ProjectStatusBadge :status="project.meta.state" :pendingStateChange="project.pendingStateChange" v-if="project.meta" />
+                </div>
+            </template>
+            <template v-slot:tools>
+                <div class="space-x-2 flex">
+                    <a v-if="editorAvailable" :href="project.url" target="_blank" class="ff-btn ff-btn--secondary">
+                        Open Editor
+                        <span class="ff-btn--icon ff-btn--icon-right">
+                            <ExternalLinkIcon />
+                        </span>
+                    </a>
+                    <DropdownMenu buttonClass="ff-btn ff-btn--primary" alt="Open actions menu" :options="options">Actions</DropdownMenu>
+                </div>
+            </template>
+        </SectionTopMenu>
         <div class="text-sm sm:px-6 mt-4 sm:mt-8">
             <router-view :project="project" @projectUpdated="updateProject"></router-view>
         </div>
@@ -42,6 +48,7 @@ import SideNavigation from '@/components/SideNavigation'
 import SideTeamSelection from '@/components/SideTeamSelection'
 import DropdownMenu from '@/components/DropdownMenu'
 import ProjectStatusBadge from './components/ProjectStatusBadge'
+import SectionTopMenu from '@/components/SectionTopMenu'
 
 import { mapState } from 'vuex'
 import { Roles } from '@core/lib/roles'
@@ -171,7 +178,8 @@ export default {
         ExternalLinkIcon,
         DropdownMenu,
         ProjectStatusBadge,
-        'ff-team-selection': SideTeamSelection
+        'ff-team-selection': SideTeamSelection,
+        SectionTopMenu
     }
 }
 </script>

--- a/frontend/src/pages/team/Overview.vue
+++ b/frontend/src/pages/team/Overview.vue
@@ -1,12 +1,11 @@
 <template>
     <div class="block md:flex">
-        <div v-if="!showingMessage" class="flex-grow p-2">
-            <FormHeading>
-                <router-link to="./projects">Projects</router-link>
+        <div v-if="!showingMessage" class="flex-grow">
+            <SectionTopMenu hero="Projects">
                 <template v-if="createProjectEnabled" v-slot:tools>
                     <ff-button kind="primary" size="small" to="./projects/create"><template v-slot:icon-left><PlusSmIcon /></template>Create Project</ff-button>
                 </template>
-            </FormHeading>
+            </SectionTopMenu>
             <template v-if="projectCount > 0">
                 <ProjectSummaryList :projects="projects" :team="team" />
             </template>
@@ -16,16 +15,14 @@
                 </div>
             </template>
         </div>
-        <div v-else class="flex-grow p-2">
+        <div v-else class="flex-grow">
             <p>
                 Thank you for signing up to FlowForge. You are now able to create projects and use the platform.
             </p>
             <ff-button kind="primary" size="small" to="./projects/create"><template v-slot:icon-left><PlusSmIcon /></template>Create Project</ff-button>
         </div>
-        <div class="md:w-48 p-2 md:ml-8">
-            <FormHeading>
-                <router-link to="./members">Members</router-link>
-            </FormHeading>
+        <div class="md:w-48 md:ml-8 mt-8 md:mt-0">
+            <SectionTopMenu hero="Members" />
             <MemberSummaryList :users="users" />
         </div>
     </div>
@@ -37,7 +34,7 @@ import { Roles } from '@core/lib/roles'
 
 import teamApi from '@/api/team'
 
-import FormHeading from '@/components/FormHeading'
+import SectionTopMenu from '@/components/SectionTopMenu'
 import MemberSummaryList from './components/MemberSummaryList'
 import ProjectSummaryList from './components/ProjectSummaryList'
 import { PlusSmIcon } from '@heroicons/vue/outline'
@@ -91,7 +88,7 @@ export default {
         }
     },
     components: {
-        FormHeading,
+        SectionTopMenu,
         MemberSummaryList,
         ProjectSummaryList,
         PlusSmIcon


### PR DESCRIPTION
Updates this Project pages to use the same `SectionTopMenu` element as the Team pages do and the proper button classes.

### Before

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/51083/170578224-58da823f-74e1-41c3-812d-34a07eef472c.png">


### After

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/51083/170578082-b9fc1239-680b-483c-a94f-f0209e5c23eb.png">
