### PR TITLE
Fix device live endpoint to handle null snapshot

### DIFF
--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -31,7 +31,7 @@ module.exports = async function (app) {
      */
     app.post('/state', async (request, reply) => {
         await app.db.controllers.Device.updateState(request.device, request.body)
-        if (request.body.snapshot !== request.device.targetSnapshot?.hashid) {
+        if (request.body.snapshot !== (request.device.targetSnapshot?.hashid || null)) {
             reply.code(409).send({
                 error: 'incorrect-snapshot',
                 snapshot: request.device.targetSnapshot?.hashid || null

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -79,7 +79,6 @@ module.exports = fp(async function (app, opts, done) {
                 await verifyToken(request, reply)
             } else if (!request.context.config.allowAnonymous) {
                 reply.code(401).send({ error: 'unauthorized' })
-                throw new Error()
             }
         } catch (err) {
             reply.code(401).send({ error: 'unauthorized' })

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -72,13 +72,17 @@ module.exports = fp(async function (app, opts, done) {
 
     app.decorate('verifyTokenOrSession', async function (request, reply) {
         // Order is important, other way round breaks nr-auth plugin
-        if (request.sid) {
-            await verifySession(request, reply)
-        } else if (request.headers && request.headers.authorization) {
-            await verifyToken(request, reply)
-        } else if (!request.context.config.allowAnonymous) {
+        try {
+            if (request.sid) {
+                await verifySession(request, reply)
+            } else if (request.headers && request.headers.authorization) {
+                await verifyToken(request, reply)
+            } else if (!request.context.config.allowAnonymous) {
+                reply.code(401).send({ error: 'unauthorized' })
+                throw new Error()
+            }
+        } catch (err) {
             reply.code(401).send({ error: 'unauthorized' })
-            throw new Error()
         }
     })
 


### PR DESCRIPTION
If a device has no active snapshot locally, it reports `null`. This was being compared against `undefined` - and failing, making it think it had an update to do.

This PR fixes it so we compare `null` with `null` in that case - so we properly recognise it's in the right state.

Also fixes the token handling to report `401` for invalid tokens, rather than a generic 500.