### PR TITLE
Map FlowForge logout to nodered auth/revoke

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -182,7 +182,7 @@ module.exports = {
         }
     },
     revokeUserToken: async (project, token) => { // logout:nodered(step-2)
-        if (this._driver.logoutNodeRED) {
+        if (this._driver.revokeUserToken) {
             await this._driver.revokeUserToken(project, token) // logout:nodered(step-3)
         }
     },

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -183,7 +183,7 @@ module.exports = {
     },
     revokeUserToken: async (project, token) => { // logout:nodered(step-2)
         if (this._driver.logoutNodeRED) {
-            await this._driver.logoutNodeRED(project, token) // logout:nodered(step-3)
+            await this._driver.revokeUserToken(project, token) // logout:nodered(step-3)
         }
     },
     logs: async (project) => {

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -181,7 +181,7 @@ module.exports = {
             this._driver.restartFlows(project, options)
         }
     },
-    logoutNodeRED: async (project, token) => { // logout:nodered(step-2)
+    revokeUserToken: async (project, token) => { // logout:nodered(step-2)
         if (this._driver.logoutNodeRED) {
             await this._driver.logoutNodeRED(project, token) // logout:nodered(step-3)
         }

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -181,6 +181,11 @@ module.exports = {
             this._driver.restartFlows(project, options)
         }
     },
+    logoutNodeRED: async (project, token) => { // logout:nodered(step-2)
+        if (this._driver.logoutNodeRED) {
+            await this._driver.logoutNodeRED(project, token) // logout:nodered(step-3)
+        }
+    },
     logs: async (project) => {
         let value = []
         if (this._driver.logs) {

--- a/forge/db/models/StorageSession.js
+++ b/forge/db/models/StorageSession.js
@@ -35,7 +35,7 @@ module.exports = {
                         const sessions = Object.values(session) || []
                         const usersSessions = sessions.filter(e => e.user === username && e.client === 'node-red-editor')
                         return { ProjectId: m.ProjectId, sessions: usersSessions }
-                    }).filter(m => m.sessions.length > 0)
+                    }).filter(m => m.sessions.length > 0 && M.ProjectId)
                 }
             }
         }

--- a/forge/db/models/StorageSession.js
+++ b/forge/db/models/StorageSession.js
@@ -20,6 +20,15 @@ module.exports = {
                         where: { ProjectId: project },
                         attributes: ['id', 'sessions']
                     })
+                },
+                byUsername: async (username) => {
+                    const allStorageSessions = await this.findAll({ attributes: ['sessions', 'ProjectId'] })
+                    return allStorageSessions.map(m => {
+                        const session = m.sessions ? JSON.parse(m.sessions) : {}
+                        const sessions = Object.values(session) || []
+                        const usersSessions = sessions.filter(e => e.user === username && e.client === 'node-red-editor')
+                        return { ProjectId: m.ProjectId, sessions: usersSessions }
+                    }).filter(m => m.sessions.length > 0)
                 }
             }
         }

--- a/forge/db/models/StorageSession.js
+++ b/forge/db/models/StorageSession.js
@@ -2,7 +2,7 @@
  * A Project's Session
  * @namespace forge.db.models.StorageSession
  */
-const { DataTypes } = require('sequelize')
+const { DataTypes, Op } = require('sequelize')
 
 module.exports = {
     name: 'StorageSession',
@@ -22,7 +22,14 @@ module.exports = {
                     })
                 },
                 byUsername: async (username) => {
-                    const allStorageSessions = await this.findAll({ attributes: ['sessions', 'ProjectId'] })
+                    const allStorageSessions = await this.findAll({
+                        where: {
+                            sessions: {
+                                [Op.like]: '%"' + username + '"%'
+                            }
+                        },
+                        attributes: ['sessions', 'ProjectId']
+                    })
                     return allStorageSessions.map(m => {
                         const session = m.sessions ? JSON.parse(m.sessions) : {}
                         const sessions = Object.values(session) || []

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -212,7 +212,7 @@ module.exports = fp(async function (app, opts, done) {
                         const project = await app.db.models.Project.byId(ProjectId)
                         for (let index = 0; index < session.sessions.length; index++) {
                             const token = session.sessions[index].accessToken
-                            await app.containers.logoutNodeRED(project, token) // logout:nodered(step-2)
+                            await app.containers.revokeUserToken(project, token) // logout:nodered(step-2)
                         }
                     }
                 }

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -196,6 +196,29 @@ module.exports = fp(async function (app, opts, done) {
      */
     app.post('/account/logout', { logLevel: 'warn' }, async (request, reply) => {
         if (request.sid) {
+            try {
+                // logout:nodered(step-1)
+                const thisSession = await app.db.models.Session.findOne({
+                    where: { sid: request.sid },
+                    include: app.db.models.User
+                })
+                const userId = thisSession?.UserId
+                if (userId != null) {
+                    const user = await app.db.models.User.byId(userId)
+                    const sessions = await app.db.models.StorageSession.byUsername(user.username)
+                    for (let index = 0; index < sessions.length; index++) {
+                        const session = sessions[index]
+                        const ProjectId = session.ProjectId
+                        const project = await app.db.models.Project.byId(ProjectId)
+                        for (let index = 0; index < session.sessions.length; index++) {
+                            const token = session.sessions[index].accessToken
+                            await app.containers.logoutNodeRED(project, token) // logout:nodered(step-2)
+                        }
+                    }
+                }
+            } catch (error) {
+                app.log.warn(`Failed to revoke nodered token(s): ${error.toString()}`) // log error but continue to delete session
+            }
             await app.db.controllers.Session.deleteSession(request.sid)
         }
         reply.clearCookie('sid')

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -217,7 +217,7 @@ module.exports = fp(async function (app, opts, done) {
                     }
                 }
             } catch (error) {
-                app.log.warn(`Failed to revoke nodered token(s): ${error.toString()}`) // log error but continue to delete session
+                app.log.warn(`Failed to revoke Node-RED token(s): ${error.toString()}`) // log error but continue to delete session
             }
             await app.db.controllers.Session.deleteSession(request.sid)
         }


### PR DESCRIPTION
fixes #442 

## NOTE
NOTE: this PR is to be reviewed and merged as 1 of 3 parts. 

1. https://github.com/flowforge/flowforge/pull/643
1. https://github.com/flowforge/flowforge-driver-localfs/pull/48
1. https://github.com/flowforge/flowforge-nr-launcher/pull/40

Also related...
1. https://github.com/flowforge/flowforge-driver-docker/pull/24
1. https://github.com/flowforge/flowforge-driver-k8s/pull/39

## Changes
* Adds code to endpoint `/account/logout` in forge/routes/auth/index.js (STEP 1) which does the following...
  * Gets the `username` from `app.db.models.User.byId(userId)`
  * Gets the storage sessions from `app.db.models.StorageSession.byUsername(user.username)`
  * Iterates each session and calls `app.containers.logoutNodeRED(project, token)` (STEP 2)
* Adds `logoutNodeRED()` to forge/containers/wrapper.js  (STEP 2)
  * This then calls to the driver `this._driver.logoutNodeRED(project, token)` (STEP 3)
* Refer to [localfs driver #48](https://github.com/flowforge/flowforge-driver-localfs/pull/48) for step 3 in this process
* Refer to [launcher #40](https://github.com/flowforge/flowforge-nr-launcher/pull/40) for steps 4 & 5 in this process

