### PR TITLE
Centralise how tests initialise Forge app

### DIFF
--- a/forge/ee/db/controllers/Subscription.js
+++ b/forge/ee/db/controllers/Subscription.js
@@ -5,7 +5,7 @@ module.exports = {
             customer: customer,
             subscription: subscription
         })
-        newSubscription.setTeam(team)
+        await newSubscription.setTeam(team)
 
         return newSubscription
     },

--- a/test/node_modules/flowforge-test-utils/index.js
+++ b/test/node_modules/flowforge-test-utils/index.js
@@ -1,8 +1,68 @@
+const PACKAGE_ROOT = "../../../"
 const path = require("path");
+const FFRequire = file => require(path.join(PACKAGE_ROOT,file))
+const { LocalTransport } = require('./forge/postoffice/localTransport.js')
+const Forge = FFRequire('forge/forge.js')
 
-const PACKAGE_ROOT = "../../../";
+async function setupApp (config = {}) {
+    config = {
+        telemetry: { enabled: false },
+        logging: {
+            level: 'warn'
+        },
+        db: {
+            type: 'sqlite',
+            storage: ':memory:'
+        },
+        email: {
+            enabled: true,
+            transport: new LocalTransport()
+        },
+        driver: {
+            type: 'stub'
+        },
+        broker: {
+            url: ':test:'
+        },
+        ...config
+    }
+
+    if (process.env.FF_TEST_DB_POSTGRES) {
+        config.db.type = 'postgres'
+        config.db.host = process.env.FF_TEST_DB_POSTGRES_HOST || 'localhost'
+        config.db.port = process.env.FF_TEST_DB_POSTGRES_PORT || 5432
+        config.db.user = process.env.FF_TEST_DB_POSTGRES_USER || 'postgres'
+        config.db.password = process.env.FF_TEST_DB_POSTGRES_PASSWORD || 'secret'
+        config.db.database = process.env.FF_TEST_DB_POSTGRES_DATABASE || 'flowforge_test'
+
+        try {
+            const { Client } = require('pg')
+            const client = new Client({
+                host: config.db.host,
+                port: config.db.port,
+                user: config.db.user,
+                password: config.db.password
+            })
+            await client.connect()
+            try {
+                await client.query(`DROP DATABASE ${config.db.database}`)
+            } catch (err) {
+                // Don't mind if it doesn't exist
+            }
+            await client.query(`CREATE DATABASE ${config.db.database}`)
+            await client.end()
+        } catch (err) {
+            console.log(err.toString())
+            process.exit(1)
+        }
+    }
+
+    return await Forge({ config })
+}
+
 
 module.exports = {
-    require: file => require(path.join(PACKAGE_ROOT,file)),
-    resolve: file => path.resolve(path.join(__dirname,PACKAGE_ROOT,file))
+    require: FFRequire,
+    resolve: file => path.resolve(path.join(__dirname,PACKAGE_ROOT,file)),
+    setupApp
 }

--- a/test/system/001-setup_spec.js
+++ b/test/system/001-setup_spec.js
@@ -1,6 +1,5 @@
 const should = require('should') // eslint-disable-line
 const FF_UTIL = require('flowforge-test-utils')
