### PR TITLE
Allow a stack-less project have a stack applied

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -338,7 +338,7 @@ module.exports = async function (app) {
     app.put('/:projectId', { preHandler: app.needsPermission('project:edit') }, async (request, reply) => {
         let changed = false
         if (request.body.stack) {
-            if (request.body.stack !== request.project.ProjectStack.id) {
+            if (request.body.stack !== request.project.ProjectStack?.id) {
                 const stack = await app.db.models.ProjectStack.byId(request.body.stack)
                 if (!stack) {
                     reply.code(400).send({ error: 'Invalid stack' })

--- a/frontend/src/pages/project/Settings/Danger.vue
+++ b/frontend/src/pages/project/Settings/Danger.vue
@@ -145,7 +145,7 @@ export default {
             })
         },
         changeStack (selectedStack) {
-            if (this.project.stack.id !== selectedStack) {
+            if (this.project.stack?.id !== selectedStack) {
                 this.loading.changingStack = true
                 projectApi.changeStack(this.project.id, selectedStack).then(() => {
                     this.$router.push({ name: 'Project', params: { id: this.project.id } })

--- a/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
@@ -52,15 +52,15 @@ export default {
             },
             async show (project) {
                 this.project = project
-                this.input.stack = this.project.stack.id
+                this.input.stack = this.project.stack?.id
                 isOpen.value = true
                 const stackList = await stacksApi.getStacks()
                 this.stacks = stackList.stacks
-                    .filter(stack => (stack.active || stack.id === this.project.stack.id))
+                    .filter(stack => (stack.active || stack.id === this.project.stack?.id))
                     .map(stack => {
                         return {
                             value: stack.id,
-                            label: stack.name + (stack.id === this.project.stack.id ? ' (current)' : '')
+                            label: stack.name + (stack.id === this.project.stack?.id ? ' (current)' : '')
                         }
                     })
             }


### PR DESCRIPTION
Fixes #534 

Stack-less projects can only exist if they were created in FlowForge 0.2.0 or earlier. Anything more recent will have a stack.

Whilst there are diminishing returns in fixing this issue, the fix is simple enough to just get done.