### PR TITLE
Add defaultTeam to User model and enable API to modify

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -74,6 +74,9 @@ module.exports = {
                     throw new Error('Cannot remove last owner')
                 }
             }
+            if (user.defaultTeamId === team.id) {
+                await user.setDefaultTeam(null)
+            }
             await userRole.destroy()
             return true
             // console.warn('TODO: forge.db.controllers.Team.removeUser - expire oauth sessions')

--- a/forge/db/migrations/20220727-01-add-default-team.js
+++ b/forge/db/migrations/20220727-01-add-default-team.js
@@ -1,0 +1,18 @@
+/**
+ * Add defaultTeam to Users table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.addColumn('Users', 'defaultTeamId', {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            references: { model: 'Teams', key: 'id' },
+            onDelete: 'SET NULL',
+            onUpdate: 'CASCADE'
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -83,6 +83,7 @@ module.exports = {
         this.hasMany(M.Session)
         this.hasMany(M.Invitation, { foreignKey: 'invitorId' })
         this.hasMany(M.Invitation, { foreignKey: 'inviteeId' })
+        this.belongsTo(M.Team, { as: 'defaultTeam' })
     },
     finders: function (M) {
         return {

--- a/forge/db/views/User.js
+++ b/forge/db/views/User.js
@@ -38,6 +38,9 @@ module.exports = {
             result.password_expired = true
         }
         result.email_verified = user.email_verified
+        if (user.defaultTeamId) {
+            result.defaultTeam = app.db.models.Team.encodeHashid(user.defaultTeamId)
+        }
         return result
     },
 

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -28,6 +28,16 @@ module.exports = {
                     user.password_expired = true
                 }
             }
+            if (request.body.defaultTeam !== undefined) {
+                // verify user is a member of request.body.defaultTeam
+                const membership = await app.db.models.TeamMember.getTeamMembership(user.id, request.body.defaultTeam)
+                if (membership) {
+                    user.defaultTeamId = membership.TeamId
+                } else {
+                    reply.code(400).send({ error: 'invalid team' })
+                    return
+                }
+            }
             await user.save()
             reply.send(app.db.views.User.userProfile(user))
         } catch (err) {

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -1,12 +1,26 @@
 <template>
     <ff-loading v-if="loading" message="" />
     <form v-else class="space-y-6">
-        <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
-        <FormRow v-model="input.name" :placeholder="input.username" :error="errors.name">Name</FormRow>
-        <FormRow v-model="input.email" :error="errors.email">Email</FormRow>
+        <FormRow v-model="input.username" :type="editing?'text':'uneditable'" :error="errors.username">Username</FormRow>
+        <FormRow v-model="input.name" :type="editing?'text':'uneditable'" :placeholder="input.username" :error="errors.name">Name</FormRow>
+        <FormRow v-model="input.email" :type="editing?'text':'uneditable'" :error="errors.email">Email</FormRow>
+        <FormRow v-if="!editing" v-model="defaultTeamName" :options="teams" type="uneditable">
+            Default Team
+        </FormRow>
+        <FormRow v-else v-model="input.defaultTeam" :options="teams" :error="errors.defaultTeam">
+            Default Team
+            <template #description>The team you'll see when you log in</template>
+        </FormRow>
 
-        <ff-button :disabled="!formValid" @click="confirm">Save Changes</ff-button>
-
+        <template v-if="editing">
+            <div class="flex space-x-4">
+                <ff-button :disabled="!formValid" @click="confirm">Save Changes</ff-button>
+                <ff-button kind="secondary" @click="cancelEdit">Cancel</ff-button>
+            </div>
+        </template>
+        <template v-else>
+            <ff-button @click="startEdit">Edit</ff-button>
+        </template>
     </form>
 </template>
 
@@ -22,16 +36,31 @@ export default {
 
     data () {
         const currentUser = this.$store.getters['account/user']
+        const teams = this.$store.getters['account/teams']
+        let defaultTeamName = 'none'
+        const teamOptions = teams.map(team => {
+            if (team.id === currentUser.defaultTeam) {
+                defaultTeamName = team.name
+            }
+            return {
+                value: team.id,
+                label: team.name
+            }
+        })
         return {
             loading: false,
+            editing: false,
             user: currentUser,
             errors: {},
             input: {
                 username: currentUser.username,
                 name: currentUser.name,
-                email: currentUser.email
+                email: currentUser.email,
+                defaultTeam: currentUser.defaultTeam
             },
-            changed: {}
+            defaultTeamName: defaultTeamName,
+            changed: {},
+            teams: teamOptions
         }
     },
     watch: {
@@ -58,11 +87,25 @@ export default {
                 this.errors.name = ''
             }
             this.changed.name = (this.user.name !== v)
+        },
+        'input.defaultTeam': function (v) {
+            this.changed.defaultTeam = (this.user.defaultTeam !== v)
         }
     },
     methods: {
+        startEdit () {
+            this.editing = true
+        },
+        cancelEdit () {
+            this.input.username = this.user.username
+            this.input.name = this.user.name
+            this.input.email = this.user.email
+            this.input.defaultTeam = this.user.defaultTeam
+            this.editing = false
+        },
         confirm () {
             this.loading = true
+            this.editing = false
             const opts = {}
             let changed = false
             if (this.input.username !== this.user.username) {
@@ -81,12 +124,20 @@ export default {
                 opts.admin = this.input.admin
                 changed = true
             }
-
+            if (this.input.defaultTeam !== this.defaultTeam) {
+                opts.defaultTeam = this.input.defaultTeam
+                changed = true
+            }
             if (changed) {
                 userApi.updateUser(opts).then((response) => {
                     this.$store.dispatch('account/setUser', response)
                     alerts.emit('User successfully updated.', 'confirmation')
                     this.user = response
+                    this.teams.forEach(team => {
+                        if (team.value === this.user.defaultTeam) {
+                            this.defaultTeamName = team.label
+                        }
+                    })
                     this.changed = {}
                 }).catch(err => {
                     console.log(err.response.data)
@@ -109,7 +160,7 @@ export default {
     },
     computed: {
         formValid () {
-            return (this.changed.name || this.changed.username || this.changed.email) &&
+            return (this.changed.name || this.changed.username || this.changed.email || this.changed.defaultTeam) &&
                    (this.input.email && !this.errors.email) &&
                    (this.input.username && !this.errors.username) &&
                    (this.input.name && !this.errors.name)

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-loading v-if="loading" message="" />
-    <form v-else class="space-y-6">
+    <form v-else class="space-y-6" @submit.enter.prevent="">
         <FormRow v-model="input.username" :type="editing?'text':'uneditable'" :error="errors.username">Username</FormRow>
         <FormRow v-model="input.name" :type="editing?'text':'uneditable'" :placeholder="input.username" :error="errors.name">Name</FormRow>
         <FormRow v-model="input.email" :type="editing?'text':'uneditable'" :error="errors.email">Email</FormRow>

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -168,36 +168,22 @@ const actions = {
                 state.commit('clearPending')
                 if (/^\/team\//.test(router.currentRoute.value.path)) {
                     router.push({ name: 'Home' })
-                    // router.push({
-                    //     name: "PageNotFound",
-                    //     params: { pathMatch: router.currentRoute.value.path.substring(1).split('/') },
-                    //     // preserve existing query and hash if any
-                    //     query: router.currentRoute.value.query,
-                    //     hash: router.currentRoute.value.hash,
-                    // })
                 }
 
                 return
             }
 
-            // Default to first in list - TODO: let the user pick their default
-            let teamSlug = teams.teams[0].slug
+            let teamId = user.defaultTeam || teams.teams[0].id
+            let teamSlug = null
             //
             const teamIdMatch = /^\/team\/([^/]+)($|\/)/.exec(redirectUrlAfterLogin || router.currentRoute.value.path)
             if (teamIdMatch && teamIdMatch[1] !== 'create') {
+                teamId = null
                 teamSlug = teamIdMatch[1]
-            // } else {
-            //     let projectIdMatch = /^\/projects\/([^\/]+)($|\/)/.exec(redirectUrlAfterLogin || router.currentRoute.value.path)
-            //     if (projectIdMatch) {
-            //         let projectId = projectIdMatch[1]
-            //
-            //     }
-            //
-            //
             }
 
             try {
-                const team = await teamApi.getTeam({ slug: teamSlug })
+                const team = await teamApi.getTeam(teamId || { slug: teamSlug })
                 const teamMembership = await teamApi.getTeamUserMembership(team.id)
                 state.commit('setTeam', team)
                 state.commit('setTeamMembership', teamMembership)

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -60,6 +60,69 @@ describe('Users API', async function () {
     afterEach(async function () {
         await app.close()
     })
+
+    describe('Update user settings', async function () {
+        describe('Default Team', async function () {
+            // PUT /api/v1/users/:userId
+            it('can set defaultTeam to a team the user is in', async function () {
+                // Alice can set bobs default team to ATeam
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.bob.hashid}`,
+                    payload: {
+                        defaultTeam: TestObjects.ATeam.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('defaultTeam', TestObjects.ATeam.hashid)
+            })
+            it('cannot set defaultTeam to a team the user is not in', async function () {
+                // Alice cannot set bobs default team to CTeam
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.bob.hashid}`,
+                    payload: {
+                        defaultTeam: TestObjects.CTeam.hashid
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(400)
+                const result = response.json()
+                result.should.have.property('error')
+            })
+            it('cannot set defaultTeam to null', async function () {
+                // Alice cannot set bobs default team to null
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.bob.hashid}`,
+                    payload: {
+                        defaultTeam: null
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(400)
+                const result = response.json()
+                result.should.have.property('error')
+            })
+            it('cannot set defaultTeam to invalid value', async function () {
+                // Alice cannot set bobs default team to 'abc'
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${TestObjects.bob.hashid}`,
+                    payload: {
+                        defaultTeam: 'abc'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(400)
+                const result = response.json()
+                result.should.have.property('error')
+            })
+        })
+    })
+
     describe('Delete a user', async function () {
         // DELETE /api/v1/users/:userId
 


### PR DESCRIPTION
Closes #299  #298 #300

 - Adds `defaultTeam` column to User table
 - Update User Settings endpoints modified to accept optional `defaultTeam` value to set it.
    - Validates the user is a member of the team - responds with 400 if not valid
    - Clears the user's defaultTeam if they are removed from that team
 - Adds Default Team to the 'User Settings' page and allows the user to change it
 - When the user logs in, it takes them to this team (if set) rather than the first in the list

<img width="479" alt="image" src="https://user-images.githubusercontent.com/51083/181289175-c84213f8-8059-41e6-aaa1-272ad55dd98a.png">