-const Forge = FF_UTIL.require('forge/forge.js')
 const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
 describe('First run setup', function () {
@@ -11,20 +10,18 @@ describe('First run setup', function () {
 
     before(async function () {
         // Create the FF application with a suitable test configuration
-        forge = await Forge({
-            config: {
-                telemetry: { enabled: false },
-                driver: {
-                    type: 'stub'
-                },
-                db: {
-                    type: 'sqlite',
-                    storage: ':memory:'
-                },
-                email: {
-                    enabled: true,
-                    transport: inbox
-                }
+        forge = await FF_UTIL.setupApp({
+            telemetry: { enabled: false },
+            driver: {
+                type: 'stub'
+            },
+            db: {
+                type: 'sqlite',
+                storage: ':memory:'
+            },
+            email: {
+                enabled: true,
+                transport: inbox
             }
         })
     })

--- a/test/system/100-project-lifecycle_spec.js
+++ b/test/system/100-project-lifecycle_spec.js
@@ -1,6 +1,5 @@
 const should = require('should') // eslint-disable-line
 const FF_UTIL = require('flowforge-test-utils')
-const Forge = FF_UTIL.require('forge/forge.js')
 const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
 
@@ -27,23 +26,21 @@ describe('Project Lifecycle', function () {
 
     before(async function () {
         // Create the FF application with a suitable test configuration
-        forge = await Forge({
-            config: {
-                telemetry: { enabled: false },
-                logging: {
-                    level: 'warn'
-                },
-                driver: {
-                    type: 'stub'
-                },
-                db: {
-                    type: 'sqlite',
-                    storage: ':memory:'
-                },
-                email: {
-                    enabled: true,
-                    transport: inbox
-                }
+        forge = await FF_UTIL.setupApp({
+            telemetry: { enabled: false },
+            logging: {
+                level: 'warn'
+            },
+            driver: {
+                type: 'stub'
+            },
+            db: {
+                type: 'sqlite',
+                storage: ':memory:'
+            },
+            email: {
+                enabled: true,
+                transport: inbox
             }
         })
 

--- a/test/unit/forge/comms/authRoutes_spec.js
+++ b/test/unit/forge/comms/authRoutes_spec.js
@@ -11,18 +11,11 @@ describe('Broker Auth API', async function () {
         SUBSCRIBE: 4
     }
     async function setupCE () {
-        app = await setup({}, {
-            broker: {
-                url: ':test:'
-            }
-        })
+        app = await setup()
         await setupTestObjects()
     }
     async function setupEE () {
-        app = await setup({}, {
-            broker: {
-                url: ':test:'
-            },
+        app = await setup({
             license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkJlbiBIYXJkaWxsIiwibmJmIjoxNjQ4MTY2NDAwLCJleHAiOjE2Nzk3ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjQ4MjA1MDA3fQ.2swXs50ZJgiQLA9MeoKIepN6BJGGnDqIUQ0FuKUadVjTcUzFekId5RaTpedi14f2iA7qC1w50Ym2egaBFSg1JA'
         })
         await setupTestObjects()

--- a/test/unit/forge/containers/index_spec.js
+++ b/test/unit/forge/containers/index_spec.js
@@ -148,7 +148,7 @@ describe('Container Wrapper', function () {
         }
 
         beforeEach(async function () {
-            app = await setup({}, {
+            app = await setup({
                 license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjM5NzUxMTc1LCJleHAiOjcyNTgxMTg0MDAsIm5vdGUiOiJGb3IgZGV2ZWxvcG1lbnQgb25seSIsInRpZXIiOiJ0ZWFtcyIsInVzZXJzIjoiMTAwIiwidGVhbXMiOiIxMDAiLCJwcm9qZWN0cyI6IjEwMCIsImlhdCI6MTYzOTc1MTE3NX0.CZwIbUV9-vC1dPHaJqVJx1YchK_4JgRMBCd5UEQfNYblXNJKiaR9BFY7T-Qvzg1HsR3rbDhmraiiVMfGuR75gw',
                 billing: {
                     stripe: {}

--- a/test/unit/forge/containers/setup.js
+++ b/test/unit/forge/containers/setup.js
@@ -1,33 +1,11 @@
 const FF_UTIL = require('flowforge-test-utils')
-const Forge = FF_UTIL.require('forge/forge.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
-const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
 // Lots of dupication between the different unit test setup.js files
 // Should pull out the common bits to one place
 
-module.exports = async function (settings = {}, config = {}) {
-    config = {
-        ...config,
-        telemetry: { enabled: false },
-        logging: {
-            level: 'warn'
-        },
-        db: {
-            type: 'sqlite',
-            storage: ':memory:'
-        },
-        email: {
-            enabled: true,
-            transport: new LocalTransport()
-        },
-        driver: {
-            type: 'stub'
-        }
-    }
-
-    const forge = await Forge({ config })
-
+module.exports = async function (config = {}) {
+    const forge = await FF_UTIL.setupApp(config)
     /*
         alice (admin)
         bob

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -29,7 +29,7 @@ describe('Project model', function () {
             const reloadedProject = await app.db.models.Project.byId(project.id)
             const pt = await reloadedProject.getProjectType()
 
-            console.log(pt.name)
+            pt.name.should.equal('default-project-type')
         })
     })
     describe('Project Settings', function () {

--- a/test/unit/forge/db/setup.js
+++ b/test/unit/forge/db/setup.js
@@ -1,29 +1,8 @@
 const FF_UTIL = require('flowforge-test-utils')
-const Forge = FF_UTIL.require('forge/forge.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
-const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
-module.exports = async function (settings = {}, config = {}) {
-    config = {
-        ...config,
-        telemetry: { enabled: false },
-        logging: {
-            level: 'warn'
-        },
-        db: {
-            type: 'sqlite',
-            storage: ':memory:'
-        },
-        email: {
-            enabled: true,
-            transport: new LocalTransport()
-        },
-        driver: {
-            type: 'stub'
-        }
-    }
-
-    const forge = await Forge({ config })
+module.exports = async function (config = {}) {
+    const forge = await FF_UTIL.setupApp(config)
 
     /*
         alice (admin)

--- a/test/unit/forge/ee/routes/setup.js
+++ b/test/unit/forge/ee/routes/setup.js
@@ -1,26 +1,9 @@
 const FF_UTIL = require('flowforge-test-utils')
-const Forge = FF_UTIL.require('forge/forge.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
-const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 
-module.exports = async function (settings = {}, config = {}) {
+module.exports = async function (config = {}) {
     config = {
         ...config,
-        telemetry: { enabled: false },
-        logging: {
-            level: 'warn'
-        },
-        db: {
-            type: 'sqlite',
-            storage: ':memory:'
-        },
-        email: {
-            enabled: true,
-            transport: new LocalTransport()
-        },
-        driver: {
-            type: 'stub'
-        },
         license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkJlbiBIYXJkaWxsIiwibmJmIjoxNjQ4MTY2NDAwLCJleHAiOjE2Nzk3ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjQ4MjA1MDA3fQ.2swXs50ZJgiQLA9MeoKIepN6BJGGnDqIUQ0FuKUadVjTcUzFekId5RaTpedi14f2iA7qC1w50Ym2egaBFSg1JA',
         billing: {
             stripe: {
@@ -29,7 +12,7 @@ module.exports = async function (settings = {}, config = {}) {
         }
     }
 
-    const forge = await Forge({ config })
+    const forge = await FF_UTIL.setupApp(config)
 
     await forge.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
     const userAlice = await forge.db.models.User.create({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -23,7 +23,7 @@ describe('Device API', async function () {
     }
 
     beforeEach(async function () {
-        app = await setup({}, { features: { devices: true } })
+        app = await setup({ features: { devices: true } })
 
         // alice : admin
         // bob

--- a/test/unit/forge/routes/api/projectDevices_spec.js
+++ b/test/unit/forge/routes/api/projectDevices_spec.js
@@ -22,7 +22,7 @@ describe('Project/Device API', async function () {
     }
 
     beforeEach(async function () {
-        app = await setup({}, { features: { devices: true } })
+        app = await setup({ features: { devices: true } })
 
         // alice : admin
         // bob

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -8,7 +8,7 @@ describe('Users API', async function () {
     const TestObjects = {}
 
     beforeEach(async function () {
-        app = await setup({}, { features: { devices: true } })
+        app = await setup({ features: { devices: true } })
 
         // alice : admin, team owner
         // bob : admin, team owner


### PR DESCRIPTION
Fixes #770

Reduces code duplication and ensures all tests are enabled for postgres testing

The basic pattern for tests to follow is:

```
// Load the common test utils module
const FF_UTIL = require('flowforge-test-utils')

// Initialise the app with whatever config is required
const app = await FF_UTIL.setupApp({
    license: '....'
})
```

The `FF_UTIL.setupApp` function includes a default app config suitable for most tests. The passed-in configuration augments (rather than replaces) that default config.

It also contains the logic to insert the postgres db config if the appropriate env vars are set to enable postgres testing.