### PR TITLE
Add Project Types, Stack Versioning and Upgrading to docs

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -104,7 +104,7 @@ The Stacks page can be used to manage the Project Stacks on the platform.
 
 It can be used to create and edit the stacks on the platform.
 
-With the 0.7 release, you can create a new version of an existing stack via the
+You can create a new version of an existing stack via the
 drop-down menu in the stack table. This allows the platform to notify users
 that an update is available for their project, allowing them to upgrade the stack
 at their convenience.

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -3,7 +3,7 @@
 ## Getting started
 
  - [Understanding the FlowForge Architecture](../contribute/architecture.md)
- - [Install](../install) - requirements, deployment models, installation methods
+ - [Install/Upgrade](../install) - requirements, deployment models, installation methods and upgrading
  - [`flowforge.yml` configuration](../install/configuration.md) - base platform configuration, done before you run.
  - [First Run Setup](../install/first-run.md) - create your admin user
  - [FlowForge Concepts](../user/concepts.md)
@@ -86,11 +86,28 @@ With the 0.1.0 release, the Teams page just lists the teams on the platform.
 
 Further team management options will come in later releases.
 
+### Managing Project Types
+
+The Project Types page can be used to manage the Project Types on the platform.
+
+When billing is enabled, a project type can be associated with a particular
+Stripe Product/Price - allowing each type to have a different monthly price
+associated with it.
+
+The Project Types page shows what types are current active, how many stacks
+each type has assigned to it, and how many projects have been created of that
+type.
+
 ### Managing Stacks
 
 The Stacks page can be used to manage the Project Stacks on the platform.
 
 It can be used to create and edit the stacks on the platform.
+
+With the 0.7 release, you can create a new version of an existing stack via the
+drop-down menu in the stack table. This allows the platform to notify users
+that an update is available for their project, allowing them to upgrade the stack
+at their convenience.
 
 It is *not* possible to edit a stack that is being used by Projects.
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -17,3 +17,8 @@ Kubernetes | Run the platform in a full Kubernetes based environment.
 
 If you are just getting started with FlowForge and want to evaluate what it can do,
 we recommend starting with the [Local model](./local/README.md).
+
+## Upgrading FlowForge
+
+If you are upgrading FlowForge, please refer to the [Upgrade Guide](./upgrading.md)
+for any specific actions required.

--- a/docs/install/first-run.md
+++ b/docs/install/first-run.md
@@ -47,10 +47,28 @@ you created in the first step.
 
 ## Next Steps
 
-Once logged in, there are two remaining tasks the Administrator must complete
+Once logged in, there are three remaining tasks the Administrator must complete
 before projects can be created
 
-### 1. Create a Project Stack
+### 1. Create a Project Type
+
+The Project Type provides a way to have different collections of Project Stacks
+the user can choose from when creating a project.
+
+They are managed on the `Project Types` section of Admin Settings.
+
+When creating a Project Type you give it a name and description. If you have
+billing enabled, you can associate a Stripe Product and Price ID with the type.
+
+The `default stack` property lets you pick which stack should be used by default
+for this project type. If you haven't created any stacks yet, this will be an
+empty list, but you can update it later.
+
+The `order` property controls how the project types are sorted when shown to the
+user.
+
+
+### 2. Create a Project Stack
 
 The Project Stack defines a set of platform configuration options that will get
 applied to each project when it is created.
@@ -71,6 +89,6 @@ chosen deployment model.
 A Project Template provides a default set of Node-RED settings, such as the path
 the editor is served from and whether users can install new nodes.
 
-In 0.3, the template provides a minimal set of options, but this will be
+The template currently provides a minimal set of options, but this will be
 expanded in future releases.
 

--- a/docs/install/upgrading.md
+++ b/docs/install/upgrading.md
@@ -9,7 +9,7 @@ has been performed.
 
 ### Upgrading to 0.7
 
-The 0.7 release introduces the [ProjectType concept](../user/concepts#project-type).
+The 0.7 release introduces the [ProjectType concept](../user/concepts.md#project-type).
 
 After upgrading to 0.7, an administrator must perform the following tasks before
 users will be able to create new projects:

--- a/docs/install/upgrading.md
+++ b/docs/install/upgrading.md
@@ -1,0 +1,27 @@
+# Upgrading FlowForge
+
+If you are upgrading an existing FlowForge installation, this page will list any
+particular requirements needed to upgrade to a given level.
+
+Note that we do not support downgrading FlowForge to previous levels once an upgrade
+has been performed.
+
+
+### Upgrading to 0.7
+
+The 0.7 release introduces the [ProjectType concept](../user/concepts#project-type).
+
+After upgrading to 0.7, an administrator must perform the following tasks before
+users will be able to create new projects:
+
+1. Create a Project Type.
+    1. On the Administrator Settings -> Project Types page, click 'Create project type'.
+    2. Provide a name and description. If you have billing enabled, copy in the default
+       Stripe Product/Price IDs from your runtime settings file.
+    3. Click 'create'
+2. Assign your existing stacks to that type
+    1. On the Administrator Settings -> Stacks page, edit each existing stack via
+       the drop-down menu in the table.
+    2. As a one-time action, set its Project Type to the one just created.
+    3. Click 'save'. This will update the stack *and* all existing projects to
+       be associated with the new Project Type

--- a/docs/user/changestack.md
+++ b/docs/user/changestack.md
@@ -8,6 +8,10 @@ to upgrade Node-RED.
 **Note:** Stacks are created by Administrators and made available to the teams
 and users of the platform.
 
+With the 0.7 release of FlowForge, when an Administrator creates a new version
+of a Stack your project is using, the platform will notify you that there is a
+new version available.
+
 
 To change a project's stack:
 

--- a/docs/user/changestack.md
+++ b/docs/user/changestack.md
@@ -8,7 +8,7 @@ to upgrade Node-RED.
 **Note:** Stacks are created by Administrators and made available to the teams
 and users of the platform.
 
-With the 0.7 release of FlowForge, when an Administrator creates a new version
+When an Administrator creates a new version
 of a Stack your project is using, the platform will notify you that there is a
 new version available.
 

--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -4,6 +4,7 @@ FlowForge makes it easy to create and manage Node-RED instances. To do that, the
 are a few concepts the platform introduces to help organise things.
 
  - [Project](#project)
+   - [Type](#project-type)
    - [Stack](#project-stack)
    - [Template](#project-template)
    - [Snapshot](#project-snapshot)
@@ -24,6 +25,16 @@ and allowed in the [Project Template](#project-template). These can be access
 from the Settings page of the project and there is a description of each one in
 the settings.
 
+#### Project Type
+
+When you create a project, you can pick its type from the list the platform
+Administrator has made available. For example, each type could provide a different
+amount of memory or CPU allocation. In the future, they will also enable different
+feature sets.
+
+If the platform has billing enabled, each type may have a different monthly price
+associated with it.
+
 #### Project Stack
 
 A Project Stack describes properties of the Project runtime. This can include the
@@ -31,7 +42,8 @@ version of Node-RED, memory and CPU allocation. The specific details will depend
 on how and where FlowForge is running.
 
 Project Stacks are created and owned by the platform Administrator. When a User
-comes to create a new project, they chose from the available stacks.
+comes to create a new project, they chose from the available stacks associated
+with the chosen Project Type.
 
 #### Project Template
 


### PR DESCRIPTION
Adds Project Types to the concepts.

Adds mention of Stack versioning to the managing stacks page - and on the Changing Stacks page.

Adds an upgrade guide to list any version-specific steps an admin must task as part of an upgrade.