### PR TITLE
Add devices/projectSnapshots/stacks/templates counts to telemetry ping

### DIFF
--- a/forge/monitor/metrics/004-platform.js
+++ b/forge/monitor/metrics/004-platform.js
@@ -3,6 +3,10 @@ module.exports = async (app) => {
         'platform.counts.users': await app.db.models.User.count(),
         'platform.counts.teams': await app.db.models.Team.count(),
         'platform.counts.projects': await app.db.models.Project.count(),
+        'platform.counts.devices': await app.db.models.Device.count(),
+        'platform.counts.projectSnapshots': await app.db.models.ProjectSnapshot.count(),
+        'platform.counts.projectTemplates': await app.db.models.ProjectStack.count(),
+        'platform.counts.projectStacks': await app.db.models.ProjectTemplate.count(),
         'platform.config.driver': app.config.driver.type
     }
 }


### PR DESCRIPTION
Adds the following properties to the Telemetry ping payload:

 - `platform.counts.devices`
 - `platform.counts.projectSnapshots`
 - `platform.counts.projectTemplates`
 - `platform.counts.projectStacks`

Issue raised on the ping collector to accept this properties: https://github.com/flowforge/usage-ping-collector/issues/10 