### PR TITLE
Allow http logging level to be set independently

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -1,0 +1,147 @@
+/**
+ * This module provides functions to verify whether a broker ACL request
+ * is valid or not.
+ *
+ * It includes the core (CE) ACLs for basic launcher/device command/status messages.
+ *
+ * Other components (ie EE-specific features) can register their own additional ACLs
+ */
+module.exports = function (app) {
+    // Standard set of verify functions to ensure the request meets particular criteria
+    const verifyFunctions = {
+        checkTeamAndObjectIds: async function (requestParts, ids) {
+            // requestParts = [ _ , <teamid>, <projectid> ]
+            // ids = [ 'project', <teamid>, <projectid> ]
+            return requestParts[1] === ids[1] && requestParts[2] === ids[2]
+        },
+        checkTeamId: async function (requestParts, ids) {
+            // requestParts = [ _ , <teamid> ]
+            // ids = [ 'project', <teamid>, <projectid> ]
+            return requestParts[1] === ids[1]
+        },
+        checkDeviceAssignedToProject: async function (requestParts, ids) {
+            // requestParts = [ _ , <teamid>, <projectid> ]
+            // ids = [ 'device', <teamid>, <deviceid> ]
+
+            // Do the simple team id check
+            if (requestParts[1] !== ids[1]) {
+                return false
+            }
+            // Get the project this device is assigned to and check it matches
+            const assignedProject = await app.db.models.Device.getDeviceProjectId(ids[2])
+            return assignedProject && assignedProject === requestParts[2]
+        },
+        checkDeviceCanAccessProject: async function (requestParts, ids) {
+            // requestParts = [ _ , <teamid>, <projectid> ]
+            // ids = [ 'device', <teamid>, <deviceid> ]
+
+            // Do the simple team id check
+            if (requestParts[1] !== ids[1]) {
+                return false
+            }
+            // Get the project this device is assigned to
+            const assignedProject = await app.db.models.Device.getDeviceProjectId(ids[2])
+            if (!assignedProject) {
+                return false
+            }
+            if (assignedProject === requestParts[2]) {
+                // Access the project we're assigned to - all good
+                return true
+            }
+
+            // Need to check if this project is in the same team.
+            const projectTeamId = await app.db.models.Project.getProjectTeamId(requestParts[2])
+            return projectTeamId && app.db.models.Team.encodeHashid(projectTeamId) === requestParts[1]
+        }
+    }
+
+    const ACLS = {
+        forge_platform: {
+            sub: [
+                // Receive status events from project launchers
+                // - ff/v1/+/l/+/status
+                { topic: /^ff\/v1\/[^/]+\/l\/[^/]+\/status$/ },
+                // Receive status events from devices
+                // - ff/v1/+/d/+/status
+                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/status$/ }
+            ],
+            pub: [
+                // Send commands to project launchers
+                // - ff/v1/+/l/+/command
+                { topic: /^ff\/v1\/[^/]+\/l\/[^/]+\/command$/ },
+                // Send commands to devices
+                // - ff/v1/+/d/+/command
+                { topic: /^ff\/v1\/[^/]+\/d\/[^/]+\/command$/ },
+                // Send commands to all project-assigned devices
+                // - ff/v1/+/p/+/command
+                { topic: /^ff\/v1\/[^/]+\/p\/[^/]+\/command$/ }
+            ]
+        },
+        project: {
+            sub: [
+                // Receive commands from the platform
+                // - ff/v1/<team>/l/<project>/command
+                { topic: /^ff\/v1\/([^/]+)\/l\/([^/]+)\/command$/, verify: 'checkTeamAndObjectIds' }
+            ],
+            pub: [
+                // Send status to the platform
+                // - ff/v1/<team>/l/<project>/status
+                { topic: /^ff\/v1\/([^/]+)\/l\/([^/]+)\/status$/, verify: 'checkTeamAndObjectIds' }
+            ]
+        },
+        device: {
+            sub: [
+                // Receive commands from the platform
+                // - ff/v1/<team>/d/<device>/command
+                { topic: /^ff\/v1\/([^/]+)\/d\/([^/]+)\/command$/, verify: 'checkTeamAndObjectIds' },
+                // Receive commands from the platform - broadcast
+                // - ff/v1/<team>/p/<project>/command
+                { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/command$/, verify: 'checkDeviceAssignedToProject' }
+            ],
+            pub: [
+                // Send status to the platform
+                // - ff/v1/<team>/d/<device>/status
+                { topic: /^ff\/v1\/([^/]+)\/d\/([^/]+)\/status$/, verify: 'checkTeamAndObjectIds' }
+            ]
+        }
+    }
+
+    return {
+        verify: async function (username, topic, accessLevel) {
+            // Three types of client
+            // - forge_platform
+            // - project:<teamid>:<projectid>
+            // - device:<teamid>:<deviceid>
+
+            let allowed = false
+            let aclList = []
+            // accessLevel 1=SUB 2=PUB 3=WRITE
+            // We do not distinguish between SUB & WRITE
+            const aclType = accessLevel === 2 ? 'pub' : 'sub'
+            // Pick the appropriate ACL list based on username/accessLevel
+            if (username === 'forge_platform') {
+                aclList = ACLS[username][aclType]
+            } else if (/^project:/.test(username)) {
+                aclList = ACLS.project[aclType]
+            } else if (/^device:/.test(username)) {
+                aclList = ACLS.device[aclType]
+            }
+            const l = aclList.length
+            for (let i = 0; i < l; i++) {
+                const m = aclList[i].topic.exec(topic)
+                if (m) {
+                    if (aclList[i].verify && verifyFunctions[aclList[i].verify]) {
+                        allowed = await verifyFunctions[aclList[i].verify](m, username.split(':'))
+                    } else {
+                        allowed = true
+                    }
+                    break
+                }
+            }
+            return allowed
+        },
+        addACL: function (scope, action, acl) {
+            ACLS[scope][action].push(acl)
+        }
+    }
+}

