### PR TITLE
Ensure access tokens can only access specific allowed routes

### DIFF
--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -5,7 +5,7 @@
  * @memberof forge.ee
  */
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifyTokenOrSession)
+    app.addHook('preHandler', app.verifySession)
     if (app.config.billing) {
         await app.register(require('./billing'), { prefix: '/billing', logLevel: 'warn' })
     }

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -29,7 +29,7 @@ module.exports = async function (app) {
      * The response will be a 200 if all is well.
      * If the snapshot doesn't match the target, it will get a 409 (conflict)
      */
-    app.post('/state', async (request, reply) => {
+    app.post('/state', { config: { allowToken: true } }, async (request, reply) => {
         await app.db.controllers.Device.updateState(request.device, request.body)
         if (Object.hasOwn(request.body, 'project') && request.body.project !== (request.device.Project?.id || null)) {
             reply.code(409).send({
@@ -61,7 +61,7 @@ module.exports = async function (app) {
         reply.code(200).send({})
     })
 
-    app.get('/state', async (request, reply) => {
+    app.get('/state', { config: { allowToken: true } }, async (request, reply) => {
         reply.send({
             project: request.device.Project?.id || null,
             snapshot: request.device.targetSnapshot?.hashid || null,
@@ -69,7 +69,7 @@ module.exports = async function (app) {
         })
     })
 
-    app.get('/snapshot', async (request, reply) => {
+    app.get('/snapshot', { config: { allowToken: true } }, async (request, reply) => {
         if (!request.device.targetSnapshot) {
             reply.send({})
         } else {
@@ -94,7 +94,7 @@ module.exports = async function (app) {
         }
     })
 
-    app.get('/settings', async (request, reply) => {
+    app.get('/settings', { config: { allowToken: true } }, async (request, reply) => {
         const response = {
             hash: request.device.settingsHash,
             env: {}

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -17,7 +17,7 @@ const Device = require('./device.js')
 const ProjectType = require('./projectType.js')
 
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifyTokenOrSession)
+    app.addHook('preHandler', app.verifySession)
     app.decorate('getPaginationOptions', (request, defaults) => {
         const result = { ...defaults }
         if (request.query.limit !== undefined) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -611,6 +611,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId/settings', {
+        config: { allowToken: true },
         preHandler: (request, reply, done) => {
             // check accessToken is project scope
             if (request.session.ownerType !== 'project') {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -115,8 +115,9 @@ module.exports = async function (app) {
         const projects = await app.db.models.Project.byTeam(request.params.teamId)
         if (projects) {
             let result = app.db.views.Project.teamProjectList(projects)
-            const limitResponse = request.session?.User === undefined
-            if (limitResponse) {
+            if (request.session.ownerType === 'project') {
+                // This request is from a project token. Filter the list to return
+                // the minimal information needed
                 result = result.map(e => {
                     return { id: e.id, name: e.name }
                 })

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -21,7 +21,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.get('/', { config: { allowUnverifiedEmail: true } }, async (request, reply) => {
+    app.get('/', { config: { allowUnverifiedEmail: true, allowToken: true } }, async (request, reply) => {
         const users = await app.db.views.User.userProfile(request.session.User)
         reply.send(users)
     })

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -68,17 +68,6 @@ module.exports = fp(async function (app, opts, done) {
 
     app.decorate('verifyToken', verifyToken)
 
-    app.decorate('verifyTokenOrSession', async function (request, reply) {
-        // Order is important, other way round breaks nr-auth plugin
-        if (request.sid) {
-            await verifySession(request, reply)
-        } else if (request.headers && request.headers.authorization) {
-            await verifyToken(request, reply)
-        } else if (!request.context.config.allowAnonymous) {
-            reply.code(401).send({ error: 'unauthorized' })
-        }
-    })
-
     /**
      * preHandler function that ensures the current request comes from an active
      * session.

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -103,6 +103,10 @@ module.exports = fp(async function (app, opts, done) {
         if (request.context.config.allowAnonymous) {
             return
         }
+        if (request.context.config.allowToken) {
+            await verifyToken(request, reply)
+            return
+        }
         reply.code(401).send({ error: 'unauthorized' })
         throw new Error()
     }


### PR DESCRIPTION
This removes `verifyTokenOrSession` as we want to be more deliberate and explicit over what routes can be accessed by a token, rather than a login session.

We have stories related to user-generated access tokens. When we come to them, we will need to carefully open it back up.

There are three sets of end points that need to be token-accessible:

 - `/api/v1/user` - used as part of `nr-auth` to get a user's identify when logging into node-red editor
 - `/api/v1/teams/<teamid>/projects` - used by Project Nodes to get a list of projects in the team. I've added logic to verify the token being used belongs to a project owned by the team it is accessing.
 - `/api/v1/devices/<device>/live/*` - used by device agent

I have verified all of those routes behave themselves with this change.