### PR TITLE
Notify user if a new stack version is available

### DIFF
--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -209,7 +209,8 @@ module.exports = {
                                 attributes: ['hashid', 'id', 'name']
                             },
                             {
-                                model: M.ProjectStack
+                                model: M.ProjectStack,
+                                attributes: ['hashid', 'id', 'name', 'links', 'properties', 'replacedBy', 'ProjectTypeId']
                             },
                             {
                                 model: M.ProjectTemplate,

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -42,6 +42,7 @@ module.exports = {
                 id: proj.ProjectStack.hashid,
                 name: proj.ProjectStack.name,
                 properties: proj.ProjectStack.properties || {},
+                replacedBy: app.db.models.ProjectStack.encodeHashid(proj.ProjectStack.replacedBy) || undefined,
                 links: proj.ProjectStack.links
             }
         }

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -18,7 +18,12 @@
                     </tr>
                     <tr class="border-b">
                         <td class="font-medium">Type</td>
-                        <td><div class="py-2">{{project.projectType?.name || 'none'}} / {{project.stack?.name || 'none'}}</div></td>
+                        <td class="flex items-center">
+                            <div class="py-2 flex-grow">{{project.projectType?.name || 'none'}} / {{project.stack?.name || 'none'}}</div>
+                            <div v-if="project.stack.replacedBy">
+                                <ff-button size="small" to="./settings/danger">Update</ff-button>
+                            </div>
+                        </td>
                     </tr>
                     <template v-if="project.meta.versions">
                         <tr class="border-b">

--- a/frontend/src/pages/project/Settings/Danger.vue
+++ b/frontend/src/pages/project/Settings/Danger.vue
@@ -21,6 +21,16 @@
             </div>
         </template>
         <FormHeading>Change Project Stack</FormHeading>
+        <div v-if="project.stack && project.stack.replacedBy" class="flex flex-col lg:flex-row max-w-2xl space-y-4">
+            <div class="flex-grow">
+                <div class="max-w-sm pt-2">There is a new version of the current stack available.
+                    Updating the stack will restart the project.
+                </div>
+            </div>
+            <div class="min-w-fit flex-shrink-0">
+                <ff-button :disabled="!project.projectType" kind="secondary" @click="upgradeStack()">Update Stack</ff-button>
+            </div>
+        </div>
         <div class="flex flex-col lg:flex-row max-w-2xl space-y-4">
             <div class="flex-grow">
                 <div class="max-w-sm pt-2">Changing the project stack requires the
@@ -29,7 +39,7 @@
                 </div>
             </div>
             <div class="min-w-fit flex-shrink-0">
-                <ff-button :disabled="!project.projectType" kind="secondary" @click="showChangeStackDialog()">Change Project Stack</ff-button>
+                <ff-button :disabled="!project.projectType" kind="secondary" @click="showChangeStackDialog()">Change Stack</ff-button>
                 <ChangeStackDialog @changeStack="changeStack" ref="changeStackDialog"/>
             </div>
         </div>
@@ -135,6 +145,9 @@ export default {
         },
         showExportToProjectDialog () {
             this.$refs.exportToProjectDialog.show(this.project)
+        },
+        upgradeStack () {
+            this.changeStack(this.project.stack.replacedBy)
         },
         exportProject (parts) {
             // call projectApi to generate zipped json

--- a/frontend/src/pages/project/Settings/General.vue
+++ b/frontend/src/pages/project/Settings/General.vue
@@ -14,8 +14,12 @@
 
         <FormRow v-model="input.stackDescription" type="uneditable">
             Stack
+            <template v-slot:append>
+                <div v-if="project.stack && project.stack.replacedBy">
+                    <ff-button size="small" to="./danger">Update</ff-button>
+                </div>
+            </template>
         </FormRow>
-
         <FormRow v-model="input.templateName" type="uneditable">
             Template
         </FormRow>


### PR DESCRIPTION

Closes #576 

Note this PR is against the `project-type` branch (#739). Once that PR has been merged, this can be retargeted to `main`.

With the ability to create new versions of stacks (#694), this PR adds a notification (in the form of a well placed button) that a new stack version is available for a project.

Clicking the button takes them to the Setting/Danger page which will have a new 'Update Stack' option alongside the 'Change Stack' button.

Clicking that button will update the project to the new stack (using the same backend API as the Change Stack flow)

 - On the project home page:

<img width="948" alt="image" src="https://user-images.githubusercontent.com/51083/176548371-747fe856-67dd-46fb-91f6-68727c7305c0.png">

 - On the project settings summary

<img width="936" alt="image" src="https://user-images.githubusercontent.com/51083/176548498-ae94e2c0-4a62-4b1f-86ee-d081d6b2df9e.png">

 - The Settings/Danger page

<img width="941" alt="image" src="https://user-images.githubusercontent.com/51083/176548639-bc324954-5c15-4d85-99b4-f300a595a457.png">