--- a/forge/comms/authRoutes.js
+++ b/forge/comms/authRoutes.js
@@ -1,0 +1,63 @@
+/**
+ * Broker authentication backend
+ *
+ * - /api/comms/auth/client - verify username/password
+ * - /api/comms/auth/acl - verify username is permitted to pub/sub to particular topic
+ *
+ */
+
+module.exports = async function (app) {
+    app.post('/client', {
+        schema: {
+            body: {
+                type: 'object',
+                required: ['clientid', 'password', 'username'],
+                properties: {
+                    clientid: { type: 'string' },
+                    password: { type: 'string' },
+                    username: { type: 'string' }
+                }
+            }
+        }
+    }, async (request, response) => {
+        const isValid = await app.db.controllers.BrokerClient.authenticateCredentials(
+            request.body.username,
+            request.body.password
+        )
+        if (isValid) {
+            response.status(200).send()
+        } else {
+            response.status(401).send()
+        }
+    })
+
+    app.post('/acl', {
+        schema: {
+            body: {
+                type: 'object',
+                required: ['acc', 'clientid', 'topic', 'username'],
+                properties: {
+                    clientid: { type: 'string' },
+                    username: { type: 'string' },
+                    topic: { type: 'string' },
+                    acc: { type: 'number' }
+                }
+            }
+        }
+    }, async (request, response) => {
+        const allowed = await app.comms.aclManager.verify(request.body.username, request.body.topic, request.body.acc)
+        if (allowed) {
+            response.status(200).send()
+        } else {
+            response.status(401).send()
+        }
+    })
+
+    // app.get('/test', async (request, response) => {
+    //     const project = await app.db.models.Project.byId('ac8e4995-cb47-42ec-a9a4-71c42366c7f3')
+    //     const creds = await app.db.controllers.BrokerClient.createClientForProject(project)
+    //     // const device = await app.db.models.Device.byId(1)
+    //     // const creds = await app.db.controllers.BrokerClient.createClientForDevice(device)
+    //     response.send(creds)
+    // })
+}

--- a/forge/comms/commsClient.js
+++ b/forge/comms/commsClient.js
@@ -1,0 +1,74 @@
+const mqtt = require('mqtt')
+const EventEmitter = require('events')
+
+/**
+ * MQTT Client wrapper. This connects to the platform broker and subscribes
+ * to the appropriate status topics.
+ */
+class CommsClient extends EventEmitter {
+    constructor (app) {
+        super()
+        this.app = app
+    }
+
+    async init () {
+        // To aid testing, we use a url of `:test:` to allow us to configure
+        // the platform with comms enabled, but no active MQTT connection
+        if (this.app.config.broker.url !== ':test:') {
+            const brokerConfig = {
+                clientId: 'forge_platform',
+                username: 'forge_platform',
+                password: await this.app.settings.get('commsToken'),
+                reconnectPeriod: 5000
+            }
+            this.client = mqtt.connect(this.app.config.broker.url, brokerConfig)
+            this.client.on('connect', () => {
+                this.app.log.info('Connected to comms broker')
+            })
+            this.client.on('reconnect', () => {
+                this.app.log.info('Reconnecting to comms broker')
+            })
+            this.client.on('error', (err) => {
+                this.app.log.info(`Connection error to comms broker: ${err.toString()}`)
+            })
+            this.client.on('message', (topic, message) => {
+                const topicParts = topic.split('/')
+                const ownerType = topicParts[3]
+                const ownerId = topicParts[4]
+                if (ownerType === 'p') {
+                    this.emit('status/project', {
+                        id: ownerId,
+                        status: message.toString()
+                    })
+                } else if (ownerType === 'd') {
+                    this.emit('status/device', {
+                        id: ownerId,
+                        status: message.toString()
+                    })
+                }
+            })
+            this.client.subscribe([
+                // Launcher status
+                'ff/v1/+/l/+/status',
+                // Device status
+                'ff/v1/+/d/+/status'
+            ])
+        }
+    }
+
+    publish (topic, payload) {
+        if (this.client) {
+            this.client.publish(topic, payload)
+        }
+    }
+
+    async disconnect () {
+        if (this.client) {
+            this.client.end()
+        }
+    }
+}
+
+module.exports = {
+    CommsClient
+}

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -1,0 +1,93 @@
+/**
+ * This module provides the handler for device status events - as well as APIs
+ * for sending commands to devices.
+ */
+
+class DeviceCommsHandler {
+    constructor (app, client) {
+        this.app = app
+        this.client = client
+
+        // Listen for any incoming device status events
+        client.on('status/device', (status) => { this.handleStatus(status) })
+    }
+
+    async handleStatus (status) {
+        // Check it looks like a valid status message
+        if (status.id && status.status) {
+            const deviceId = status.id
+            const device = await this.app.db.models.Device.byId(deviceId)
+            if (!device) {
+                // TODO: log invalid device
+                return
+            }
+            try {
+                const payload = JSON.parse(status.status)
+                await this.app.db.controllers.Device.updateState(device, payload)
+
+                // If the status state===unknown, the device is waiting for confirmation
+                // it has the right details. Always response with an 'update' command in
+                // this scenario
+                let sendUpdateCommand = payload.state === 'unknown'
+
+                if (Object.hasOwn(payload, 'project') && payload.project !== (device.Project?.id || null)) {
+                    // The Project is incorrect
+                    sendUpdateCommand = true
+                }
+                if (Object.hasOwn(payload, 'snapshot') && payload.snapshot !== (device.targetSnapshot?.hashid || null)) {
+                    // The Snapshot is incorrect
+                    sendUpdateCommand = true
+                }
+                if (Object.hasOwn(payload, 'settings') && payload.settings !== (device.settingsHash || null)) {
+                    // The Settings are incorrect
+                    sendUpdateCommand = true
+                }
+
+                if (sendUpdateCommand) {
+                    this.sendCommand(device.Team.hashid, deviceId, 'update', {
+                        project: device.Project?.id || null,
+                        snapshot: device.targetSnapshot?.hashid || null,
+                        settings: device.settingsHash || null
+                    })
+                }
+            } catch (err) {
+                // Not a JSON payload - ignore
+            }
+        }
+    }
+
+    /**
+     * Send a command to all devices assigned to a project using the broadcast
+     * topic.
+     * @param {String} teamId
+     * @param {String} projectId
+     * @param {String} command
+     * @param {Object} payload
+     */
+    sendCommandToProjectDevices (teamId, projectId, command, payload) {
+        const topic = `ff/v1/${teamId}/p/${projectId}/command`
+        this.client.publish(topic, JSON.stringify({
+            command: command,
+            ...payload
+        }))
+    }
+
+    /**
+     * Send a command to a specific device using its command topic.
+     * @param {String} teamId
+     * @param {String} deviceId
+     * @param {String} command
+     * @param {Object} payload
+     */
+    sendCommand (teamId, deviceId, command, payload) {
+        const topic = `ff/v1/${teamId}/d/${deviceId}/command`
+        this.client.publish(topic, JSON.stringify({
+            command: command,
+            ...payload
+        }))
+    }
+}
+
+module.exports = {
+    DeviceCommsHandler: (app, client) => new DeviceCommsHandler(app, client)
+}

