### PR TITLE
Ensure request has teamMembership attached for device api reqs

### DIFF
--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -18,6 +18,7 @@ module.exports = async function (app) {
                         reply.code(404).type('text/html').send('Not Found')
                         return
                     }
+                    request.teamMembership = await request.session.User.getTeamMembership(request.device.Team.id)
                 } catch (err) {
                     reply.code(404).type('text/html').send('Not Found')
                 }

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -267,7 +267,7 @@ describe('Device API', async function () {
                     body: {
                         project: TestObjects.deviceProject.id
                     },
-                    cookies: { sid: TestObjects.tokens.alice }
+                    cookies: { sid: TestObjects.tokens.bob }
                 })
                 const result = response.json()
                 result.should.have.property('project')


### PR DESCRIPTION
Fixes #686 

This also modifies the unit test to ensure this scenario is covered. Previously it was using an admin user to make the request which bypassed the TeamMembership check.