### PR TITLE
Add device state in dashboard with periodic refresh

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -2,6 +2,9 @@ const { literal } = require('sequelize')
 
 module.exports = {
     updateState: async function (app, device, state) {
+        if (state.state) {
+            device.set('state', state.state)
+        }
         device.set('lastSeenAt', literal('CURRENT_TIMESTAMP'))
         if (!state.snapshot) {
             if (device.currentSnapshot !== null) {

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -12,7 +12,7 @@ module.exports = {
                 activeSnapshot: app.db.views.ProjectSnapshot.snapshot(device.activeSnapshot),
                 targetSnapshot: app.db.views.ProjectSnapshot.snapshot(device.targetSnapshot),
                 links: result.links,
-                status: 'offline'
+                status: result.state || 'offline'
             }
             if (device.Team) {
                 filtered.team = app.db.views.Team.teamSummary(device.Team)
@@ -39,7 +39,7 @@ module.exports = {
                 activeSnapshot: app.db.views.ProjectSnapshot.snapshot(device.activeSnapshot),
                 targetSnapshot: app.db.views.ProjectSnapshot.snapshot(device.targetSnapshot),
                 links: result.links,
-                status: 'offline'
+                status: result.state || 'offline'
             }
             if (device.Team) {
                 filtered.team = app.db.views.Team.teamSummary(device.Team)

--- a/frontend/src/api/devices.js
+++ b/frontend/src/api/devices.js
@@ -1,9 +1,13 @@
 import client from './client'
 import paginateUrl from '@/utils/paginateUrl'
+import daysSince from '@/utils/daysSince'
 
 const getDevices = async (cursor, limit) => {
     const url = paginateUrl('/api/v1/devices', cursor, limit)
     return client.get(url).then(res => {
+        res.data.devices.forEach(device => {
+            device.lastSeenSince = device.lastSeenAt ? daysSince(device.lastSeenAt) : ''
+        })
         return res.data
     })
 }

--- a/frontend/src/api/project.js
+++ b/frontend/src/api/project.js
@@ -83,6 +83,9 @@ const changeStack = async (projectId, stackId) => {
 const getProjectDevices = async (projectId, cursor, limit) => {
     const url = paginateUrl(`/api/v1/projects/${projectId}/devices`, cursor, limit)
     const res = await client.get(url)
+    res.data.devices.forEach(device => {
+        device.lastSeenSince = device.lastSeenAt ? daysSince(device.lastSeenAt) : ''
+    })
     return res.data
 }
 

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -110,6 +110,9 @@ const updateTeam = async (teamId, options) => {
 const getTeamDevices = async (teamId, cursor, limit) => {
     const url = paginateUrl(`/api/v1/teams/${teamId}/devices`, cursor, limit)
     const res = await client.get(url)
+    res.data.devices.forEach(device => {
+        device.lastSeenSince = device.lastSeenAt ? daysSince(device.lastSeenAt) : ''
+    })
     return res.data
 }
 


### PR DESCRIPTION
This plumbs through the 'state' property of devices to be shown in the dashboard.

The dashboard also refreshes the list every 10 seconds to avoid showing stale information. This isn't the most ideal way of doing it (rather than a websocket connection for live updates.... but that's another story).
