### PR TITLE
Avoid flicker of auditlog loading placeholder when refreshing project

### DIFF
--- a/frontend/src/components/AuditLog.vue
+++ b/frontend/src/components/AuditLog.vue
@@ -73,10 +73,12 @@ export default {
         return {
             nextCursor: null,
             logEntries: [],
-            loading: false
+            loading: false,
+            initialLoad: true
         }
     },
     mounted () {
+        this.initialLoad = true
         this.fetchData()
     },
     methods: {
@@ -108,12 +110,15 @@ export default {
             })
         },
         fetchData: async function (newVal) {
-            this.loading = true
+            if (this.initialLoad) {
+                this.loading = true
+            }
             if (this.entity && this.entity.id) {
                 const result = await this.loadItems(this.entity.id)
                 this.logEntries = this.formatResults(result.log)
                 this.nextCursor = result.meta.next_cursor
             }
+            this.initialLoad = false
             this.loading = false
         }
     },


### PR DESCRIPTION
Fixes #689

When the AuditLog component is mounted it does an initial load of the log. This load should use the loading placeholder.

It also watches the 'entity' (either team or project) in case it changes. That will happen when the project is being restarted (for example) and the page is polling the project to see when it is available again. The polling causes the watch handler of the AuditLog to fire.

This PR adds a flag to track if the AuditLog is doing its 'initial' load or not. If not, then don't show the loading placeholder. This removes the flicker.

I agree with @joepavitt's comments in #689 about the messiness of the polling. This is a pragmatic stop-gap solution.