### PR TITLE
Add basic helmet config

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -8,6 +8,7 @@ const containers = require('./containers')
 const comms = require('./comms')
 const cookie = require('@fastify/cookie')
 const csrf = require('@fastify/csrf-protection')
+const helmet = require('@fastify/helmet')
 const postoffice = require('./postoffice')
 const monitor = require('./monitor')
 const ee = require('./ee')
@@ -59,6 +60,18 @@ module.exports = async (options = {}) => {
             secret: server.settings.get('cookieSecret')
         })
         await server.register(csrf, { cookieOpts: { _signed: true, _httpOnly: true } })
+        await server.register(helmet, {
+            global: true,
+            contentSecurityPolicy: false,
+            crossOriginEmbedderPolicy: false,
+            crossOriginOpenerPolicy: false,
+            crossOriginResourcePolicy: false,
+            hidePoweredBy: true,
+            hsts: false,
+            frameguard: {
+                action: 'deny'
+            }
+        })
 
         // Routes : the HTTP routes
         await server.register(routes, { logLevel: server.config.logging.http })

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@fastify/autoload": "^4.0.1",
         "@fastify/cookie": "^6.0.0",
         "@fastify/csrf-protection": "^4.0.1",
+        "@fastify/helmet": "8.1.0",
         "@fastify/static": "^5.0.2",
         "@flowforge/forge-ui-components": "^0.2.4",
         "@flowforge/localfs": "^0.7.0",


### PR DESCRIPTION
Uses:

 - global: applies to all routes
 - hidePoweredBy: don't advertise we are using fastify
 - frameguard: prevents iframe embedding

I've disabled the following to start with

 - contentSecurityPolicy
 - crossOriginEmbedderPolicy
 - crossOriginOpenerPolicy
 - crossOriginREsourcePolicy

Using @fastify/helmet 8.1.0 since 9.1.0 requires newer version of fastify