### PR TITLE
Add project version info to Project overview

### DIFF
--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -6,16 +6,30 @@
 
                 <table class="table-fixed w-full">
                     <tr class="border-b">
-                        <td class="w-1/4">Editor</td>
+                        <td class="w-1/4 font-medium">Editor</td>
                         <td>
-                            <a v-if="editorAvailable" :href="project.url" target="_blank" class="forge-button-inline py-2 -mx-3"><span class="ml-r">{{project.url}}</span><ExternalLinkIcon class="w-4 ml-3" /></a>
+                            <a v-if="editorAvailable" :href="project.url" target="_blank" class="forge-button-secondary py-1 mb-1"><span class="ml-r">{{project.url}}</span><ExternalLinkIcon class="w-4 ml-3" /></a>
                             <div v-else class="my-2">Unavailable</div>
                         </td>
                     </tr>
                     <tr class="border-b">
-                        <td class="">Status</td>
+                        <td class="font-medium">Status</td>
                         <td><div class="py-2"><ProjectStatusBadge :status="project.meta.state" :pendingStateChange="project.pendingStateChange" /></div></td>
                     </tr>
+                    <template v-if="project.meta.versions">
+                        <tr class="border-b">
+                            <td class="font-medium">Node-RED Version</td>
+                            <td><div class="py-2">{{project.meta.versions['node-red']}}</div></td>
+                        </tr>
+                        <tr class="border-b">
+                            <td class="font-medium">Launcher Version</td>
+                            <td><div class="py-2">{{project.meta.versions.launcher}}</div></td>
+                        </tr>
+                        <tr class="border-b">
+                            <td class="font-medium">Node.js Version</td>
+                            <td><div class="py-2">{{project.meta.versions.node}}</div></td>
+                        </tr>
+                    </template>
                 </table>
             </div>
             <div class="border rounded p-4">


### PR DESCRIPTION
Part of #576 

This adds version information to the Project overview page - if the launcher provides the information.

<img width="569" alt="image" src="https://user-images.githubusercontent.com/51083/171032702-41415a60-70a5-4e3f-ad02-0f6be8d00be6.png">

The next task for #576 is to include a notification if the Launcher version is down-level and a restart is needed - we'll add that inline to this version table (in absence of a wider notification system yet)