### PR TITLE
Do not include projectType properties when editing projectType

### DIFF
--- a/forge/routes/api/projectType.js
+++ b/forge/routes/api/projectType.js
@@ -108,29 +108,39 @@ module.exports = async function (app) {
             reply.code(400).send({ error: 'Cannot edit in-use ProjectType' })
             return
         }
-        if (request.body.name !== undefined) {
-            projectType.name = request.body.name
-        }
-        if (request.body.description !== undefined) {
-            projectType.description = request.body.description
-        }
-        if (request.body.active !== undefined) {
-            projectType.active = request.body.active
-        }
-        if (request.body.properties !== undefined) {
-            projectType.properties = request.body.properties
-        }
-        if (request.body.order !== undefined) {
-            projectType.order = request.body.order
-        }
-        if (request.body.defaultStack) {
-            const defaultStack = app.db.models.ProjectStack.decodeHashid(request.body.defaultStack)
-            if (defaultStack) {
-                projectType.defaultStackId = defaultStack
+        try {
+            if (request.body.name !== undefined) {
+                projectType.name = request.body.name
             }
+            if (request.body.description !== undefined) {
+                projectType.description = request.body.description
+            }
+            if (request.body.active !== undefined) {
+                projectType.active = request.body.active
+            }
+            if (request.body.properties !== undefined) {
+                projectType.properties = request.body.properties
+            }
+            if (request.body.order !== undefined) {
+                projectType.order = request.body.order
+            }
+            if (request.body.defaultStack) {
+                const defaultStack = app.db.models.ProjectStack.decodeHashid(request.body.defaultStack)
+                if (defaultStack) {
+                    projectType.defaultStackId = defaultStack
+                }
+            }
+            await projectType.save()
+            reply.send(app.db.views.ProjectType.projectType(projectType, request.session.User.admin))
+        } catch (err) {
+            let responseMessage
+            if (err.errors) {
+                responseMessage = err.errors.map(err => err.message).join(',')
+            } else {
+                responseMessage = err.toString()
+            }
+            reply.code(400).send({ error: responseMessage })
         }
-        await projectType.save()
-        reply.send(app.db.views.ProjectType.projectType(projectType, request.session.User.admin))
     })
 
     /**

--- a/frontend/src/pages/admin/ProjectTypes/dialogs/ProjectTypeEditDialog.vue
+++ b/frontend/src/pages/admin/ProjectTypes/dialogs/ProjectTypeEditDialog.vue
@@ -11,13 +11,13 @@
                 <FormRow :options="stacks" v-model="input.defaultStack" id="stack">Default Stack</FormRow>
                 <template v-if="this.features.billing">
                     <FormHeading>Billing</FormHeading>
-                    <FormRow v-model="input.properties.billingProductId">
+                    <FormRow v-model="input.properties.billingProductId" :type="editDisabled?'uneditable':''">
                         Stripe Product Id
                     </FormRow>
-                    <FormRow v-model="input.properties.billingPriceId">
+                    <FormRow v-model="input.properties.billingPriceId" :type="editDisabled?'uneditable':''">
                         Stripe Price Id
                     </FormRow>
-                    <FormRow v-model="input.properties.billingDescription">
+                    <FormRow v-model="input.properties.billingDescription" :type="editDisabled?'uneditable':''">
                         Pricing description
                         <template #description>
                             How should the pricing be displayed to the user? eg '$10/month'
@@ -71,27 +71,6 @@ export default {
             editDisabled: false
         }
     },
-    watch: {
-        // 'input.properties': {
-        //     deep: true,
-        //     handler (v) {
-        //         this.stackProperties.forEach(prop => {
-        //             if (v[prop.name] && !prop.validator.test(v[prop.name])) {
-        //                 this.errors[prop.name] = prop.invalidMessage
-        //             } else {
-        //                 this.errors[prop.name] = ''
-        //             }
-        //         })
-        //     }
-        // },
-        // 'input.name': function (v) {
-        //     if (v && !/^[a-z0-9-_/@.]+$/i.test(v)) {
-        //         this.errors.name = 'Must only contain a-z 0-9 - _ / @ .'
-        //     } else {
-        //         this.errors.name = ''
-        //     }
-        // }
-    },
     computed: {
         ...mapState('account', ['features']),
         formValid () {
@@ -122,6 +101,8 @@ export default {
             }
 
             if (this.projectType) {
+                // For edits, we cannot touch the properties
+                delete opts.properties
                 // Update
                 projectTypesApi.updateProjectType(this.projectType.id, opts).then((response) => {
                     this.isOpen = false


### PR DESCRIPTION
Fixes #758

When updating a projectType, the API will request the request if it includes a `properties` object (and the type is in-use) - this is because these things cannot by modified (ie, billing ids).

This PR makes the properties fields uneditable and ensures the api request doesn't include them.

With regard #760 - this has removed the path where trying to edit the type would silently fail. The only failure the user can cause is to provide a duplicate name. This PR fixes up the reporting of that:

<img width="613" alt="image" src="https://user-images.githubusercontent.com/51083/177405597-2259a93f-72ec-468a-878e-657128e421ba.png">

