### PR TITLE
Fix axios network error detection

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -15,7 +15,7 @@ client.interceptors.response.use(function (response) {
         // 401 when !pending && !loginInflight means the session has expired
         store.dispatch('account/logout')
         return Promise.reject(error)
-    } else if (!error.response) {
+    } else if (error.code === 'ERR_NETWORK') {
         // network error
         store.dispatch('account/setOffline', true)
     }


### PR DESCRIPTION
A recent update to axios changed the format of the error they provide when there is a network error. This PR fixes our handling to match.

Some broader observations:

 - axios are pre-1.0 and will happily make breaking changes in semver minor releases. We need to take particular care when updating axios in the future
 - This is a hard issue to have unit tested. The most likely approach would have been to mock the expected response from axios to ensure the frontend did the right thing. That test would not have spotted this change - the test would have kept passing.