--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -1,0 +1,56 @@
+const fp = require('fastify-plugin')
+const { CommsClient } = require('./commsClient')
+const { DeviceCommsHandler } = require('./devices')
+const ACLManager = require('./aclManager')
+
+/**
+ * This module represents the real-time comms component of the platform.
+ * We depend on an external MQTT broker (mosquitto) and of the runtime configuration
+ * to include the details needed to connect to it.
+ *
+ * This module handles
+ *  - Incoming device status messages
+ *  - Broker ACL requests
+ *
+ */
+module.exports = fp(async function (app, _opts, next) {
+    // Check the runtime configuration includes the minimum required configuration
+    // to use the MQTT broker service
+    if (app.config.broker && app.config.broker.url) {
+        // Register the authentication routes the broker will be using
+        await app.register(require('./authRoutes'), { prefix: '/api/comms/auth', logLevel: 'warn' })
+
+        // Ensure we have a BrokerClient object (auth details) for use by the platform
+        await app.db.controllers.BrokerClient.ensurePlatformClient()
+
+        // Create the platform's client for connecting to the broker
+        const client = new CommsClient(app)
+
+        // Create the handler for any device-related messages
+        const deviceCommsHandler = DeviceCommsHandler(app, client)
+
+        // Not in the current release, but when we handle Launcher status
+        // via MQTT, it will arrive here. Compare to the status/device handler in `devices.js`
+        // client.on('status/project', (status) => {
+        //     // console.log(status)
+        // })
+
+        // Setup the platform API for the comms component
+        app.decorate('comms', {
+            devices: deviceCommsHandler,
+            aclManager: ACLManager(app)
+        })
+
+        app.ready().then(async () => {
+            // Once the whole platform is ready, tell the client to connect
+            await client.init()
+        })
+        app.addHook('onClose', async (_) => {
+            app.log.info('Comms shutdown')
+            await client.disconnect()
+        })
+    } else {
+        app.log.warn('[comms] Broker not configured - comms unavailable')
+    }
+    next()
+})

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -107,6 +107,17 @@ module.exports = fp(async function (app, opts, next) {
             }
         }
 
+        if (!config.logging) {
+            config.logging = {
+                level: 'info',
+                http: 'warn'
+            }
+        } else {
+            if (!config.logging.http) {
+                config.logging.http = 'warn'
+            }
+        }
+
         config.features = features(app, config)
 
         Object.freeze(config)

