### PR TITLE
Fix next bill date

### DIFF
--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -99,6 +99,7 @@ export default {
         this.loading = true
         try {
             const billingSubscription = await billingApi.getSubscriptionInfo(this.team.id)
+            billingSubscription.next_billing_date = billingSubscription.next_billing_date*1000 //API returns Seconds, JS expects miliseconds
             this.subscription = billingSubscription
             this.loading = false
         } catch (err) {

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -99,7 +99,7 @@ export default {
         this.loading = true
         try {
             const billingSubscription = await billingApi.getSubscriptionInfo(this.team.id)
-            billingSubscription.next_billing_date = billingSubscription.next_billing_date*1000 //API returns Seconds, JS expects miliseconds
+            billingSubscription.next_billing_date = billingSubscription.next_billing_date * 1000 // API returns Seconds, JS expects miliseconds
             this.subscription = billingSubscription
             this.loading = false
         } catch (err) {


### PR DESCRIPTION
API (Stripe) returns the Next Billing date in whole seconds since 1st Jan 1970, but when formatDate converts this into a human readable string it expects milliseconds

Fixes #745 