### PR TITLE
Ensure expired password users cannot access API

### DIFF
--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -21,7 +21,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.get('/', { config: { allowUnverifiedEmail: true, allowToken: true } }, async (request, reply) => {
+    app.get('/', { config: { allowUnverifiedEmail: true, allowToken: true, allowExpiredPassword: true } }, async (request, reply) => {
         const users = await app.db.views.User.userProfile(request.session.User)
         reply.send(users)
     })
@@ -33,6 +33,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.user
      */
     app.put('/change_password', {
+        config: { allowExpiredPassword: true },
         schema: {
             body: {
                 type: 'object',

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -87,6 +87,9 @@ module.exports = fp(async function (app, opts, done) {
                 if (!app.postoffice.enabled() || request.session.User.email_verified || request.context.config.allowUnverifiedEmail) {
                     return
                 }
+                if (!request.session.User.password_expired || request.context.config.allowExpiredPassword) {
+                    return
+                }
             }
         }
         if (request.context.config.allowAnonymous) {

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -84,10 +84,9 @@ module.exports = fp(async function (app, opts, done) {
         if (request.sid) {
             request.session = await app.db.controllers.Session.getOrExpire(request.sid)
             if (request.session && request.session.User) {
-                if (!app.postoffice.enabled() || request.session.User.email_verified || request.context.config.allowUnverifiedEmail) {
-                    return
-                }
-                if (!request.session.User.password_expired || request.context.config.allowExpiredPassword) {
+                const emailVerified = !app.postoffice.enabled() || request.session.User.email_verified || request.context.config.allowUnverifiedEmail
+                const passwordNotExpired = !request.session.User.password_expired || request.context.config.allowExpiredPassword
+                if (emailVerified && passwordNotExpired) {
                     return
                 }
             }

--- a/frontend/src/components/auth/UpdateExpiredPassword.vue
+++ b/frontend/src/components/auth/UpdateExpiredPassword.vue
@@ -1,9 +1,9 @@
 <template>
-    <form class="space-y-6">
+    <form class="space-y-6" ref="password_form">
         <div>You must set a new password before continuing</div>
-        <FormRow type="password" :onEnter="focusPassword" :error="errors.old_password" v-model="input.old_password" id="old_password">Old Password</FormRow>
-        <FormRow type="password" :onEnter="focusConfirmPassword" :error="errors.password" v-model="input.password" id="password">New Password</FormRow>
-        <FormRow type="password" :onEnter="changePassword" :error="errors.password_confirm" v-model="input.password_confirm" id="password_confirm">Confirm</FormRow>
+        <FormRow type="password" :onEnter="focusPassword" :error="errors.old_password" v-model="input.old_password">Old Password</FormRow>
+        <FormRow type="password" :onEnter="focusConfirmPassword" :error="errors.password" v-model="input.password">New Password</FormRow>
+        <FormRow type="password" :onEnter="changePassword" :error="errors.password_confirm" v-model="input.password_confirm">Confirm</FormRow>
         <ff-button @click="changePassword">
             Change Password
         </ff-button>
@@ -64,17 +64,19 @@ export default {
             })
         },
         focusOldPassword () {
-            document.getElementById('old_password').focus()
+            this.$refs.password_form.querySelectorAll('input')[0].focus()
         },
         focusPassword () {
-            document.getElementById('password').focus()
+            this.$refs.password_form.querySelectorAll('input')[1].focus()
         },
         focusConfirmPassword () {
-            document.getElementById('password_confirm').focus()
+            this.$refs.password_form.querySelectorAll('input')[2].focus()
         }
     },
     mounted () {
-        this.focusOldPassword()
+        setTimeout(() => {
+            this.focusOldPassword()
+        }, 50)
     },
     watch: {
         loginError (newError, oldError) {

--- a/frontend/src/components/auth/UpdateExpiredPassword.vue
+++ b/frontend/src/components/auth/UpdateExpiredPassword.vue
@@ -7,6 +7,7 @@
         <ff-button @click="changePassword">
             Change Password
         </ff-button>
+        <ff-button kind="tertiary" @click="logout">Log out</ff-button>
         <div v-if="errors.password_change" class="ml-4 text-red-400 font-medium inline text-sm">{{errors.password_change}}</div>
     </form>
 </template>
@@ -15,6 +16,7 @@
 import { mapState } from 'vuex'
 import FormRow from '@/components/FormRow'
 import userApi from '@/api/user'
+import store from '@/store'
 
 export default {
     name: 'UpdateExpiredPassword',
@@ -71,6 +73,9 @@ export default {
         },
         focusConfirmPassword () {
             this.$refs.password_form.querySelectorAll('input')[2].focus()
+        },
+        logout () {
+            store.dispatch('account/logout')
         }
     },
     mounted () {

--- a/frontend/src/pages/UnverifiedEmail.vue
+++ b/frontend/src/pages/UnverifiedEmail.vue
@@ -12,6 +12,7 @@
                 <span v-if="!sent">Resend email</span>
                 <span v-else>Sent</span>
             </ff-button>
+            <ff-button kind="tertiary" @click="logout">Log out</ff-button>
         </form>
     </ff-layout-box>
 </template>
@@ -19,6 +20,7 @@
 <script>
 import { mapState } from 'vuex'
 import userApi from '@/api/user'
+import store from '@/store'
 
 import FFLayoutBox from '@/layouts/Box'
 
@@ -30,6 +32,9 @@ export default {
                 this.sent = true
                 await userApi.triggerVerification()
             }
+        },
+        logout () {
+            store.dispatch('account/logout')
         }
     },
     computed: mapState('account', ['user']),

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -152,7 +152,7 @@ const actions = {
                 window.location = '/'
                 return
             }
-            if (user.email_verified === false) {
+            if (user.email_verified === false || user.password_expired) {
                 state.commit('clearPending')
                 router.push({ name: 'Home' })
                 return

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -78,7 +78,7 @@ describe('User API', async function () {
             result.should.have.property('username', TestObjects.alice.username)
             result.should.have.property('email', TestObjects.alice.email)
         })
-        describe('Unverified Email', async function  () {
+        describe('Unverified Email', async function () {
             it('return user info for unverified_email user', async function () {
                 await login('chris', 'ccPassword')
                 const response = await app.inject({

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -36,6 +36,8 @@ describe('User API', async function () {
         await TestObjects.BTeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
         await TestObjects.BTeam.addUser(TestObjects.dave, { through: { role: Roles.Member } })
 
+        TestObjects.Project1 = app.project
+
         TestObjects.tokens = {}
     })
 
@@ -103,6 +105,13 @@ describe('User API', async function () {
                     cookies: { sid: TestObjects.tokens.chris }
                 })
                 response.statusCode.should.equal(401)
+
+                const response2 = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${TestObjects.Project1.id}`,
+                    cookies: { sid: TestObjects.tokens.chris }
+                })
+                response2.statusCode.should.equal(401)
             })
         })
         describe('Password Expired', async function () {
@@ -146,6 +155,13 @@ describe('User API', async function () {
                     cookies: { sid: TestObjects.tokens.dave }
                 })
                 response.statusCode.should.equal(401)
+
+                const response2 = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${TestObjects.Project1.id}`,
+                    cookies: { sid: TestObjects.tokens.dave }
+                })
+                response2.statusCode.should.equal(401)
             })
         })
     })

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -120,6 +120,22 @@ describe('User API', async function () {
                 result.should.have.property('email', TestObjects.dave.email)
                 result.should.have.property('password_expired', true)
             })
+            it('password_expired user can change password', async function () {
+                await login('dave', 'ddPassword')
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: '/api/v1/user/change_password',
+                    payload: {
+                        old_password: 'ddPassword',
+                        password: 'newDDPassword'
+                    },
+                    cookies: { sid: TestObjects.tokens.dave }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('status', 'okay')
+            })
+
             it('cannot access other parts of api', async function () {
                 // Not an exhaustive check by any means, but a simple check the
                 // basic blocking is working


### PR DESCRIPTION
 - Adds `allowExpiredPassword` flag for API routes that should be accessible to users with expired passwords.
 - Blocks access to all api end points otherwise
 - Opens access to `/api/v1/user` and `/api/v1/user/change_password`
 - Fixes a focus issue in the Change Password dialog
 - Adds a 'logout' option to both the Change Password and Verify Email dialogs - so users don't get stuck in them

<img width="543" alt="image" src="https://user-images.githubusercontent.com/51083/182584562-84086e41-22b9-4a7f-bdfd-e9cc36c4dba2.png">
