### PR TITLE
Use require.resolve to find vue in webpack config

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -124,7 +124,7 @@ module.exports = {
     resolve: {
         extensions: ['*', '.js', '.vue', '.json'],
         alias: {
-            vue: path.resolve('./node_modules/vue/dist/vue.esm-bundler.js'),
+            vue: require.resolve('vue/dist/vue.esm-bundler.js'),
             '@core': getPath('forge'),
             '@': getPath('frontend/src')
         }


### PR DESCRIPTION
This removes the assumption that there is a `node_modules` directory relative to the config file. This then allows us to setup this repository in npm workspaces that hoist dependencies to a higher directory level.

I have verified this builds the platform correctly with all expected functionality with the external modules (ui-components etc) - I know we had some issues in this area when they were first introduced.

Would appreciate someone else testing this change just to make sure I've not been tricked into thinking its working due to some local webpack caching stuff... That said, I have tested this on a clean checkout and it works for me.
