### PR TITLE
Better handle billing errors whilst deleting projects

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -132,9 +132,6 @@ module.exports = {
      * @returns {Promise} Resolves when the project has been stopped
      */
     remove: async (project) => {
-        if (this._driver.remove) {
-            await this._driver.remove(project)
-        }
         if (project.state !== 'suspended') {
             // Only updated billing if the project isn't already suspended
             if (this._app.license.active() && this._app.billing) {
@@ -150,6 +147,9 @@ module.exports = {
                     throw new Error('No Subscription for this team')
                 }
             }
+        }
+        if (this._driver.remove) {
+            await this._driver.remove(project)
         }
     },
     details: async (project) => {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -326,9 +326,7 @@ module.exports = async function (app) {
             )
             reply.send({ status: 'okay' })
         } catch (err) {
-            console.log('missing', err)
-            console.log(err)
-            reply.code(500).send({})
+            reply.code(500).send({ error: err.toString() })
         }
     })
 

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -12,84 +12,100 @@ module.exports = async function (app) {
     app.addHook('preHandler', app.needsPermission('project:change-status'))
 
     app.post('/start', async (request, reply) => {
-        if (request.project.state === 'suspended') {
-            // Restart the container
-            request.project.state = 'running'
-            await request.project.save()
-            app.db.controllers.Project.setInflightState(request.project, 'starting')
-            const startResult = await app.containers.start(request.project)
-            startResult.started.then(async () => {
+        try {
+            if (request.project.state === 'suspended') {
+                // Restart the container
+                request.project.state = 'running'
+                await request.project.save()
+                app.db.controllers.Project.setInflightState(request.project, 'starting')
+                const startResult = await app.containers.start(request.project)
+                startResult.started.then(async () => {
+                    await app.db.controllers.AuditLog.projectLog(
+                        request.project.id,
+                        request.session.User.id,
+                        'project.started'
+                    )
+                    app.db.controllers.Project.clearInflightState(request.project)
+                })
+            } else {
+                app.db.controllers.Project.setInflightState(request.project, 'starting')
+                request.project.state = 'running'
+                await request.project.save()
+                await app.containers.startFlows(request.project)
                 await app.db.controllers.AuditLog.projectLog(
                     request.project.id,
                     request.session.User.id,
                     'project.started'
                 )
                 app.db.controllers.Project.clearInflightState(request.project)
-            })
-        } else {
-            app.db.controllers.Project.setInflightState(request.project, 'starting')
-            request.project.state = 'running'
-            await request.project.save()
-            await app.containers.startFlows(request.project)
-            await app.db.controllers.AuditLog.projectLog(
-                request.project.id,
-                request.session.User.id,
-                'project.started'
-            )
-            app.db.controllers.Project.clearInflightState(request.project)
+            }
+            reply.send()
+        } catch (err) {
+            reply.code(500).send({ error: err.toString() })
         }
-        reply.send()
     })
 
     app.post('/stop', async (request, reply) => {
-        if (request.project.state === 'suspended') {
-            reply.code(400).send({ error: 'Project suspended' })
-            return
+        try {
+            if (request.project.state === 'suspended') {
+                reply.code(400).send({ error: 'Project suspended' })
+                return
+            }
+            app.db.controllers.Project.setInflightState(request.project, 'stopping')
+            request.project.state = 'stopped'
+            await request.project.save()
+            const result = await app.containers.stopFlows(request.project)
+            await app.db.controllers.AuditLog.projectLog(
+                request.project.id,
+                request.session.User.id,
+                'project.stopped'
+            )
+            app.db.controllers.Project.clearInflightState(request.project)
+            reply.send(result)
+        } catch (err) {
+            reply.code(500).send({ error: err.toString() })
         }
-        app.db.controllers.Project.setInflightState(request.project, 'stopping')
-        request.project.state = 'stopped'
-        await request.project.save()
-        const result = await app.containers.stopFlows(request.project)
-        await app.db.controllers.AuditLog.projectLog(
-            request.project.id,
-            request.session.User.id,
-            'project.stopped'
-        )
-        app.db.controllers.Project.clearInflightState(request.project)
-        reply.send(result)
     })
 
     app.post('/restart', async (request, reply) => {
-        if (request.project.state === 'suspended') {
-            reply.code(400).send({ error: 'Project suspended' })
-            return
+        try {
+            if (request.project.state === 'suspended') {
+                reply.code(400).send({ error: 'Project suspended' })
+                return
+            }
+            app.db.controllers.Project.setInflightState(request.project, 'restarting')
+            request.project.state = 'running'
+            await request.project.save()
+            const result = await app.containers.restartFlows(request.project)
+            await app.db.controllers.AuditLog.projectLog(
+                request.project.id,
+                request.session.User.id,
+                'project.restarted'
+            )
+            app.db.controllers.Project.clearInflightState(request.project)
+            reply.send(result)
+        } catch (err) {
+            reply.code(500).send({ error: err.toString() })
         }
-        app.db.controllers.Project.setInflightState(request.project, 'restarting')
-        request.project.state = 'running'
-        await request.project.save()
-        const result = await app.containers.restartFlows(request.project)
-        await app.db.controllers.AuditLog.projectLog(
-            request.project.id,
-            request.session.User.id,
-            'project.restarted'
-        )
-        app.db.controllers.Project.clearInflightState(request.project)
-        reply.send(result)
     })
 
     app.post('/suspend', async (request, reply) => {
-        if (request.project.state === 'suspended') {
-            reply.code(400).send({ error: 'Project suspended' })
-            return
+        try {
+            if (request.project.state === 'suspended') {
+                reply.code(400).send({ error: 'Project suspended' })
+                return
+            }
+            app.db.controllers.Project.setInflightState(request.project, 'suspending')
+            await app.containers.stop(request.project)
+            app.db.controllers.Project.clearInflightState(request.project)
+            await app.db.controllers.AuditLog.projectLog(
+                request.project.id,
+                request.session.User.id,
+                'project.suspended'
+            )
+            reply.send()
+        } catch (err) {
+            reply.code(500).send({ error: err.toString() })
         }
-        app.db.controllers.Project.setInflightState(request.project, 'suspending')
-        await app.containers.stop(request.project)
-        app.db.controllers.Project.clearInflightState(request.project)
-        await app.db.controllers.AuditLog.projectLog(
-            request.project.id,
-            request.session.User.id,
-            'project.suspended'
-        )
-        reply.send()
     })
 }


### PR DESCRIPTION
Fixes #612 

This PR reorders the sequence we do things when deleting a project.

With this PR, if billing is enabled, our interactions with Stripe are the first thing we do - so if they fail, the whole delete can fail cleanly.

Whilst investigating this issue, I also found that in the unlikely case that a container driver has deleted its internal state for a project, but the overall delete has been cancelled, we didn't protect against errors being thrown when the user tries to interact with the project. This PR adds that error handling.

There will be companion PRs in the localfs, docker and kube drivers to ensure appropriate errors are thrown in those scenarios.