### PR TITLE
Fix reply-already-sent error when auth fails on storage routes

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -41,7 +41,7 @@ module.exports = fp(async function (app, opts, done) {
                 const scheme = parts[0]
                 const token = parts[1]
                 if (scheme !== 'Bearer') {
-                    throw new Error('Unsupported authorization scheme')
+                    reply.code(401).send({ error: 'unauthorized' })
                 }
                 if (/^ff[td]/.test(token)) {
                     const accessToken = await app.db.controllers.AccessToken.getOrExpire(token)
@@ -57,14 +57,12 @@ module.exports = fp(async function (app, opts, done) {
                     request.session = await app.db.controllers.Session.getOrExpire(token)
                     return
                 }
-                throw new Error(`bad token ${token}`)
+                reply.code(401).send({ error: 'unauthorized' })
             } else {
-                // return done(new Error("Malformed authorization header"))
-                throw new Error('Malformed authorization header')
+                reply.code(401).send({ error: 'unauthorized' })
             }
         } else {
-            // done(new Error("Missing authorization header"))
-            throw new Error('Missing authorization header')
+            reply.code(401).send({ error: 'unauthorized' })
         }
     }
 
@@ -72,15 +70,11 @@ module.exports = fp(async function (app, opts, done) {
 
     app.decorate('verifyTokenOrSession', async function (request, reply) {
         // Order is important, other way round breaks nr-auth plugin
-        try {
-            if (request.sid) {
-                await verifySession(request, reply)
-            } else if (request.headers && request.headers.authorization) {
-                await verifyToken(request, reply)
-            } else if (!request.context.config.allowAnonymous) {
-                reply.code(401).send({ error: 'unauthorized' })
-            }
-        } catch (err) {
+        if (request.sid) {
+            await verifySession(request, reply)
+        } else if (request.headers && request.headers.authorization) {
+            await verifyToken(request, reply)
+        } else if (!request.context.config.allowAnonymous) {
             reply.code(401).send({ error: 'unauthorized' })
         }
     })

--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -31,9 +31,37 @@ describe('Storage API', function () {
     afterEach(async function () {
         await app.close()
     })
-
+    it('Rejects bad token', async function () {
+        const settingsURL = `/api/v1/projects/${app.project.id}/settings`
+        const response = await app.inject({
+            method: 'GET',
+            url: settingsURL,
+            headers: {
+                authorization: 'Bearer 123'
+            }
+        })
+        response.statusCode.should.equal(401)
+    })
+    it('Rejects missing token', async function () {
+        const settingsURL = `/api/v1/projects/${app.project.id}/settings`
+        const response = await app.inject({
+            method: 'GET',
+            url: settingsURL
+        })
+        response.statusCode.should.equal(401)
+    })
+    it('Rejects invalid project', async function () {
+        const settingsURL = '/api/v1/projects/123/settings'
+        const response = await app.inject({
+            method: 'GET',
+            url: settingsURL,
+            headers: {
+                authorization: `Bearer ${tokens.token}`
+            }
+        })
+        response.statusCode.should.equal(404)
+    })
     it('Get Settings', async function () {
-        this.timeout(10000)
         const settingsURL = `/api/v1/projects/${app.project.id}/settings`
         const response = await app.inject({
             method: 'GET',
@@ -48,7 +76,6 @@ describe('Storage API', function () {
     })
 
     it('Save Flow', async function () {
-        this.timeout(10000)
         const newFlow = [{ id: '1', type: 'tab', label: 'tab1', disabled: false, info: '' }]
         const flowURL = `/storage/${project.id}/flows`
         await app.inject({
@@ -71,7 +98,6 @@ describe('Storage API', function () {
     })
 
     it('Get Credentials', async function () {
-        this.timeout(10000)
         const credsURL = `/storage/${project.id}/credentials`
         const response = await app.inject({
             method: 'GET',
@@ -85,7 +111,6 @@ describe('Storage API', function () {
     })
 
     it('Save Credentials', async function () {
-        this.timeout(10000)
         const newCreds = [{ id: '1', type: 'tab', label: 'tab1', disabled: false, info: '' }]
         const credsURL = `/storage/${project.id}/credentials`
         await app.inject({
@@ -122,7 +147,6 @@ describe('Storage API', function () {
     })
 
     it('Save Settings', async function () {
-        this.timeout(10000)
         const newSettings = [{ id: '1', type: 'tab', label: 'tab1', disabled: false, info: '' }]
         const settingsURL = `/storage/${project.id}/settings`
         await app.inject({
@@ -160,7 +184,6 @@ describe('Storage API', function () {
     })
 
     it('Save Sessions', async function () {
-        this.timeout(10000)
         const newSessions = [{ id: '1', type: 'tab', label: 'tab1', disabled: false, info: '' }]
         const sessionURL = `/storage/${project.id}/sessions`
         await app.inject({
@@ -210,7 +233,6 @@ describe('Storage API', function () {
     })
 
     it('Add to Library with path', async function () {
-        this.timeout(10000)
         const funcText = '\nreturn msg;'
         const libraryURL = `/storage/${project.id}/library/functions`
         await app.inject({


### PR DESCRIPTION
If auth failed on the certain routes, we were getting:
```
[2022-07-29T08:54:31.962Z] WARN: Reply already sent {"reqId":"req-1"}
    err: {
      "type": "FastifyError",
      "message": "Reply was already sent.",
      "stack":
          FastifyError: Reply was already sent.
              at _Reply.Reply.send (/Users/nol/code/flowforge/flowforge/node_modules/fastify/lib/reply.js:128:26)
              at Object.verifyTokenOrSession (/Users/nol/code/flowforge/flowforge/forge/routes/auth/index.js:80:25)
      "name": "FastifyError",
      "code": "FST_ERR_REP_ALREADY_SENT",
      "statusCode": 500
    }
```

This was due to a mismatch in how `verifySession` and `verifyToken` handled auth failures.

`verifySession` would reply with the appropriate 401 and throw an error. `verifyToken` would only throw an error and rely on Fastify to send the error.

In the case of `verifyTokenOrSession`, it would catch the error throw by the upstream function and reply with a 401 - causing a duplicate response if it had gone via `verifySession`.

The `verifyToken` approach of leaving it to Fastify to return the error meant it was actually returning 500 errors, not 401.

This PR tidies it all up. `verifyToken` now explicitly responds with a 401 and `verifyTokenOrSession` doesn't duplicate the response.

Also added unit test coverage for auth failures in the storage api endpoints.