### PR TITLE
Override default Device.getAccessToken to pass id as string

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -52,6 +52,11 @@ module.exports = {
                         token: accessToken.token,
                         credentialSecret
                     }
+                },
+                async getAccessToken () {
+                    return M.AccessToken.findOne({
+                        where: { ownerId: '' + this.id }
+                    })
                 }
             },
             static: {


### PR DESCRIPTION
The default Device.getAccessToken() generated by sequelize searches the `AccessToken.ownerId` field for `Device.id`.

`ownerId` is a String but `Device.id` is a number. sqlite doesn't blink at this and Just Works. Postgres doesn't like the type mismatch.

This PR provides our own `Device.getAccessToken()` that casts the integer id to a string to keep everyone happy.