### PR TITLE
 Allow http logging level to be set independently #802 

### DIFF
--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -18,7 +18,7 @@ module.exports = fp(async function (app, _opts, next) {
     // to use the MQTT broker service
     if (app.config.broker && app.config.broker.url) {
         // Register the authentication routes the broker will be using
-        await app.register(require('./authRoutes'), { prefix: '/api/comms/auth', logLevel: 'warn' })
+        await app.register(require('./authRoutes'), { prefix: '/api/comms/auth', logLevel: app.config.logging.http })
 
         // Ensure we have a BrokerClient object (auth details) for use by the platform
         await app.db.controllers.BrokerClient.ensurePlatformClient()

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -107,6 +107,17 @@ module.exports = fp(async function (app, opts, next) {
             }
         }
 
+        if (!config.logging) {
+            config.logging = {
+                level: 'info',
+                http: 'warn'
+            }
+        } else {
+            if (!config.logging.http) {
+                config.logging.http = 'warn'
+            }
+        }
+
         config.features = features(app, config)
 
         Object.freeze(config)

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -25,7 +25,8 @@ module.exports = async (options = {}) => {
             level: loggerLevel,
             prettyPrint: {
                 translateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss.l'Z'",
-                ignore: 'pid,hostname'
+                ignore: 'pid,hostname',
+                singleLine: true
             }
         }
     })
@@ -60,7 +61,7 @@ module.exports = async (options = {}) => {
         await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
 
         // Routes : the HTTP routes
-        await server.register(routes, { logLevel: 'warn' })
+        await server.register(routes, { logLevel: server.config.logging.http })
         // Post Office : handles email
         await server.register(postoffice)
         // Comms : real-time communication broker

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -30,7 +30,7 @@ const SESSION_COOKIE_OPTIONS = {
 }
 
 module.exports = fp(async function (app, opts, done) {
-    await app.register(require('./oauth'), { logLevel: 'warn' })
+    await app.register(require('./oauth'), { logLevel: app.config.logging.http })
     await app.register(require('./permissions'))
 
     // WIP:
@@ -174,7 +174,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         const result = await app.db.controllers.User.authenticateCredentials(request.body.username, request.body.password)
         if (result) {
@@ -197,7 +197,7 @@ module.exports = fp(async function (app, opts, done) {
      * @static
      * @memberof forge.routes.session
      */
-    app.post('/account/logout', { logLevel: 'warn' }, async (request, reply) => {
+    app.post('/account/logout', async (request, reply) => {
         if (request.sid) {
             // logout:nodered(step-1)
             const thisSession = await app.db.models.Session.findOne({
@@ -246,7 +246,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         if (!app.settings.get('user:signup') && !app.settings.get('team:user:invite:external')) {
             reply.code(400).send({ error: 'user registration not enabled' })
@@ -301,7 +301,7 @@ module.exports = fp(async function (app, opts, done) {
         }
     })
 
-    app.get('/account/verify/:token', { logLevel: 'warn' }, async (request, reply) => {
+    app.get('/account/verify/:token', async (request, reply) => {
         try {
             let sessionUser
             if (request.sid) {
@@ -338,7 +338,7 @@ module.exports = fp(async function (app, opts, done) {
         }
     })
 
-    app.post('/account/verify', { preHandler: app.verifySession, logLevel: 'warn' }, async (request, reply) => {
+    app.post('/account/verify', { preHandler: app.verifySession }, async (request, reply) => {
         if (!app.postoffice.enabled()) {
             reply.code(400).send({ error: 'email not configured' })
             return
@@ -368,7 +368,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         if (!app.settings.get('user:reset-password')) {
             reply.code(400).send({ error: 'password reset not enabled' })
@@ -403,7 +403,7 @@ module.exports = fp(async function (app, opts, done) {
                 }
             }
         },
-        logLevel: 'warn'
+        logLevel: app.config.logging.http
     }, async (request, reply) => {
         if (!app.settings.get('user:reset-password')) {
             reply.code(400).send({ error: 'password reset not enabled' })

--- a/forge/routes/index.js
+++ b/forge/routes/index.js
@@ -12,11 +12,11 @@
  */
 const fp = require('fastify-plugin')
 module.exports = fp(async function (app, opts, done) {
-    await app.register(require('./auth'), { logLevel: 'warn' })
-    await app.register(require('./api'), { prefix: '/api/v1', logLevel: 'warn' })
-    await app.register(require('./ui'), { logLevel: 'warn' })
-    await app.register(require('./setup'), { logLevel: 'warn' })
-    await app.register(require('./storage'), { prefix: '/storage', logLevel: 'warn' })
-    await app.register(require('./logging'), { prefix: '/logging', logLevel: 'warn' })
+    await app.register(require('./auth'), { logLevel: app.config.logging.http })
+    await app.register(require('./api'), { prefix: '/api/v1', logLevel: app.config.logging.http })
+    await app.register(require('./ui'), { logLevel: app.config.logging.http })
+    await app.register(require('./setup'), { logLevel: app.config.logging.http })
+    await app.register(require('./storage'), { prefix: '/storage', logLevel: app.config.logging.http })
+    await app.register(require('./logging'), { prefix: '/logging', logLevel: app.config.logging.http })
     done()
 })


### PR DESCRIPTION
This allows http route logging to be set independently of all other logging.

It can be controlled from the flowforge.yaml file with:
```yaml
logging:
  level: info
  http: warn
```

Defaults to before the change ('warn') so doesn't log http requests.

Also changes log format to be single line for most output to make parsing it a lot easier
