### PR TITLE
Remove all manual show/close logic for ff-dialog (now contained within the component)

### DIFF
--- a/frontend/src/pages/admin/ProjectTypes/dialogs/ProjectTypeDeleteDialog.vue
+++ b/frontend/src/pages/admin/ProjectTypes/dialogs/ProjectTypeDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Project Type" @close="close">
+    <ff-dialog ref="dialog" header="Delete Project Type" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="deleteDisabled">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -14,15 +14,10 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" :disabled="deleteDisabled" @click="confirm()">Delete</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 export default {
     name: 'ProjectTypeDeleteDialog',
@@ -37,21 +32,15 @@ export default {
         confirm () {
             if (!this.deleteDisabled) {
                 this.$emit('deleteProjectType', this.projectType)
-                this.isOpen = false
             }
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (projectType) {
+                this.$refs.dialog.show()
                 this.projectType = projectType
                 this.deleteDisabled = projectType.projectCount > 0
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/admin/ProjectTypes/dialogs/ProjectTypeEditDialog.vue
+++ b/frontend/src/pages/admin/ProjectTypes/dialogs/ProjectTypeEditDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" :header="dialogTitle" @close="close">
+    <ff-dialog ref="dialog" :header="dialogTitle" :confirm-label="projectType ? 'Update' : 'Create'" @confirm="confirm()" :disable-primary="!formValid">
         <template v-slot:default>
             <form class="space-y-6 mt-2" @submit.prevent>
                 <FormRow v-model="input.name" :error="errors.name">Name</FormRow>
@@ -32,21 +32,12 @@
                 </FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button :disabled="!formValid" class="ml-4" @click="confirm()">
-                <span v-if="projectType">Update</span>
-                <span v-else>Create</span>
-            </ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
 import projectTypesApi from '@/api/projectTypes'
 import stacksApi from '@/api/stacks'
-
-import { ref } from 'vue'
 
 import FormRow from '@/components/FormRow'
 import FormHeading from '@/components/FormHeading'
@@ -109,7 +100,6 @@ export default {
                     delete opts.properties
                     // Update
                     projectTypesApi.updateProjectType(this.projectType.id, opts).then((response) => {
-                        this.isOpen = false
                         this.$emit('projectTypeUpdated', response)
                     }).catch(err => {
                         console.log(err.response.data)
@@ -121,7 +111,6 @@ export default {
                     })
                 } else {
                     projectTypesApi.create(opts).then((response) => {
-                        this.isOpen = false
                         this.$emit('projectTypeCreated', response)
                     }).catch(err => {
                         console.log(err.response.data)
@@ -136,13 +125,9 @@ export default {
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (projectType) {
+                this.$refs.dialog.show()
                 this.projectType = projectType
                 this.stacks = []
                 if (projectType) {
@@ -167,7 +152,6 @@ export default {
                     this.input = { active: true, name: '', properties: {}, description: '', order: '1' }
                 }
                 this.errors = {}
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/admin/Stacks/dialogs/AdminStackDeleteDialog.vue
+++ b/frontend/src/pages/admin/Stacks/dialogs/AdminStackDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Stack" @close="close">
+    <ff-dialog ref="dialog" header="Delete Stack" kind="danger" confirm-label="Delete" @confirm="confirm" :disable-primary="deleteDisabled">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -14,16 +14,10 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" :disabled="deleteDisabled" @click="confirm()">Delete</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
-
 export default {
     name: 'AdminStackDeleteDialog',
     emits: ['deleteStack'],
@@ -37,21 +31,15 @@ export default {
         confirm () {
             if (!this.deleteDisabled) {
                 this.$emit('deleteStack', this.stack)
-                this.isOpen = false
             }
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (stack) {
+                this.$refs.dialog.show()
                 this.stack = stack
                 this.deleteDisabled = stack.projectCount > 0
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/admin/Template/dialogs/AdminTemplateSaveDialog.vue
+++ b/frontend/src/pages/admin/Template/dialogs/AdminTemplateSaveDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Update Template" @close="close">
+    <ff-dialog ref="dialog" header="Update Template" confirm-label="Save Template" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6">
                 <div class="space-y-2">
@@ -8,33 +8,22 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close">Cancel</ff-button>
-            <ff-button kind="primary" @click="confirm">Save Template</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 export default {
     name: 'AdminTemplateSaveDialog',
     methods: {
         confirm () {
             this.$emit('saveTemplate')
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show () {
-                isOpen.value = true
+                this.$refs.show()
             }
         }
     }

--- a/frontend/src/pages/admin/Templates/dialogs/AdminTemplateDeleteDialog.vue
+++ b/frontend/src/pages/admin/Templates/dialogs/AdminTemplateDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Stack" @close="close">
+    <ff-dialog ref="dialog" header="Delete Stack" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="deleteDisabled">
         <template v-slot:default>
             <form class="space-y-6">
                 <div class="mt-2 space-y-2">
@@ -14,15 +14,10 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close">Cancel</ff-button>
-            <ff-button kind="danger" class="ml-4" :disabled="deleteDisabled" @click="confirm">Delete</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 export default {
     name: 'AdminStackDeleteDialog',
@@ -35,20 +30,14 @@ export default {
     methods: {
         confirm () {
             this.$emit('deleteTemplate', this.template)
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (template) {
+                this.$refs.dialog.show()
                 this.template = template
                 this.deleteDisabled = template.projectCount > 0
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
+++ b/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog header="Delete Device" :open="isOpen">
+    <ff-dialog ref="dialog" header="Delete Device" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -14,15 +14,10 @@
                 <FormRow v-model="input.deviceName" id="deviceName">Name</FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import FormRow from '@/components/FormRow'
 
@@ -53,20 +48,14 @@ export default {
         confirm () {
             if (this.formValid) {
                 this.$emit('delete-device')
-                this.isOpen = false
             }
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (device) {
                 this.device = device
-                isOpen.value = true
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ChangeStackDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog header="Change Project Stack" :open="isOpen">
+    <ff-dialog ref="dialog" header="Change Project Stack" confirm-label="Change Stack" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <p >
@@ -8,15 +8,10 @@
                 <FormRow :options="stacks" v-model="input.stack">Stack</FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button class="ml-4" @click="confirm()">Change Stack</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import stacksApi from '@/api/stacks'
 
@@ -39,21 +34,14 @@ export default {
     methods: {
         confirm () {
             this.$emit('changeStack', this.input.stack)
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
-
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             async show (project) {
+                this.$refs.dialog.show()
                 this.project = project
                 this.input.stack = this.project.stack?.id
-                isOpen.value = true
                 const stackList = await stacksApi.getStacks(null, null, 'all', this.project.projectType?.id)
                 this.stacks = stackList.stacks
                     .filter(stack => (stack.active || stack.id === this.project.stack?.id))

--- a/frontend/src/pages/project/Settings/dialogs/ChangeTypeDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ChangeTypeDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog header="Change Project Type" :open="isOpen">
+    <ff-dialog ref="dialog" header="Change Project Type" :disable-primary="!formValid" confirm-label="Set Project Type" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <p>
@@ -18,15 +18,10 @@
                 </ul>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button class="ml-4" :disabled="!formValid" @click="confirm()">Set Project Type</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import projectTypesApi from '@/api/projectTypes'
 import ProjectTypeSummary from '../../../team/components/ProjectTypeSummary'
@@ -49,7 +44,6 @@ export default {
         confirm () {
             if (this.formValid) {
                 this.$emit('changeType', this.input.projectType)
-                this.isOpen = false
             }
         }
     },
@@ -59,17 +53,11 @@ export default {
         }
     },
     setup () {
-        const isOpen = ref(false)
-
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             async show (project) {
+                this.$refs.dialog.show()
                 this.project = project
                 this.input.projectType = this.project.projectType
-                isOpen.value = true
                 const projectTypes = await projectTypesApi.getProjectTypes()
                 this.projectTypes = projectTypes.types
             }

--- a/frontend/src/pages/project/Settings/dialogs/ConfirmProjectDeleteDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ConfirmProjectDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog header="Delete Project" :open="isOpen">
+    <ff-dialog ref="dialog" header="Delete Project" kind="danger" confirm-label="Delete" :disable-primary="!formValid" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -14,15 +14,10 @@
                 <FormRow v-model="input.projectName" id="projectName">Name</FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import FormRow from '@/components/FormRow'
 
@@ -52,20 +47,14 @@ export default {
         confirm () {
             if (this.formValid) {
                 this.$emit('deleteProject')
-                this.isOpen = false
             }
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (project) {
+                this.$refs.dialog.show()
                 this.project = project
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/project/Settings/dialogs/ExportProjectDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ExportProjectDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog header="Export Project" :open="isOpen">
+    <ff-dialog ref="dialog" header="Export Project" confirm-label="Export Project" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -10,15 +10,10 @@
                 <ExportProjectComponents id="exportSettings" v-model="parts" showSecret="true"/>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button class="ml-4" @click="confirm()">Export project</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 // import FormRow from '@/components/FormRow'
 import ExportProjectComponents from '../../components/ExportProjectComponents'
@@ -47,18 +42,12 @@ export default {
                 delete parts.credsSecret
             }
             this.$emit('exportProject', this.parts)
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
-
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             async show (project) {
+                this.$refs.dialog.show()
                 this.project = project
                 this.parts = {
                     flows: true,
@@ -67,7 +56,6 @@ export default {
                     envVars: true,
                     envVarsKo: false
                 }
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/project/Settings/dialogs/ExportToProjectDialog.vue
+++ b/frontend/src/pages/project/Settings/dialogs/ExportToProjectDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog header="Export to Existing Project" :open="isOpen">
+    <ff-dialog ref="dialog" header="Export to Existing Project" confirm-label="Export to Existing Project" :disable-primary="!exportEnabled" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <FormRow>
@@ -19,15 +19,10 @@
                 </FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button :disabled="!exportEnabled" class="ml-4" @click="confirm()">Export To Existing Project</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import teamApi from '@/api/team'
 
@@ -76,19 +71,13 @@ export default {
                     }
                 }
                 this.$emit('exportToProject', settings)
-                this.isOpen = false
             }
         }
     },
     setup () {
-        const isOpen = ref(false)
-
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             async show (project) {
+                this.$refs.dialog.show()
                 this.input.target = ''
                 this.input.exportConfirm = false
                 this.project = project
@@ -100,7 +89,6 @@ export default {
                     settings: false,
                     envVars: 'all'
                 }
-                isOpen.value = true
                 this.input.stack = this.project.stack.id
                 this.input.template = this.project.template.id
                 this.input.team = this.project.team.id
@@ -114,10 +102,6 @@ export default {
                         })
                     }
                 }
-
-                // setTimeout(() => {
-                //     this.input.target = this.projects.length > 0 ? this.projects[0].value : ''
-                // }, 100)
             }
         }
     }

--- a/frontend/src/pages/project/Snapshots/dialogs/ConfirmSnapshotDeleteDialog.vue
+++ b/frontend/src/pages/project/Snapshots/dialogs/ConfirmSnapshotDeleteDialog.vue
@@ -1,17 +1,12 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Snapshot">
+    <ff-dialog ref="dialog" header="Delete Snapshot" kind="danger" confirm-label="Delete" @confirm="confirm()">
         <template v-slot:default>
             Are you sure you want to delete this snapshot?
-        </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" class="ml-4" @click="confirm()">Delete</ff-button>
         </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts'
 
@@ -26,19 +21,13 @@ export default {
         confirm () {
             this.$emit('deleteSnapshot', this.snapshot)
             alerts.emit('Successfully deleted snapshot.', 'confirmation')
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (snapshot) {
                 this.snapshot = snapshot
-                isOpen.value = true
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/project/Snapshots/dialogs/ConfirmSnapshotRollbackDialog.vue
+++ b/frontend/src/pages/project/Snapshots/dialogs/ConfirmSnapshotRollbackDialog.vue
@@ -1,20 +1,15 @@
 <template>
-    <ff-dialog :open="isOpen" header="Rollback Snapshot">
+    <ff-dialog ref="dialog" header="Rollback Snapshot" confirm-label="Confirm Rollback" @confirm="confirm()">
         <template v-slot:default>
             <p>This rollback will overwrite the current project.</p>
             <p>All changes to the flows, settings and environment variables made since
                 the last snapshot will be lost.</p>
             <p>Are you sure you want to rollback to this snapshot?</p>
         </template>
-        <template v-slot:actions>
-            <ff-button ref="cancel" kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="primary" class="ml-4" @click="confirm()">Confirm Rollback</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 export default {
     name: 'ConfirmSnapshotRollbackDialog',
@@ -26,20 +21,13 @@ export default {
     methods: {
         confirm () {
             this.$emit('rollbackSnapshot', this.snapshot)
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (snapshot) {
+                this.$refs.dialog.show()
                 this.snapshot = snapshot
-                isOpen.value = true
-                this.$refs.cancel.$el.focus()
             }
         }
     }

--- a/frontend/src/pages/project/Snapshots/dialogs/ConfirmSnapshotTargetDialog.vue
+++ b/frontend/src/pages/project/Snapshots/dialogs/ConfirmSnapshotTargetDialog.vue
@@ -1,18 +1,13 @@
 <template>
-    <ff-dialog :open="isOpen" header="Set Device Target Snapshot">
+    <ff-dialog ref="dialog" header="Set Device Target Snapshot" confirm-label="Set Target" @confirm="confirm()">
         <template v-slot:default>
             <p>Are you sure you want to set this snapshot as the device target?</p>
             <p>All devices in this team will be restarted on this snapshot.</p>
-        </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="primary" class="ml-4" @click="confirm()">Set Target</ff-button>
         </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts'
 
@@ -27,19 +22,13 @@ export default {
         confirm () {
             this.$emit('targetSnapshot', this.snapshot)
             alerts.emit('Successfully set snapshot as device target.', 'confirmation')
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (snapshot) {
                 this.snapshot = snapshot
-                isOpen.value = true
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/project/Snapshots/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/project/Snapshots/dialogs/SnapshotCreateDialog.vue
@@ -1,18 +1,14 @@
 <template>
-    <ff-dialog :open="isOpen" header="Create Snapshot">
+    <ff-dialog ref="dialog" header="Create Snapshot" confirm-label="Create" :disable-primary="!formValid" @confirm="confirm()">
         <template v-slot:default>
             <form class="space-y-6 mt-2" @submit.prevent>
                 <FormRow v-model="input.name" :error="errors.name">Name</FormRow>
                 <FormRow>Description
-                    <template #input><textarea v-model="input.description" rows="8" class="ff-input ff-text-input" style="height: auto"></textarea></template>
+                    <template #input>
+                        <textarea v-model="input.description" rows="8" class="ff-input ff-text-input" style="height: auto"></textarea>
+                    </template>
                 </FormRow>
             </form>
-        </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button class="ml-4" :disabled="!formValid" @click="confirm()">
-                <span>Create</span>
-            </ff-button>
         </template>
     </ff-dialog>
 </template>
@@ -22,8 +18,6 @@
 import snapshotApi from '@/api/projectSnapshots'
 
 import alerts from '@/services/alerts'
-
-import { ref } from 'vue'
 
 import FormRow from '@/components/FormRow'
 
@@ -60,7 +54,6 @@ export default {
                     description: this.input.description
                 }
                 snapshotApi.create(this.project.id, opts).then((response) => {
-                    this.isOpen = false
                     this.$emit('snapshotCreated', response)
                     alerts.emit('Successfully created snapshot of project.', 'confirmation')
                 }).catch(err => {
@@ -75,18 +68,13 @@ export default {
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show () {
+                this.$refs.dialog.show()
                 this.input.name = ''
                 this.input.description = ''
                 this.submitted = false
                 this.errors = {}
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/team/Devices/dialogs/ConfirmDeviceDeleteDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ConfirmDeviceDeleteDialog.vue
@@ -1,17 +1,12 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Device">
+    <ff-dialog ref="dialog" header="Delete Device" kind="danger" confirm-label="Delete" @confirm="confirm()">
         <template v-slot:default>
             Are you sure you want to delete this device? Once deleted, there is no going back.
-        </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" class="ml-4" @click="confirm()">Delete</ff-button>
         </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts'
 
@@ -26,19 +21,13 @@ export default {
         confirm () {
             this.$emit('deleteDevice', this.device)
             alerts.emit('Successfully deleted the device.', 'confirmation')
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (device) {
                 this.device = device
-                isOpen.value = true
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/team/Devices/dialogs/ConfirmDeviceUnassignDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ConfirmDeviceUnassignDialog.vue
@@ -1,18 +1,13 @@
 <template>
-    <ff-dialog :open="isOpen" header="Remove Device from Project">
+    <ff-dialog ref="dialog" header="Remove Device from Project" kind="danger" confirm-label="Remove" @confirm="confirm()">
         <template v-slot:default>
             Are you sure you want to remove this device from the project? This will stop the project
             running on the device.
-        </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" class="ml-4" @click="confirm()">Remove</ff-button>
         </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts'
 
@@ -27,19 +22,13 @@ export default {
         confirm () {
             this.$emit('unassignDevice', this.device)
             alerts.emit('Successfully unassigned the project from this device.', 'confirmation')
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (device) {
                 this.device = device
-                isOpen.value = true
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/team/Devices/dialogs/DeviceAssignProjectDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceAssignProjectDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Add Device to Project">
+    <ff-dialog ref="dialog" header="Add Device to Project" confirm-label="Add" @confirm="assignDevice()">
         <template v-slot:default>
             <form class="space-y-6 mt-2 mb-2">
                 <p class="text-sm text-gray-500">
@@ -8,17 +8,12 @@
                 <FormRow :options="projects" v-model="input.project">Project</FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button class="ml-4" @click="assignDevice()">Add</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
 // import devicesApi from '@/api/devices'
 
-import { ref } from 'vue'
 import teamApi from '@/api/team'
 import alerts from '@/services/alerts'
 import FormRow from '@/components/FormRow'
@@ -41,20 +36,14 @@ export default {
         assignDevice () {
             this.$emit('assignDevice', this.device, this.input.project)
             alerts.emit('Device successfully assigned to project.', 'confirmation')
-            this.close()
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             async show (device) {
+                this.$refs.dialog.show()
                 this.device = device
                 this.projects = []
-                isOpen.value = true
 
                 const result = await teamApi.getTeamProjects(this.team.id)
                 this.projects = result.projects.map(d => { return { value: d.id, label: d.name } })

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Device Credentials">
+    <ff-dialog ref="dialog" header="Device Credentials">
         <template v-slot:default>
             <form class="space-y-6 mt-2">
                 <template v-if="!hasCredentials">
@@ -37,7 +37,6 @@
 <script>
 // import devicesApi from '@/api/devices'
 
-import { ref } from 'vue'
 import { mapState } from 'vuex'
 import deviceApi from '@/api/devices'
 
@@ -68,7 +67,7 @@ export default {
             this.device.credentials = creds
         },
         close () {
-            this.isOpen = false
+            this.$refs.dialog.close()
             this.device.credentials = undefined
         }
     },
@@ -96,12 +95,10 @@ brokerPassword: ${this.device.credentials.broker.password}
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
             show (device) {
+                this.$refs.dialog.show()
                 this.device = device
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -1,17 +1,11 @@
 <template>
-    <ff-dialog :open="isOpen" :header="device?'Update Device':'Register Device'">
+    <ff-dialog ref="dialog" :header="device ? 'Update Device' : 'Register Device'"
+               :confirm-label="device ? 'Update' : 'Register'" @confirm="confirm()" :disable-primary="!formValid">
         <template v-slot:default>
             <form class="space-y-6 mt-2">
                 <FormRow v-model="input.name" :error="errors.name" :disabled="editDisabled">Name</FormRow>
                 <FormRow v-model="input.type" :error="errors.type" :disabled="editDisabled">Type</FormRow>
             </form>
-        </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button :disabled="!formValid" class="ml-4" @click="confirm()">
-                <span v-if="device">Update</span>
-                <span v-else>Register</span>
-            </ff-button>
         </template>
     </ff-dialog>
 </template>
@@ -21,8 +15,6 @@
 import devicesApi from '@/api/devices'
 
 import alerts from '@/services/alerts'
-
-import { ref } from 'vue'
 
 import FormRow from '@/components/FormRow'
 
@@ -62,7 +54,6 @@ export default {
             if (this.device) {
                 // Update
                 devicesApi.updateDevice(this.device.id, opts).then((response) => {
-                    this.isOpen = false
                     this.$emit('deviceUpdated', response)
                     alerts.emit('Device successfully updated.', 'confirmation')
                 }).catch(err => {
@@ -77,7 +68,6 @@ export default {
                 opts.team = this.team.id
                 devicesApi.create(opts).then((response) => {
                     if (!this.project) {
-                        this.isOpen = false
                         this.$emit('deviceCreated', response)
                         alerts.emit('Device successfully created.', 'confirmation')
                     } else {
@@ -86,7 +76,6 @@ export default {
                         //       in the project directly? Currently done as a two
                         //       step process
                         return devicesApi.updateDevice(response.id, { project: this.project.id }).then((response) => {
-                            this.isOpen = false
                             // Reattach the credentials from the create request
                             // so they can be displayed to the user
                             response.credentials = creds
@@ -106,13 +95,9 @@ export default {
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (device, project) {
+                this.$refs.dialog.show()
                 this.project = project
                 this.device = device
                 if (device) {
@@ -125,7 +110,6 @@ export default {
                     this.input = { name: '', type: '' }
                 }
                 this.errors = {}
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
+++ b/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Change Role" @close="close">
+    <ff-dialog ref="dialog" header="Change Role" confirm-label="Change" @confirm="confirm()" :disable-primary="ownerCount < 2 && isOwner">
         <template v-slot:default v-if="user">
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -21,15 +21,10 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" class="ml-4" @click="close()">Cancel</ff-button>
-            <ff-button :disabled="ownerCount < 2 && isOwner" class="ml-4" @click="confirm()">Change</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts'
 
@@ -66,7 +61,6 @@ export default {
                 } catch (err) {
                     console.warn(err)
                 }
-                this.isOpen = false
             }
         }
     },
@@ -76,18 +70,13 @@ export default {
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (team, user, ownerCount) {
+                this.$refs.dialog.show()
                 this.team = team
                 this.ownerCount = ownerCount
                 this.user = user
                 this.input.role = user.role
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Delete Team" @close="close">
+    <ff-dialog ref="dialog" header="Delete Team" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
         <template v-slot:default>
             <form class="space-y-6" v-if="team" @submit.prevent>
                 <div class="space-y-6">
@@ -13,15 +13,10 @@
                 <FormRow v-model="input.teamName" id="projectName">Name</FormRow>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" :disabled="!formValid" class="ml-4" @click="confirm()">Delete</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts.js'
 
@@ -50,19 +45,13 @@ export default {
         confirm () {
             this.$emit('deleteTeam')
             alerts.emit('Team successfully deleted', 'confirmation')
-            this.isOpen = false
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (team) {
                 this.team = team
-                isOpen.value = true
+                this.$refs.dialog.show()
             }
         }
     }

--- a/frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Remove User" @close="close">
+    <ff-dialog ref="dialog" header="Remove User" kind="danger" confirm-label="Remove" @confirm="confirm()" :disable-primary="disableConfirm">
         <template v-slot:default v-if="user">
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
@@ -15,15 +15,10 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" class="forge-button-secondary ml-4" @click="close()">Cancel</ff-button>
-            <ff-button kind="danger" :disabled="disableConfirm" class="ml-4" @click="confirm()">Remove</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 
 import alerts from '@/services/alerts'
 import teamApi from '@/api/team'
@@ -47,7 +42,6 @@ export default {
                 } catch (err) {
                     console.warn(err)
                 }
-                this.isOpen = false
             }
         }
     },
@@ -57,17 +51,12 @@ export default {
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show (team, user, ownerCount) {
+                this.$refs.dialog.show()
                 this.user = user
                 this.team = team
                 this.ownerCount = ownerCount
-                isOpen.value = true
             }
         }
     }

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disabledConfirm">
+    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disableConfirm">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="space-y-2">

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog :open="isOpen" header="Invite Team Member" @close="close">
+    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disabledConfirm">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="space-y-2">
@@ -17,15 +17,10 @@
                 </div>
             </form>
         </template>
-        <template v-slot:actions>
-            <ff-button kind="secondary" @click="close">Cancel</ff-button>
-            <ff-button :disabled="disabledConfirm" class="ml-4" @click="confirm">Invite</ff-button>
-        </template>
     </ff-dialog>
 </template>
 
 <script>
-import { ref } from 'vue'
 import { mapState } from 'vuex'
 import FormRow from '@/components/FormRow'
 import teamApi from '@/api/team'
@@ -80,26 +75,19 @@ export default {
                 } else {
                     alerts.emit('Invite sent to ' + this.input.userInfo, 'confirmation')
                     this.$emit('invitationSent')
-                    this.isOpen = false
                 }
             } catch (err) {
                 console.warn(err)
-                this.isOpen = false
             }
         }
     },
     setup () {
-        const isOpen = ref(false)
         return {
-            isOpen,
-            close () {
-                isOpen.value = false
-            },
             show () {
+                this.$refs.dialog.show()
                 this.responseErrors = null
                 this.input.userInfo = ''
                 this.errors.userInfo = null
-                isOpen.value = true
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@fastify/cookie": "^6.0.0",
         "@fastify/csrf-protection": "^4.0.1",
         "@fastify/static": "^5.0.2",
-        "@flowforge/forge-ui-components": "^0.2.4",
+        "@flowforge/forge-ui-components": "^0.3.0",
         "@flowforge/localfs": "^0.7.0",
         "@headlessui/vue": "1.6.3",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
Requires latest forge-ui-components to test locally. Will be releasing new forge-ui-components major version.

This is the first step in updating our dialog workflow. This PR utilises the fact that the internals of `ff-dialog` now better handle the show/close logic and provide control over the default cancel/confirm buttons via properties, rather than having to manually template it each time.

Future work to do here still in making a single JS API that allows devs to call single line or two to open and action a dialog. Discussion on full plans in https://github.com/flowforge/flowforge/issues/830