### PR TITLE
Handle a device that reports an invalid snapshot id

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -11,8 +11,12 @@ module.exports = {
                 device.set('activeSnapshotId', null)
             }
         } else {
+            // Check the snapshot is one we recognise
             const snapshotId = app.db.models.ProjectSnapshot.decodeHashid(state.snapshot)
-            device.set('activeSnapshotId', snapshotId)
+            // hashid.decode returns an array of values, not the raw value.
+            if (snapshotId.length > 0) {
+                device.set('activeSnapshotId', snapshotId)
+            }
         }
         await device.save()
     }


### PR DESCRIPTION
In the call-home ping from a device, it includes the snapshot id the device is running.

If it provides a value for snapshot (rather than `null`) that does not decode to a valid snapshot id, then we were failing the request with a 500 response and no details.

This PR handles this case better and allows the device to be notified it needs to change its snapshot.