### PR TITLE
Fix loading logic on stack create dialog

### DIFF
--- a/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
+++ b/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
@@ -19,7 +19,7 @@
         </template>
         <template v-slot:actions>
             <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="primary" @click="confirm()" :disabled="!formValid || !loading">{{ (stack ? 'Save' : 'Create') }}</ff-button>
+            <ff-button kind="primary" @click="confirm()" :disabled="!formValid || loading">{{ (stack ? 'Save' : 'Create') }}</ff-button>
         </template>
     </ff-dialog>
 </template>


### PR DESCRIPTION
Following https://github.com/flowforge/flowforge/pull/650/files#r888389193, the Stack Create dialog 'create' button is permanently disabled.

This fixes the logic.