### PR TITLE
Add forgeURL to downloaded credentials file

### DIFF
--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -17,7 +17,8 @@ module.exports = async function (app) {
                 'team:create': app.settings.get('team:create'),
                 email: app.postoffice.enabled(),
                 stacks: app.containers.properties().stack || {},
-                features: app.config.features.getAllFeatures()
+                features: app.config.features.getAllFeatures(),
+                base_url: app.config.base_url
             }
 
             if (request.session.User.admin) {

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -41,6 +41,7 @@
 
 import { ref } from 'vue'
 import deviceApi from '@/api/devices'
+import settings from '@/api/settings'
 
 import FormRow from '@/components/FormRow'
 import { DocumentDownloadIcon } from '@heroicons/vue/outline'
@@ -55,6 +56,9 @@ export default {
         return {
             device: null
         }
+    },
+    async mounted () {
+        this.base_url = (await settings.getSettings()).base_url
     },
     methods: {
         downloadCredentials () {
@@ -84,6 +88,7 @@ export default {
                 return `deviceId: ${this.device.id}
 token: ${this.device.credentials.token}
 credentialSecret: ${this.device.credentials.credentialSecret}
+forgeURL: ${this.base_url}
 `
             } else {
                 return ''

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -40,8 +40,8 @@
 // import devicesApi from '@/api/devices'
 
 import { ref } from 'vue'
+import { mapState } from 'vuex'
 import deviceApi from '@/api/devices'
-import settings from '@/api/settings'
 
 import FormRow from '@/components/FormRow'
 import { DocumentDownloadIcon } from '@heroicons/vue/outline'
@@ -56,9 +56,6 @@ export default {
         return {
             device: null
         }
-    },
-    async mounted () {
-        this.base_url = (await settings.getSettings()).base_url
     },
     methods: {
         downloadCredentials () {
@@ -80,15 +77,18 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['settings']),
         hasCredentials: function () {
             return this.device && this.device.credentials
         },
         credentials: function () {
             if (this.device) {
+                console.log(this)
+                console.log(this.settings)
                 return `deviceId: ${this.device.id}
 token: ${this.device.credentials.token}
 credentialSecret: ${this.device.credentials.credentialSecret}
-forgeURL: ${this.base_url}
+forgeURL: ${this.settings.base_url}
 `
             } else {
                 return ''

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -83,8 +83,6 @@ export default {
         },
         credentials: function () {
             if (this.device) {
-                console.log(this)
-                console.log(this.settings)
                 return `deviceId: ${this.device.id}
 token: ${this.device.credentials.token}
 credentialSecret: ${this.device.credentials.credentialSecret}


### PR DESCRIPTION
This includes the `app.config.base_url` in the response to `/api/v1/settings` GET

And then includes it in the generated device credentials file.

Should we show it with details in the dialog as well?