### PR TITLE
Improve Device Credentials dialog ux

### DIFF
--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -17,9 +17,11 @@
                         credentials. Make a note of them as this is the only
                         time you will see them.
                     </p>
+                    <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ this.credentials }}</pre>
+                    <!--
                     <FormRow v-model="device.id" type="uneditable">Device ID</FormRow>
                     <FormRow v-model="device.credentials.token" type="uneditable">Access Token</FormRow>
-                    <FormRow v-model="device.credentials.credentialSecret" type="uneditable">Credential Secret</FormRow>
+                    <FormRow v-model="device.credentials.credentialSecret" type="uneditable">Credential Secret</FormRow> -->
                 </template>
             </form>
         </template>
@@ -29,7 +31,7 @@
                 <ff-button kind="danger" class="ml-4" @click="regenerateCredentials()">Regenerate credentials</ff-button>
             </template>
             <template v-else>
-                <ff-button kind="secondary" @click="downloadCredentials()"><template v-slot:icon-left><DocumentDownloadIcon /></template>Download credentials file</ff-button>
+                <ff-button kind="secondary" @click="downloadCredentials()"><template v-slot:icon-left><DocumentDownloadIcon /></template>Download device-{{ this.device.id }}.yml</ff-button>
                 <ff-button class="ml-4" @click="close()">Done</ff-button>
             </template>
         </template>
@@ -61,7 +63,7 @@ export default {
         downloadCredentials () {
             const element = document.createElement('a')
             element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(this.credentials))
-            element.setAttribute('download', `ff-credentials-${this.device.id}.yml`)
+            element.setAttribute('download', `device-${this.device.id}.yml`)
             element.style.display = 'none'
             document.body.appendChild(element)
             element.click()

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -18,10 +18,6 @@
                         time you will see them.
                     </p>
                     <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ this.credentials }}</pre>
-                    <!--
-                    <FormRow v-model="device.id" type="uneditable">Device ID</FormRow>
-                    <FormRow v-model="device.credentials.token" type="uneditable">Access Token</FormRow>
-                    <FormRow v-model="device.credentials.credentialSecret" type="uneditable">Credential Secret</FormRow> -->
                 </template>
             </form>
         </template>
@@ -45,12 +41,10 @@ import { ref } from 'vue'
 import { mapState } from 'vuex'
 import deviceApi from '@/api/devices'
 
-import FormRow from '@/components/FormRow'
 import { DocumentDownloadIcon } from '@heroicons/vue/outline'
 export default {
     name: 'DeviceCredentialsDialog',
     components: {
-        FormRow,
         DocumentDownloadIcon
     },
     props: ['team'],


### PR DESCRIPTION
Whilst doing a testing run through of the devices feature, the Device Credentials dialog stuck out as needing some improvements.

This is the existing dialog:

<img width="612" alt="device-creds-old" src="https://user-images.githubusercontent.com/51083/172514614-ae6374f6-58dd-49a9-8974-1c05bed64235.png">

Issues:

 - The 'Download credentials file' gave you a file called `ff-credentials-<deviceId>.yml`. The device agent expects a file called `device.yml`
 - The wrapping of the values looks odd
 - It doesn't include the forgeURL property we include in the file download
 - There's not much use providing the values in a way that cannot be easily copy and pasted in the right format for use

This is the new dialog:

<img width="618" alt="device-creds-new" src="https://user-images.githubusercontent.com/51083/172514644-4ecc7d13-c240-4d70-a8d2-5e9dad5ff410.png">

 - The download button has been relabelled and new generates a file called `device-<deviceId>.yml`. I decided it was still useful to include the id so that if a user needs to reset a few devices and download their credential files, they are distinct and identifiable.
 - The values are presented in the yml format they need to be in the config file - so can be easily copied from the page
