### PR TITLE
Stop execes oauth logging

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -30,7 +30,7 @@ const SESSION_COOKIE_OPTIONS = {
 }
 
 module.exports = fp(async function (app, opts, done) {
-    await app.register(require('./oauth'),{ logLevel: 'warn' })
+    await app.register(require('./oauth'), { logLevel: 'warn' })
     await app.register(require('./permissions'))
 
     // WIP:

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -30,7 +30,7 @@ const SESSION_COOKIE_OPTIONS = {
 }
 
 module.exports = fp(async function (app, opts, done) {
-    await app.register(require('./oauth'))
+    await app.register(require('./oauth'),{ logLevel: 'warn' })
     await app.register(require('./permissions'))
 
     // WIP:

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -128,7 +128,7 @@ module.exports = async function (app) {
     app.get('/account/complete/:code', async function (request, reply) {
         const requestId = request.params.code
         const requestObject = requestCache.get(requestId)
-        requestCache.del(requestId)
+        requestCache.delete(requestId)
 
         if (!requestObject) {
             return badRequest(reply, 'invalid_request', 'Invalid request')


### PR DESCRIPTION
fixes #687

Turned logging down to warn level to match all other routes. 

Also fixed a deprecation warning that was printed from the LRU cache.