### PR TITLE
Fix device queries for postgres

### DIFF
--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -19,7 +19,7 @@ module.exports = async function (app) {
     app.get('/', async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const where = {
-            projectId: request.project.id
+            ProjectId: request.project.id
         }
         const devices = await app.db.models.Device.getAll(paginationOptions, where)
         devices.devices = devices.devices.map(d => app.db.views.Device.deviceSummary(d))

--- a/forge/routes/api/teamDevices.js
+++ b/forge/routes/api/teamDevices.js
@@ -43,7 +43,7 @@ module.exports = async function (app) {
     app.get('/', async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const where = {
-            teamId: request.team.id
+            TeamId: request.team.id
         }
         const devices = await app.db.models.Device.getAll(paginationOptions, where)
         devices.devices = devices.devices.map(d => app.db.views.Device.deviceSummary(d))


### PR DESCRIPTION
Postgres is case-sensitive when it comes to column names - unlike sqlite which accepts anything.

