### PR TITLE
Warn if trying to login with email address

### DIFF
--- a/frontend/src/components/auth/Credentials.vue
+++ b/frontend/src/components/auth/Credentials.vue
@@ -53,6 +53,10 @@ export default {
                 valid = false
                 this.errors.password = 'Required field'
             }
+            if (this.input.username.includes('@')) {
+                valid = false
+                this.errors.username = 'Username cannot be an email address'
+            }
             if (valid) {
                 this.$store.dispatch('account/login', this.input)
             }


### PR DESCRIPTION
This is a simple iteration towards https://github.com/flowforge/flowforge/issues/705, we should still implement 705 but this will improve the experience for some users now as a stepping stone.

Add a warning when users try to login with an email address instead of a username, currently they just get a generic LOGIN FAILED message and have been contacting us thinking there is an issue with their passwords.

![Screen Shot 2022-07-22 at 10 14 41 PM](https://user-images.githubusercontent.com/187645/180569798-3f941fcc-8fe1-4e44-a4ff-b8a4e1820811.png)
