### PR TITLE
Admin version

### DIFF
--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -54,13 +54,12 @@ module.exports = fp(async function (app, opts, next) {
         ffVersion = version
     }
     try {
-        fs.statSync(path.join(__dirname,"..","..",".git"));
-        ffVersion += "-git";
-    } catch(err) {
+        fs.statSync(path.join(__dirname,'..', '..', '.git'))
+        ffVersion += '-git'
+    } catch (err) {
         // No git directory
     }
     app.log.info(`FlowForge v${ffVersion}`)
-
 
     app.log.info(`FlowForge running with NodeJS ${process.version}`)
 

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -54,7 +54,7 @@ module.exports = fp(async function (app, opts, next) {
         ffVersion = version
     }
     try {
-        fs.statSync(path.join(__dirname,'..', '..', '.git'))
+        fs.statSync(path.join(__dirname, '..', '..', '.git'))
         ffVersion += '-git'
     } catch (err) {
         // No git directory

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -48,13 +48,19 @@ module.exports = fp(async function (app, opts, next) {
     if (process.env.npm_package_version) {
         ffVersion = process.env.npm_package_version
         // npm start
-        app.log.info(`FlowForge v${process.env.npm_package_version}`)
     } else {
         // everything else
         const { version } = require(path.join(module.parent.path, '..', 'package.json'))
         ffVersion = version
-        app.log.info(`FlowForge v${version}`)
     }
+    try {
+        fs.statSync(path.join(__dirname,"..","..",".git"));
+        ffVersion += "-git";
+    } catch(err) {
+        // No git directory
+    }
+    app.log.info(`FlowForge v${ffVersion}`)
+
 
     app.log.info(`FlowForge running with NodeJS ${process.version}`)
 

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -30,6 +30,9 @@ module.exports = async function (app) {
                 response['user:reset-password'] = app.settings.get('user:reset-password')
                 response['user:team:auto-create'] = app.settings.get('user:team:auto-create')
                 response.email = app.postoffice.exportSettings(true)
+                response['version:forge'] = app.settings.get('version:forge')
+                response['version:node'] = app.settings.get('version:node')
+
             }
             reply.send(response)
         } else {

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -32,7 +32,6 @@ module.exports = async function (app) {
                 response.email = app.postoffice.exportSettings(true)
                 response['version:forge'] = app.settings.get('version:forge')
                 response['version:node'] = app.settings.get('version:node')
-
             }
             reply.send(response)
         } else {

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -13,24 +13,23 @@ module.exports = fp(async function (app, _opts, next) {
     loadedSettings.forEach(setting => {
         settings[setting.key] = setting.value
     })
-    
+
     // Versions of Node and Forge App
-    settings["version:node"] = process.version
+    settings['version:node'] = process.version
 
     if (process.env.npm_package_version) {
-        settings["version:forge"] = "v"+process.env.npm_package_version
+        settings['version:forge'] = "v" + process.env.npm_package_version
     } else {
         const { version } = require(path.join(module.parent.path, '..', 'package.json'))
-        settings["version:forge"] = "v"+version
+        settings['version:forge'] = 'v' + version
     }
     // if .git
     try {
-        fs.statSync(path.join(__dirname,"..","..",".git"));
-        settings["version:forge"] += "-git";
-    } catch(err) {
+        fs.statSync(path.join(__dirname, '..', '..', '.git'))
+        settings["version:forge"] += "-git"
+    } catch (err) {
         // No git directory
     }
-    
 
     const settingsApi = {
         get: (key) => {

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -18,7 +18,7 @@ module.exports = fp(async function (app, _opts, next) {
     settings['version:node'] = process.version
 
     if (process.env.npm_package_version) {
-        settings['version:forge'] = "v" + process.env.npm_package_version
+        settings['version:forge'] = 'v' + process.env.npm_package_version
     } else {
         const { version } = require(path.join(module.parent.path, '..', 'package.json'))
         settings['version:forge'] = 'v' + version
@@ -26,7 +26,7 @@ module.exports = fp(async function (app, _opts, next) {
     // if .git
     try {
         fs.statSync(path.join(__dirname, '..', '..', '.git'))
-        settings["version:forge"] += "-git"
+        settings['version:forge'] += '-git'
     } catch (err) {
         // No git directory
     }

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -1,5 +1,7 @@
 const { v4: uuidv4 } = require('uuid')
 const fp = require('fastify-plugin')
+const path = require('path')
+const fs = require('fs')
 
 const defaultSettings = require('./defaults')
 
@@ -11,6 +13,24 @@ module.exports = fp(async function (app, _opts, next) {
     loadedSettings.forEach(setting => {
         settings[setting.key] = setting.value
     })
+    
+    // Versions of Node and Forge App
+    settings["version:node"] = process.version
+
+    if (process.env.npm_package_version) {
+        settings["version:forge"] = process.env.npm_package_version
+    } else {
+        const { version } = require(path.join(module.parent.path, '..', 'package.json'))
+        settings["version:forge"] = version
+    }
+    // if .git
+    try {
+        fs.statSync(path.join(__dirname,"..","..",".git"));
+        settings["version:forge"] += "-git";
+    } catch(err) {
+        // No git directory
+    }
+    
 
     const settingsApi = {
         get: (key) => {

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -18,10 +18,10 @@ module.exports = fp(async function (app, _opts, next) {
     settings["version:node"] = process.version
 
     if (process.env.npm_package_version) {
-        settings["version:forge"] = process.env.npm_package_version
+        settings["version:forge"] = "v"+process.env.npm_package_version
     } else {
         const { version } = require(path.join(module.parent.path, '..', 'package.json'))
-        settings["version:forge"] = version
+        settings["version:forge"] = "v"+version
     }
     // if .git
     try {

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -41,7 +41,7 @@
                 <tr><td class="font-medium p-2 pr-4 align-top">Forge Application</td><td class="p-2">{{settings['version:forge']}}</td></tr>
                 <tr><td class="font-medium p-2 pr-4 align-top">NodeJS</td><td class="p-2">{{settings['version:node']}}</td></tr>
             </table>
-            </div>
+        </div>
     </div>
 
 </template>

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -35,6 +35,13 @@
                 </table>
             </div>
         </div>
+        <div class="border rounded p-4 col-span-3">
+            <div class="text-xl mb-1 border-b">Version</div>
+            <table>
+                <tr><td class="font-medium p-2 pr-4 align-top">Forge Application</td><td class="p-2">{{settings['version:forge']}}</td></tr>
+                <tr><td class="font-medium p-2 pr-4 align-top">NodeJS</td><td class="p-2">{{settings['version:node']}}</td></tr>
+            </table>
+            </div>
     </div>
 
 </template>
@@ -42,18 +49,21 @@
 <script>
 import adminApi from '@/api/admin'
 import SectionTopMenu from '@/components/SectionTopMenu'
+import Settings from '@/api/settings'
 
 export default {
     name: 'AdminSettingsGeneral',
     data: function () {
         return {
             license: {},
-            stats: {}
+            stats: {},
+            settings: {}
         }
     },
     async mounted () {
         this.stats = await adminApi.getStats()
         this.license = await adminApi.getLicenseDetails()
+        this.settings = await Settings.getSettings()
     },
     components: {
         SectionTopMenu


### PR DESCRIPTION
closes #655 

Adds a new box to the admin/overview page displaying the version of the Forge app and the Node version
![image](https://user-images.githubusercontent.com/187645/174815262-8c3c4db8-51c7-421d-a08e-2ed9d74bb521.png)

Also added a `-git` label to the version if there is a `.git` folder which is the same pattern as used by Node-RED,
```
[2022-06-21T13:45:17.655Z] INFO: Development mode
[2022-06-21T13:45:17.656Z] INFO: FlowForge v0.6.0-git
[2022-06-21T13:45:17.656Z] INFO: FlowForge running with NodeJS v16.13.0
```