--- a/forge/db/controllers/BrokerClient.js
+++ b/forge/db/controllers/BrokerClient.js
@@ -1,0 +1,112 @@
+const { generateToken, compareHash } = require('../utils')
+
+module.exports = {
+    /**
+     * Validate the username/password
+     */
+    authenticateCredentials: async function (app, username, password) {
+        const user = await app.db.models.BrokerClient.findOne({
+            where: { username: username },
+            attributes: ['password']
+        })
+        if (compareHash(password || '', user ? user.password : '')) {
+            return true
+        }
+        return false
+    },
+
+    ensurePlatformClient: async function (app, project) {
+        const existingClient = await app.db.models.BrokerClient.findOne({
+            where: {
+                username: 'forge_platform'
+            }
+        })
+        if (existingClient) {
+            return
+        }
+        const username = 'forge_platform'
+        const password = generateToken(32, 'ffbpl')
+        await app.db.models.BrokerClient.create({
+            username,
+            password,
+            ownerId: '',
+            ownerType: 'platform'
+        })
+        await app.settings.set('commsToken', password)
+        return {
+            username,
+            password
+        }
+    },
+
+    /**
+     *
+     */
+    createClientForProject: async function (app, project) {
+        if (app.comms) {
+            const existingClient = await app.db.models.BrokerClient.findOne({
+                where: {
+                    ownerId: project.id,
+                    ownerType: 'project'
+                }
+            })
+            if (existingClient) {
+                await existingClient.destroy()
+            }
+            if (!project.Team) {
+                // When restarting the platform, the container drivers get a minimal list
+                // of projects to restart. They don't necessarily include the Team in their
+                // query - so we need to ensure its available.
+                await project.reload({
+                    include: [{
+                        model: app.db.models.Team,
+                        attributes: ['hashid', 'id', 'name', 'slug', 'links']
+                    }]
+                })
+            }
+            const username = `project:${project.Team.hashid}:${project.id}`
+            const password = generateToken(32, 'ffbp')
+            await app.db.models.BrokerClient.create({
+                username,
+                password,
+                ownerId: project.id,
+                ownerType: 'project'
+            })
+            return {
+                url: app.config.broker.url || null,
+                username,
+                password
+            }
+        }
+        return null
+    },
+
+    createClientForDevice: async function (app, device) {
+        if (app.comms) {
+            const existingClient = await app.db.models.BrokerClient.findOne({
+                where: {
+                    ownerId: '' + device.id,
+                    ownerType: 'device'
+                }
+            })
+            if (existingClient) {
+                await existingClient.destroy()
+            }
+            const username = `device:${device.Team.hashid}:${device.hashid}`
+            const password = generateToken(32, 'ffbd')
+            await app.db.models.BrokerClient.create({
+                username,
+                password,
+                ownerId: '' + device.id,
+                ownerType: 'device'
+            })
+            return {
+                // Devices should default to the public url if set
+                url: app.config.broker.public_url || app.config.broker.url || null,
+                username,
+                password
+            }
+        }
+        return null
+    }
+}

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -20,7 +20,8 @@ const modelTypes = [
     'Project',
     'ProjectTemplate',
     'ProjectSnapshot',
-    'Device'
+    'Device',
+    'BrokerClient'
 ]
 
 async function init (app) {

--- a/forge/db/migrations/20220621-01-add-brokerclient.js
+++ b/forge/db/migrations/20220621-01-add-brokerclient.js
@@ -1,0 +1,19 @@
+/**
+ * Add BrokerClients table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.createTable('BrokerClients', {
+            username: { type: DataTypes.STRING, allowNull: false, primaryKey: true },
+            password: { type: DataTypes.STRING, allowNull: false },
+            ownerId: { type: DataTypes.STRING },
+            ownerType: { type: DataTypes.STRING },
+            createdAt: { type: DataTypes.DATE },
+            updatedAt: { type: DataTypes.DATE }
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/BrokerClient.js
+++ b/forge/db/models/BrokerClient.js
@@ -1,0 +1,22 @@
+const { DataTypes } = require('sequelize')
+const { hash } = require('../utils')
+
+module.exports = {
+    name: 'BrokerClient',
+    schema: {
+        username: {
+            type: DataTypes.STRING,
+            primaryKey: true,
+            allowNull: false
+        },
+        password: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            set (value) {
+                this.setDataValue('password', hash(value))
+            }
+        },
+        ownerId: { type: DataTypes.STRING },
+        ownerType: { type: DataTypes.STRING }
+    }
+}

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -64,7 +64,8 @@ const modelTypes = [
     'StorageSettings',
     'StorageSession',
     'StorageLibrary',
-    'AuditLog'
+    'AuditLog',
+    'BrokerClient'
 ]
 
 // A local map of the known models.

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -4,5 +4,6 @@ module.exports = fp(async function (app, opts, done) {
     if (app.config.billing) {
         app.decorate('billing', require('./billing').init(app))
     }
+    require('./projectComms').init(app)
     done()
 })

--- a/forge/ee/lib/projectComms/index.js
+++ b/forge/ee/lib/projectComms/index.js
@@ -1,0 +1,71 @@
+module.exports.init = function (app) {
+    if (app.comms) {
+        // Set the feature flag
+        app.config.features.register('projectComms', true, false)
+
+        // Register the broker comms ACLs for inter-project communication
+
+        // Project ACL
+
+        // Receive broadcasts from other projects in the team
+        // - ff/v1/<team>/p/+/out/+/#
+        app.comms.aclManager.addACL(
+            'project',
+            'sub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/[^/]+\/out\/[^/]+($|\/.*$)/, verify: 'checkTeamId' }
+        )
+        // Receive messages sent to this project
+        // - ff/v1/<team>/p/<project>/in/+/#
+        app.comms.aclManager.addACL(
+            'project',
+            'sub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
+        )
+        // Send message to other project
+        // - ff/v1/<team>/p/+/in/+/#
+        app.comms.aclManager.addACL(
+            'project',
+            'pub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/[^/]+\/in\/[^/]+($|\/.*$)/, verify: 'checkTeamId' }
+        )
+        // Send broadcast messages
+        // - ff/v1/<team>/p/<project>/out/+/#
+        app.comms.aclManager.addACL(
+            'project',
+            'pub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkTeamAndObjectIds' }
+        )
+
+        // Device ACL
+
+        // Receive broadcasts from other projects in the team
+        // - ff/v1/<team>/p/+/out/+/#
+        app.comms.aclManager.addACL(
+            'device',
+            'sub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
+        )
+        // Receive messages sent to this project
+        // - ff/v1/<team>/p/<project>/in/+/#
+        app.comms.aclManager.addACL(
+            'device',
+            'sub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)$/, verify: 'checkDeviceAssignedToProject' }
+        )
+
+        // Send message to other project
+        // - ff/v1/<team>/p/+/in/+/#
+        app.comms.aclManager.addACL(
+            'device',
+            'pub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
+        )
+        // Send broadcast messages
+        // - ff/v1/<team>/p/<project>/out/+/#
+        app.comms.aclManager.addACL(
+            'device',
+            'pub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceAssignedToProject' }
+        )
+    }
+}

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -5,6 +5,7 @@ const config = require('./config')
 const settings = require('./settings')
 const license = require('./licensing')
 const containers = require('./containers')
+const comms = require('./comms')
 const cookie = require('@fastify/cookie')
 const csrf = require('@fastify/csrf-protection')
 const postoffice = require('./postoffice')
@@ -62,6 +63,8 @@ module.exports = async (options = {}) => {
         await server.register(routes, { logLevel: 'warn' })
         // Post Office : handles email
         await server.register(postoffice)
+        // Comms : real-time communication broker
+        await server.register(comms)
         // Containers:
         await server.register(containers)
 

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -25,7 +25,8 @@ module.exports = async (options = {}) => {
             level: loggerLevel,
             prettyPrint: {
                 translateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss.l'Z'",
-                ignore: 'pid,hostname'
+                ignore: 'pid,hostname',
+                singleLine: true
             }
         }
     })
@@ -60,7 +61,7 @@ module.exports = async (options = {}) => {
         await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
 
         // Routes : the HTTP routes
-        await server.register(routes, { logLevel: 'warn' })
+        await server.register(routes, { logLevel: server.config.logging.http })
         // Post Office : handles email
         await server.register(postoffice)
         // Comms : real-time communication broker

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -103,7 +103,7 @@ module.exports = async function (app) {
             type: request.body.type,
             credentialSecret: ''
         })
-        const credentials = await device.refreshAuthTokens()
+
         await team.addDevice(device)
 
         await device.reload({
@@ -111,6 +111,8 @@ module.exports = async function (app) {
                 { model: app.db.models.Team }
             ]
         })
+
+        const credentials = await device.refreshAuthTokens()
 
         await app.db.controllers.AuditLog.teamLog(
             team.id,
@@ -152,6 +154,7 @@ module.exports = async function (app) {
     app.put('/:deviceId', {
         preHandler: app.needsPermission('device:edit')
     }, async (request, reply) => {
+        let sendDeviceUpdate = false
         if (request.body.project !== undefined) {
             if (request.body.project === null) {
                 // Remove device from project if it is currently assigned
@@ -162,6 +165,7 @@ module.exports = async function (app) {
                     // Clear its target snapshot, so the next time it calls home
                     // it will stop the current snapshot
                     await request.device.setTargetSnapshot(null)
+                    sendDeviceUpdate = true
 
                     await app.db.controllers.AuditLog.teamLog(
                         request.device.Team.id,
@@ -198,7 +202,8 @@ module.exports = async function (app) {
                     // Set the target snapshot to match the project's one
                     const deviceSettings = await project.getSetting('deviceSettings')
                     request.device.targetSnapshotId = deviceSettings?.targetSnapshot
-                    // if (project.team.id)
+
+                    sendDeviceUpdate = true
 
                     await app.db.controllers.AuditLog.teamLog(
                         request.device.Team.id,
@@ -237,7 +242,13 @@ module.exports = async function (app) {
         await request.device.save()
 
         const updatedDevice = await app.db.models.Device.byId(request.device.id)
-
+        if (app.comms && sendDeviceUpdate) {
+            app.comms.devices.sendCommand(updatedDevice.Team.hashid, updatedDevice.hashid, 'update', {
+                project: updatedDevice.Project?.id || null,
+                snapshot: updatedDevice.targetSnapshot?.hashid || null,
+                settings: updatedDevice.settingsHash || null
+            })
+        }
         reply.send(app.db.views.Device.device(updatedDevice))
     })
 
@@ -258,6 +269,13 @@ module.exports = async function (app) {
         preHandler: app.needsPermission('device:edit')
     }, async (request, reply) => {
         await request.device.updateSettings(request.body)
+        if (app.comms) {
+            app.comms.devices.sendCommand(request.device.Team.hashid, request.device.hashid, 'update', {
+                project: request.device.Project?.id || null,
+                snapshot: request.device.targetSnapshot?.hashid || null,
+                settings: request.device.settingsHash || null
+            })
+        }
         reply.send({ status: 'okay' })
     })
 

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -31,17 +31,28 @@ module.exports = async function (app) {
      */
     app.post('/state', async (request, reply) => {
         await app.db.controllers.Device.updateState(request.device, request.body)
-        if (request.body.snapshot !== (request.device.targetSnapshot?.hashid || null)) {
+        if (Object.hasOwn(request.body, 'project') && request.body.project !== (request.device.Project?.id || null)) {
             reply.code(409).send({
-                error: 'incorrect-snapshot',
+                error: 'incorrect-project',
+                project: request.device.Project?.id || null,
                 snapshot: request.device.targetSnapshot?.hashid || null,
                 settings: request.device.settingsHash || null
             })
             return
         }
-        if (request.body.settings && request.body.settings !== (request.device.settingsHash || null)) {
+        if (request.body.snapshot !== (request.device.targetSnapshot?.hashid || null)) {
+            reply.code(409).send({
+                error: 'incorrect-snapshot',
+                project: request.device.Project?.id || null,
+                snapshot: request.device.targetSnapshot?.hashid || null,
+                settings: request.device.settingsHash || null
+            })
+            return
+        }
+        if (request.body.settings !== undefined && request.body.settings !== (request.device.settingsHash || null)) {
             reply.code(409).send({
                 error: 'incorrect-settings',
+                project: request.device.Project?.id || null,
                 settings: request.device.settingsHash || null,
                 snapshot: request.device.targetSnapshot?.hashid || null
             })
@@ -52,7 +63,9 @@ module.exports = async function (app) {
 
     app.get('/state', async (request, reply) => {
         reply.send({
-            snapshot: request.device.targetSnapshot?.hashid || null
+            project: request.device.Project?.id || null,
+            snapshot: request.device.targetSnapshot?.hashid || null,
+            settings: request.device.settingsHash || null
         })
     })
 

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -324,6 +324,13 @@ module.exports = async function (app) {
     app.delete('/:projectId', { preHandler: app.needsPermission('project:delete') }, async (request, reply) => {
         try {
             await app.containers.remove(request.project)
+
+            if (app.comms) {
+                app.comms.devices.sendCommandToProjectDevices(request.project.Team.hashid, request.project.id, 'update', {
+                    project: null
+                })
+            }
+
             await request.project.destroy()
             await app.db.controllers.AuditLog.projectLog(
                 request.project.id,

--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -68,6 +68,11 @@ module.exports = async function (app) {
                 'project.snapshot.deviceTarget',
                 { id: request.body.targetSnapshot }
             )
+            if (app.comms) {
+                app.comms.devices.sendCommandToProjectDevices(request.project.Team.hashid, request.project.id, 'update', {
+                    snapshot: targetSnapshot.hashid
+                })
+            }
             reply.send({ status: 'okay' })
         }
     })

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -52,6 +52,23 @@ module.exports = async function (app) {
         preHandler: app.needsPermission('project:snapshot:delete')
     }, async (request, reply) => {
         const id = request.snapshot.hashid
+        const project = await request.snapshot.getProject()
+        const deviceSettings = await project.getSetting('deviceSettings') || {
+            targetSnapshot: null
+        }
+        if (deviceSettings.targetSnapshot === request.snapshot.id) {
+            // We're about to delete the active snapshot for this project
+            await project.updateSetting('deviceSettings', {
+                targetSnapshot: null
+            })
+            // The cascade relationship will ensure Device.targetSnapshotId is cleared
+            if (app.comms) {
+                const team = await project.getTeam()
+                app.comms.devices.sendCommandToProjectDevices(team.hashid, project.id, 'update', {
+                    snapshot: null
+                })
+            }
+        }
         await request.snapshot.destroy()
         await app.db.controllers.AuditLog.projectLog(
             request.project.id,

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -30,7 +30,7 @@ const SESSION_COOKIE_OPTIONS = {
 }
 
 module.exports = fp(async function (app, opts, done) {
-    await app.register(require('./oauth'), { logLevel: 'warn' })
+    await app.register(require('./oauth'), { logLevel: app.config.logging.http })
     await app.register(require('./permissions'))
 
     // WIP:
@@ -174,7 +174,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         const result = await app.db.controllers.User.authenticateCredentials(request.body.username, request.body.password)
         if (result) {
@@ -197,7 +197,7 @@ module.exports = fp(async function (app, opts, done) {
      * @static
      * @memberof forge.routes.session
      */
-    app.post('/account/logout', { logLevel: 'warn' }, async (request, reply) => {
+    app.post('/account/logout', async (request, reply) => {
         if (request.sid) {
             // logout:nodered(step-1)
             const thisSession = await app.db.models.Session.findOne({
@@ -246,7 +246,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         if (!app.settings.get('user:signup') && !app.settings.get('team:user:invite:external')) {
             reply.code(400).send({ error: 'user registration not enabled' })
@@ -301,7 +301,7 @@ module.exports = fp(async function (app, opts, done) {
         }
     })
 
-    app.get('/account/verify/:token', { logLevel: 'warn' }, async (request, reply) => {
+    app.get('/account/verify/:token', async (request, reply) => {
         try {
             let sessionUser
             if (request.sid) {
@@ -338,7 +338,7 @@ module.exports = fp(async function (app, opts, done) {
         }
     })
 
-    app.post('/account/verify', { preHandler: app.verifySession, logLevel: 'warn' }, async (request, reply) => {
+    app.post('/account/verify', { preHandler: app.verifySession }, async (request, reply) => {
         if (!app.postoffice.enabled()) {
             reply.code(400).send({ error: 'email not configured' })
             return
@@ -368,7 +368,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         if (!app.settings.get('user:reset-password')) {
             reply.code(400).send({ error: 'password reset not enabled' })
@@ -403,7 +403,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         if (!app.settings.get('user:reset-password')) {
             reply.code(400).send({ error: 'password reset not enabled' })

--- a/forge/routes/index.js
+++ b/forge/routes/index.js
@@ -12,11 +12,11 @@
  */
 const fp = require('fastify-plugin')
 module.exports = fp(async function (app, opts, done) {
-    await app.register(require('./auth'), { logLevel: 'warn' })
-    await app.register(require('./api'), { prefix: '/api/v1', logLevel: 'warn' })
-    await app.register(require('./ui'), { logLevel: 'warn' })
-    await app.register(require('./setup'), { logLevel: 'warn' })
-    await app.register(require('./storage'), { prefix: '/storage', logLevel: 'warn' })
-    await app.register(require('./logging'), { prefix: '/logging', logLevel: 'warn' })
+    await app.register(require('./auth'), { logLevel: app.config.logging.http })
+    await app.register(require('./api'), { prefix: '/api/v1', logLevel: app.config.logging.http })
+    await app.register(require('./ui'), { logLevel: app.config.logging.http })
+    await app.register(require('./setup'), { logLevel: app.config.logging.http })
+    await app.register(require('./storage'), { prefix: '/storage', logLevel: app.config.logging.http })
+    await app.register(require('./logging'), { prefix: '/logging', logLevel: app.config.logging.http })
     done()
 })

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -8,6 +8,9 @@ module.exports = {
     // Secret used to sign cookies:
     cookieSecret: null,
 
+    // Token to connect the platform client to the broker
+    commsToken: null,
+
     // Whether the intial setup has been run
     'setup:initialised': false,
 

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -78,15 +78,21 @@ export default {
             return this.device && this.device.credentials
         },
         credentials: function () {
+            let result = ''
             if (this.device) {
-                return `deviceId: ${this.device.id}
+                result = `deviceId: ${this.device.id}
 token: ${this.device.credentials.token}
 credentialSecret: ${this.device.credentials.credentialSecret}
 forgeURL: ${this.settings.base_url}
 `
-            } else {
-                return ''
+                if (this.device.credentials.broker) {
+                    result += `brokerURL: ${this.device.credentials.broker.url}
+brokerUsername: ${this.device.credentials.broker.username}
+brokerPassword: ${this.device.credentials.broker.password}
+`
+                }
             }
+            return result
         }
     },
     setup () {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "lru-cache": "^7.10.1",
         "marked": "^4.0.16",
         "moment": "^2.29.2",
+        "mqtt": "^4.3.7",
         "nodemailer": "^6.7.5",
         "pino-pretty": "^5.1.3",
         "semver": "^7.3.7",

--- a/test/unit/forge/comms/authRoutes_spec.js
+++ b/test/unit/forge/comms/authRoutes_spec.js
@@ -1,0 +1,658 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../routes/setup')
+
+describe('Broker Auth API', async function () {
+    let app
+    const TestObjects = {}
+
+    const ACC = {
+        READ: 1,
+        WRITE: 2,
+        SUBSCRIBE: 4
+    }
+    async function setupCE () {
+        app = await setup({}, {
+            broker: {
+                url: ':test:'
+            }
+        })
+        await setupTestObjects()
+    }
+    async function setupEE () {
+        app = await setup({}, {
+            broker: {
+                url: ':test:'
+            },
+            license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkJlbiBIYXJkaWxsIiwibmJmIjoxNjQ4MTY2NDAwLCJleHAiOjE2Nzk3ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjQ4MjA1MDA3fQ.2swXs50ZJgiQLA9MeoKIepN6BJGGnDqIUQ0FuKUadVjTcUzFekId5RaTpedi14f2iA7qC1w50Ym2egaBFSg1JA'
+        })
+        await setupTestObjects()
+    }
+    async function sendACLPost (opts) {
+        opts.clientid = opts.username
+        return await app.inject({
+            method: 'POST',
+            url: '/api/comms/auth/acl',
+            body: opts
+        })
+    }
+    async function allowWrite (opts) {
+        opts.acc = ACC.WRITE
+        const response = await sendACLPost(opts)
+        response.statusCode.should.equal(200)
+    }
+    async function allowRead (opts) {
+        // Due to the way mosquitto auth checks work, we need to check
+        // both READ and SUBSCRIBE access
+        opts.acc = ACC.READ
+        const response = await sendACLPost(opts)
+        response.statusCode.should.equal(200)
+
+        opts.acc = ACC.SUBSCRIBE
+        const response2 = await sendACLPost(opts)
+        response2.statusCode.should.equal(200)
+    }
+    async function denyWrite (opts) {
+        opts.acc = ACC.WRITE
+        const response = await sendACLPost(opts)
+        response.statusCode.should.equal(401)
+    }
+    async function denyRead (opts) {
+        // Due to the way mosquitto auth checks work, we need to check
+        // both READ and SUBSCRIBE access
+        opts.acc = ACC.READ
+        const response = await sendACLPost(opts)
+        response.statusCode.should.equal(401)
+
+        opts.acc = ACC.SUBSCRIBE
+        const response2 = await sendACLPost(opts)
+        response2.statusCode.should.equal(401)
+    }
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    async function setupTestObjects () {
+        // alice : admin
+        // ATeam ( alice  (owner) )
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        // Alice set as ATeam owner in setup()
+
+        TestObjects.ProjectA = app.project
+        TestObjects.ProjectACredentials = await TestObjects.ProjectA.refreshAuthTokens()
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+    }
+
+    describe('Auth Client', async function () {
+        // POST /api/comms/auth/client
+        before(async function () {
+            await setupCE()
+        })
+
+        after(async function () {
+            await app.close()
+        })
+
+        it('rejects if request missing required values', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/comms/auth/client',
+                body: { }
+            })
+            response.statusCode.should.equal(400)
+        })
+
+        it('accepts valid credentials', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/comms/auth/client',
+                body: {
+                    clientid: TestObjects.ProjectACredentials.broker.username,
+                    username: TestObjects.ProjectACredentials.broker.username,
+                    password: TestObjects.ProjectACredentials.broker.password
+                }
+            })
+            response.statusCode.should.equal(200)
+        })
+
+        it('rejects invalid password', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/comms/auth/client',
+                body: {
+                    clientid: TestObjects.ProjectACredentials.broker.username,
+                    username: TestObjects.ProjectACredentials.broker.username,
+                    password: 'wrong-password'
+                }
+            })
+            response.statusCode.should.equal(401)
+        })
+    })
+
+    describe('Auth ACL', async function () {
+        describe('Platform Client', async function () {
+            before(async function () {
+                await setupCE()
+            })
+
+            after(async function () {
+                await app.close()
+            })
+            it('allows platform to subscribe to launcher status topic', async function () {
+                await allowRead({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/+/l/+/status'
+                })
+            })
+            it('allows platform to subscribe to device status topic', async function () {
+                await allowRead({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/+/d/+/status'
+                })
+            })
+            it('allows platform to publish to project-device command topic', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/abc/p/xyz/command'
+                })
+            })
+            it('allows platform to publish to launcher command topic', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/abc/l/xyz/command'
+                })
+            })
+            it('allows platform to publish to device command topic', async function () {
+                await allowWrite({
+                    username: 'forge_platform',
+                    topic: 'ff/v1/abc/d/ghi/command'
+                })
+            })
+        })
+
+        describe('Project', async function () {
+            describe('CE', async function () {
+                before(async function () {
+                    await setupCE()
+                })
+
+                after(async function () {
+                    await app.close()
+                })
+
+                // Status Topic
+                it('allows launcher to publish to own status topic', async function () {
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/xyz/status'
+                    })
+                })
+                it('prevents launcher from publishing to other status topic', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/other-project/status'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/other-team/l/xyz/status'
+                    })
+                })
+                it('prevents launcher from subscribing to status topic', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/xyz/status'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/other-project/status'
+                    })
+                })
+
+                // Command topic
+                it('allows launcher to subscribe to own command topic', async function () {
+                    allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/xyz/command'
+                    })
+                })
+                it('prevents project from subscribing to other command topic', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/other-project/command'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/other-team/l/xyz/command'
+                    })
+                })
+                it('prevents launcher from publishing to command topic', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/xyz/command'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/l/other-project/command'
+                    })
+                })
+                it('project cannot publish to own broadcast topic', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/foo'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/foo/'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/foo/bar'
+                    })
+                })
+                it('project cannot subscribe to another projects broadcast', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo/'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo/bar'
+                    })
+                })
+                it('project canonot subscribe to own inbox', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/foo'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/foo/bar'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/#'
+                    })
+                })
+                it('project cannot publish to another projects inbox', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo/'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo/bar'
+                    })
+                })
+            })
+
+            describe('EE', async function () {
+                before(async function () {
+                    await setupEE()
+                })
+
+                after(async function () {
+                    await app.close()
+                })
+                // Inter-project comms
+                it('allows project to publish to own broadcast topic', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/'
+                    })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/foo'
+                    })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/foo/'
+                    })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/out/foo/bar'
+                    })
+                })
+                it('allows project to subscribe to another projects broadcast', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo/'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo/bar'
+                    })
+                })
+                it('prevents project from publishing to other broadcast topic', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo/'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/out/foo/bar'
+                    })
+                })
+                it('allows project to subscribe to own inbox', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/foo'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/foo/bar'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/in/#'
+                    })
+                })
+                it('prevents project from subscribing to another projects inbox', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo/bar'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/#'
+                    })
+                })
+                it('allows project to publish to another projects inbox', async function () {
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in'
+                    })
+                    await denyWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/'
+                    })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo'
+                    })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo/'
+                    })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/in/foo/bar'
+                    })
+                })
+            })
+        })
+
+        describe('Device', async function () {
+            let deviceUsername
+            let deviceCommandTopic
+            let deviceStatusTopic
+            async function setupDeviceTestObjects () {
+                const response = await app.inject({
+                    method: 'POST',
+                    url: '/api/v1/devices',
+                    body: {
+                        name: 'my device',
+                        type: 'test device',
+                        team: TestObjects.ATeam.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                TestObjects.DeviceA = response.json()
+                deviceUsername = `device:${TestObjects.ATeam.hashid}:${TestObjects.DeviceA.id}`
+                deviceCommandTopic = `ff/v1/${TestObjects.ATeam.hashid}/d/${TestObjects.DeviceA.id}/command`
+                deviceStatusTopic = `ff/v1/${TestObjects.ATeam.hashid}/d/${TestObjects.DeviceA.id}/status`
+
+                // Create a second project in the team
+                TestObjects.ProjectB = await app.db.models.Project.create({ name: 'project2', type: '', url: '' })
+                await TestObjects.ATeam.addProject(TestObjects.ProjectB)
+            }
+            describe('CE', async function () {
+                before(async function () {
+                    await setupCE()
+                    await setupDeviceTestObjects()
+                })
+                after(async function () {
+                    await app.close()
+                })
+
+                // Status Topic
+                it('allows device to publish to own status topic', async function () {
+                    await allowWrite({
+                        username: deviceUsername,
+                        topic: deviceStatusTopic
+                    })
+                })
+                it('prevents device from publishing to other status topic', async function () {
+                    await denyWrite({
+                        username: deviceUsername,
+                        topic: 'ff/v1/abc/d/other-device/status'
+                    })
+                    await denyWrite({
+                        username: deviceUsername,
+                        topic: 'ff/v1/other-team/d/xyz/status'
+                    })
+                })
+                it('prevents device from subscribing to status topic', async function () {
+                    await denyRead({
+                        username: deviceUsername,
+                        topic: deviceStatusTopic
+                    })
+                    await denyRead({
+                        username: deviceUsername,
+                        topic: 'ff/v1/abc/d/other-device/status'
+                    })
+                })
+
+                // Command topic
+                it('allows device to subscribe to own command topic', async function () {
+                    allowRead({
+                        username: deviceUsername,
+                        topic: deviceCommandTopic
+                    })
+                })
+                it('prevents device from subscribing to other command topic', async function () {
+                    await denyRead({
+                        username: deviceUsername,
+                        topic: 'ff/v1/abc/d/other-device/command'
+                    })
+                    await denyRead({
+                        username: deviceUsername,
+                        topic: 'ff/v1/other-team/d/ghi/command'
+                    })
+                })
+                it('prevents device from publishing to command topic', async function () {
+                    await denyWrite({
+                        username: deviceUsername,
+                        topic: deviceCommandTopic
+                    })
+                    await denyWrite({
+                        username: deviceUsername,
+                        topic: 'ff/v1/abc/d/other-device/command'
+                    })
+                })
+            })
+            describe('EE', async function () {
+                before(async function () {
+                    await setupEE()
+                    await setupDeviceTestObjects()
+                })
+                after(async function () {
+                    await app.close()
+                })
+                describe('unassigned', async function () {
+                    it('cannot subscribe to project command if unassigned', async function () {
+                        await denyRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectA.id}/command`
+                        })
+                    })
+                    it('cannot subscribe to project inbox if unassigned', async function () {
+                        await denyRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectA.id}/in/foo`
+                        })
+                    })
+                    it('cannot subscribe to project broadcast if unassigned', async function () {
+                        await denyRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectB.id}/out/foo`
+                        })
+                    })
+                    it('cannot publish to project inbox if unassigned', async function () {
+                        await denyWrite({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectB.id}/in/foo`
+                        })
+                    })
+                    it('cannot publish to project output if unassigned', async function () {
+                        await denyWrite({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectA.id}/out/foo`
+                        })
+                    })
+                })
+                describe('assigned', async function () {
+                    before(async function () {
+                        await app.inject({
+                            method: 'PUT',
+                            url: `/api/v1/devices/${TestObjects.DeviceA.id}`,
+                            body: {
+                                project: TestObjects.ProjectA.id
+                            },
+                            cookies: { sid: TestObjects.tokens.alice }
+                        })
+                    })
+                    it('can subscribe to project command if assigned', async function () {
+                        await allowRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectA.id}/command`
+                        })
+                    })
+                    it('can subscribe to project inbox if assigned', async function () {
+                        await allowRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectA.id}/in/foo`
+                        })
+                    })
+                    it('can subscribe to project broadcast if assigned', async function () {
+                        await allowRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectB.id}/out/foo`
+                        })
+                    })
+                    it('can publish to project inbox if assigned', async function () {
+                        await allowWrite({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectB.id}/in/foo`
+                        })
+                    })
+                    it('can publish to project output if unassigned', async function () {
+                        await allowWrite({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectA.id}/out/foo`
+                        })
+                    })
+                })
+            })
+        })
+    })
+})

--- a/test/unit/forge/routes/setup.js
+++ b/test/unit/forge/routes/setup.js
@@ -101,6 +101,12 @@ module.exports = async function (settings = {}, config = {}) {
     await project1.setProjectTemplate(template)
     await project1.setProjectType(forge.projectType)
 
+    await project1.reload({
+        include: [
+            { model: forge.db.models.Team }
+        ]
+    })
+
     forge.project = project1
     forge.template = template
     forge.stack = stack


### PR DESCRIPTION
This allows http route logging to be set independently of all other logging.

It can be controlled from the flowforge.yaml file with:
 
```yaml
logging:
  level: info
  http: warn
```

Defaults to before the change ('warn') so doesn't log http requests