### PR TITLE
Prevent user with unverified email from accessing API

### DIFF
--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -5,7 +5,7 @@
  * @memberof forge.ee
  */
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifyTokenOrSession)
+    app.addHook('preHandler', app.verifySession)
     if (app.config.billing) {
         await app.register(require('./billing'), { prefix: '/billing', logLevel: 'warn' })
     }

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -29,7 +29,7 @@ module.exports = async function (app) {
      * The response will be a 200 if all is well.
      * If the snapshot doesn't match the target, it will get a 409 (conflict)
      */
-    app.post('/state', async (request, reply) => {
+    app.post('/state', { config: { allowToken: true } }, async (request, reply) => {
         await app.db.controllers.Device.updateState(request.device, request.body)
         if (Object.hasOwn(request.body, 'project') && request.body.project !== (request.device.Project?.id || null)) {
             reply.code(409).send({
@@ -61,7 +61,7 @@ module.exports = async function (app) {
         reply.code(200).send({})
     })
 
-    app.get('/state', async (request, reply) => {
+    app.get('/state', { config: { allowToken: true } }, async (request, reply) => {
         reply.send({
             project: request.device.Project?.id || null,
             snapshot: request.device.targetSnapshot?.hashid || null,
@@ -69,7 +69,7 @@ module.exports = async function (app) {
         })
     })
 
-    app.get('/snapshot', async (request, reply) => {
+    app.get('/snapshot', { config: { allowToken: true } }, async (request, reply) => {
         if (!request.device.targetSnapshot) {
             reply.send({})
         } else {
@@ -94,7 +94,7 @@ module.exports = async function (app) {
         }
     })
 
-    app.get('/settings', async (request, reply) => {
+    app.get('/settings', { config: { allowToken: true } }, async (request, reply) => {
         const response = {
             hash: request.device.settingsHash,
             env: {}

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -17,7 +17,7 @@ const Device = require('./device.js')
 const ProjectType = require('./projectType.js')
 
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifyTokenOrSession)
+    app.addHook('preHandler', app.verifySession)
     app.decorate('getPaginationOptions', (request, defaults) => {
         const result = { ...defaults }
         if (request.query.limit !== undefined) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -611,6 +611,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId/settings', {
+        config: { allowToken: true },
         preHandler: (request, reply, done) => {
             // check accessToken is project scope
             if (request.session.ownerType !== 'project') {

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -1,5 +1,5 @@
 module.exports = async function (app) {
-    app.get('/', { config: { allowAnonymous: true } }, async (request, reply) => {
+    app.get('/', { config: { allowAnonymous: true, allowUnverifiedEmail: true } }, async (request, reply) => {
         // This isn't as clean as I'd like, but it works for now.
         //
         // We return different things depending on the user session.

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -22,8 +22,27 @@ module.exports = async function (app) {
         if (request.params.teamId !== undefined) {
             if (request.params.teamId) {
                 try {
-                    // if User is not defined, check to see if request.context.config.allowAnonymous is set
-                    if (request.session?.User === undefined && request.context.config?.allowAnonymous === true) {
+                    if (!request.session.User) {
+                        // If request.session.User is not defined, this request is being
+                        // made with an access token. If it is a project access token,
+                        // ensure that project is in this team
+                        if (request.session.ownerType === 'project') {
+                            // Want this to be as small a query as possible. Sequelize
+                            // doesn't make it easy to just get `TeamId` without doing
+                            // a join on Team table.
+                            const project = await app.db.models.Project.findOne({
+                                where: { id: request.session.ownerId },
+                                include: {
+                                    model: app.db.models.Team,
+                                    attributes: ['hashid', 'id']
+                                }
+                            })
+                            // Ensure the token's project is in the team being accessed
+                            if (project && project.Team.hashid === request.params.teamId) {
+                                return
+                            }
+                        }
+                        reply.code(404).type('text/html').send('Not Found')
                         return
                     }
                     request.teamMembership = await request.session.User.getTeamMembership(request.params.teamId)
@@ -92,12 +111,13 @@ module.exports = async function (app) {
         }
     })
 
-    app.get('/:teamId/projects', { config: { allowAnonymous: true } }, async (request, reply) => {
+    app.get('/:teamId/projects', { config: { allowToken: true } }, async (request, reply) => {
         const projects = await app.db.models.Project.byTeam(request.params.teamId)
         if (projects) {
             let result = app.db.views.Project.teamProjectList(projects)
-            const limitResponse = request.session?.User === undefined
-            if (limitResponse) {
+            if (request.session.ownerType === 'project') {
+                // This request is from a project token. Filter the list to return
+                // the minimal information needed
                 result = result.map(e => {
                     return { id: e.id, name: e.name }
                 })

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -21,7 +21,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', { config: { allowUnverifiedEmail: true } }, async (request, reply) => {
         const users = await app.db.views.User.userProfile(request.session.User)
         reply.send(users)
     })

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -21,7 +21,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.get('/', { config: { allowUnverifiedEmail: true } }, async (request, reply) => {
+    app.get('/', { config: { allowUnverifiedEmail: true, allowToken: true } }, async (request, reply) => {
         const users = await app.db.views.User.userProfile(request.session.User)
         reply.send(users)
     })

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -68,17 +68,6 @@ module.exports = fp(async function (app, opts, done) {
 
     app.decorate('verifyToken', verifyToken)
 
-    app.decorate('verifyTokenOrSession', async function (request, reply) {
-        // Order is important, other way round breaks nr-auth plugin
-        if (request.sid) {
-            await verifySession(request, reply)
-        } else if (request.headers && request.headers.authorization) {
-            await verifyToken(request, reply)
-        } else if (!request.context.config.allowAnonymous) {
-            reply.code(401).send({ error: 'unauthorized' })
-        }
-    })
-
     /**
      * preHandler function that ensures the current request comes from an active
      * session.
@@ -101,6 +90,10 @@ module.exports = fp(async function (app, opts, done) {
             }
         }
         if (request.context.config.allowAnonymous) {
+            return
+        }
+        if (request.context.config.allowToken) {
+            await verifyToken(request, reply)
             return
         }
         reply.code(401).send({ error: 'unauthorized' })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,7 +15,7 @@
             </main>
         </template>
         <!-- Platform Entry Point -->
-        <template v-else-if="user && !user.password_expired">
+        <template v-else-if="user && !user.password_expired && user.email_verified">
             <ff-layout-platform>
                 <router-view></router-view>
             </ff-layout-platform>
@@ -23,6 +23,10 @@
         <!-- Password Reset Required -->
         <template v-else-if="user && user.password_expired">
             <PasswordExpired/>
+        </template>
+        <!-- Email Verification Required -->
+        <template v-else-if="user && !user.email_verified">
+            <UnverifiedEmail/>
         </template>
         <template v-else-if="!loginRequired">
             <router-view></router-view>
@@ -40,7 +44,7 @@ import Login from '@/pages/Login.vue'
 import Loading from '@/components/Loading'
 import Offline from '@/components/Offline'
 import PasswordExpired from '@/pages/PasswordExpired.vue'
-
+import UnverifiedEmail from '@/pages/UnverifiedEmail.vue'
 import FFLayoutPlatform from '@/layouts/Platform.vue'
 
 export default {
@@ -54,13 +58,13 @@ export default {
     components: {
         Login,
         PasswordExpired,
+        UnverifiedEmail,
         Loading,
         Offline,
         'ff-layout-platform': FFLayoutPlatform
     },
     mounted () {
         this.$store.dispatch('account/checkState')
-        this.$store.dispatch('account/countNotifications')
     }
 }
 </script>

--- a/frontend/src/pages/UnverifiedEmail.vue
+++ b/frontend/src/pages/UnverifiedEmail.vue
@@ -1,0 +1,45 @@
+<template>
+    <ff-layout-box>
+        <form class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6 max-w-md" @submit.prevent>
+            <p>
+                Before you can access the platform, we need to verify your email
+                address.
+            </p>
+            <p>
+                We sent you an email with a link to click when you signed up.
+            </p>
+            <ff-button :disabled="sent" @click="resend">
+                <span v-if="!sent">Resend email</span>
+                <span v-else>Sent</span>
+            </ff-button>
+        </form>
+    </ff-layout-box>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import userApi from '@/api/user'
+
+import FFLayoutBox from '@/layouts/Box'
+
+export default {
+    name: 'UnverifiedEmail',
+    methods: {
+        async resend () {
+            if (!this.sent) {
+                this.sent = true
+                await userApi.triggerVerification()
+            }
+        }
+    },
+    computed: mapState('account', ['user']),
+    data () {
+        return {
+            sent: false
+        }
+    },
+    components: {
+        'ff-layout-box': FFLayoutBox
+    }
+}
+</script>

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -144,14 +144,8 @@ const actions = {
 
             state.commit('setOffline', false)
 
-            // check notifications count
-            state.dispatch('countNotifications')
-
             const user = await userApi.getUser()
             state.commit('login', user)
-
-            const teams = await teamApi.getTeams()
-            state.commit('setTeams', teams.teams)
 
             if (router.currentRoute.value.meta.requiresLogin === false) {
                 // This is only for logged-out users
@@ -163,6 +157,12 @@ const actions = {
                 router.push({ name: 'Home' })
                 return
             }
+
+            // check notifications count
+            state.dispatch('countNotifications')
+
+            const teams = await teamApi.getTeams()
+            state.commit('setTeams', teams.teams)
 
             if (teams.count === 0) {
                 state.commit('clearPending')

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -36,7 +36,7 @@ describe('Device API', async function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')

--- a/test/unit/forge/routes/api/projectDevices_spec.js
+++ b/test/unit/forge/routes/api/projectDevices_spec.js
@@ -35,7 +35,7 @@ describe('Project/Device API', async function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')

--- a/test/unit/forge/routes/api/projectSnapshots_spec.js
+++ b/test/unit/forge/routes/api/projectSnapshots_spec.js
@@ -38,7 +38,7 @@ describe('Project Snapshots API', function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -37,7 +37,7 @@ describe('Project API', function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -20,7 +20,7 @@ describe('Team Invitations API', function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')

--- a/test/unit/forge/routes/api/teamMembers_spec.js
+++ b/test/unit/forge/routes/api/teamMembers_spec.js
@@ -20,7 +20,7 @@ describe('Team Members API', function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -12,7 +12,7 @@ describe('Team API', function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         TestObjects.tokens = {}
         await login('alice', 'aaPassword')

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -1,0 +1,92 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('User API', async function () {
+    let app
+    const TestObjects = {}
+
+    beforeEach(async function () {
+        app = await setup({ features: { devices: true } })
+
+        // alice : admin, team owner
+        // bob
+        // chris : (unverified_email)
+
+        // ATeam ( alice  (owner), bob (owner), chris)
+        // BTeam ( bob (owner), chris)
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword', admin: true })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam' })
+
+        // Alice set as ATeam owner in setup()
+        await TestObjects.ATeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+        await TestObjects.ATeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+        await TestObjects.BTeam.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+        await TestObjects.BTeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
+
+        TestObjects.tokens = {}
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('User settings', async function () {
+        it('returns 401 on /user if not logged in', async function () {
+            // await login('alice', 'aaPassword')
+            // await login('bob', 'bbPassword')
+            // await login('chris', 'ccPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/user'
+            })
+            response.statusCode.should.equal(401)
+        })
+        it('return user info for logged in user', async function () {
+            await login('alice', 'aaPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id', TestObjects.alice.hashid)
+            result.should.have.property('username', TestObjects.alice.username)
+            result.should.have.property('email', TestObjects.alice.email)
+        })
+        it('return user info for unverified_email user', async function () {
+            await login('chris', 'ccPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id', TestObjects.chris.hashid)
+            result.should.have.property('username', TestObjects.chris.username)
+            result.should.have.property('email', TestObjects.chris.email)
+            result.should.have.property('email_verified', false)
+        })
+    })
+})

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -22,8 +22,8 @@ describe('Users API', async function () {
         // Alice create in setup()
         TestObjects.alice = await app.db.models.User.byUsername('alice')
         TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword', admin: true })
-        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
-        TestObjects.dave = await app.db.models.User.create({ username: 'dave', name: 'Dave Vader', email: 'dave@example.com', password: 'ddPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
+        TestObjects.dave = await app.db.models.User.create({ username: 'dave', name: 'Dave Vader', email: 'dave@example.com', email_verified: true, password: 'ddPassword' })
 
         // ATeam create in setup()
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')


### PR DESCRIPTION
Fixes https://github.com/flowforge/security/issues/3

This restricts the admin api so users with unverified emails cannot call it.
It is possible to poke holes in the api for specific routes by adding `{ config: { allowUnverifiedEmail: true } }`

This also reworks the UX for such a user. It is now consistent with the 'expired password' ux - they don't get in to the platform to try doing anything:

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/51083/181771451-f131341e-9375-46dc-b3c7-f19b7110a9ef.png">
