### PR TITLE
Fix loading of default team when logging in

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -48,14 +48,6 @@ export default {
                             team_slug: this.team.slug
                         }
                     })
-                } else if (this.teams && this.teams.length > 0) {
-                    this.$store.dispatch('account/setTeam', this.teams[0])
-                    this.$router.push({
-                        name: 'Team',
-                        params: {
-                            team_slug: this.teams[0].slug
-                        }
-                    })
                 }
             }
         }


### PR DESCRIPTION
When logging in with a default team set, we see the URL update to show the default team, but the page content still showed the first team's details.

I've tracked this down to a bit of code in the Home component, that tries to redirect the user from `/` to the appropriate team url. When first logging in, there is a window where `team` is not yet defined, but `teams` is - and the code picks the first team in the list to redirect to.

This logic was added by me last year - https://github.com/flowforge/flowforge/pull/65 - to fix 'redirect to team page on login'.

How the team is identified and loaded has evolved since then. The `account` component takes care of setting things properly. I believe it is safe to remove this bit of code. My testing locally shows it resolves the default team issue identified on staging today, and having tried various scenarios, I do not see any other regression in behaviour.

Tested with:

 - User with a default team set
 - User without a default team set
 - User who isn't a member of any team