### PR TITLE
Fix frontend team api test

### DIFF
--- a/test/unit/frontend/api/team.spec.js
+++ b/test/unit/frontend/api/team.spec.js
@@ -5,7 +5,8 @@ import { expect, vi } from 'vitest'
 */
 const mockGet = vi.fn().mockImplementation().mockReturnValue(Promise.resolve({
     data: {
-        teams: []
+        teams: [],
+        devices: []
     }
 }))
 const mockPost = vi.fn().mockImplementation().mockReturnValue(Promise.resolve({ data: {} }))


### PR DESCRIPTION
The `TeamAPI.getTeamDevices` function expects the response to have a `devices` property.

This PR modifies the default mocked GET response to include that property. It isn't so clean as the mocked response is now an amalgamation of different api responses.

It would be better to have mocked responses providing more real looking data - but this will do for now.