### PR TITLE
Permit login with `username` or `email`

### DIFF
--- a/forge/db/controllers/Session.js
+++ b/forge/db/controllers/Session.js
@@ -8,9 +8,7 @@ module.exports = {
      * Create a new session for the given username
      */
     createUserSession: async function (app, username) {
-        const user = await app.db.models.User.findOne({
-            where: { username: username }
-        })
+        const user = await app.db.models.User.byUsernameOrEmail(username)
         if (user) {
             return app.db.models.Session.create({
                 sid: generateToken(32, 'ffu'),
@@ -25,9 +23,7 @@ module.exports = {
      * Create a new oauth session for the given username
      */
     createTokenSession: async function (app, username) {
-        const user = await app.db.models.User.findOne({
-            where: { username: username }
-        })
+        const user = await app.db.models.User.byUsernameOrEmail(username)
         if (user) {
             const session = {
                 sid: generateToken(32, 'ffp'),

--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -6,8 +6,12 @@ module.exports = {
      * Validate the username/password
      */
     authenticateCredentials: async function (app, username, password) {
+        let clause = { username: username }
+        if (/.+@.+/.test(username)) {
+            clause = { email: username }
+        }
         const user = await app.db.models.User.findOne({
-            where: { username: username },
+            where: clause,
             attributes: ['password']
         })
         // Always call compareSync, even if no user found, to ensure

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -143,10 +143,12 @@ module.exports = {
                     })
                 },
                 byUsernameOrEmail: async (name) => {
+                    let clause = { username: name }
+                    if (/.+@.+/.test(name)) {
+                        clause = { email: name }
+                    }
                     return this.findOne({
-                        where: {
-                            [Op.or]: [{ username: name }, { email: name }]
-                        },
+                        where: clause,
                         include: {
                             model: M.Team,
                             attributes: ['name'],

--- a/frontend/src/components/auth/Credentials.vue
+++ b/frontend/src/components/auth/Credentials.vue
@@ -53,10 +53,6 @@ export default {
                 valid = false
                 this.errors.password = 'Required field'
             }
-            if (this.input.username.includes('@')) {
-                valid = false
-                this.errors.username = 'Username cannot be an email address'
-            }
             if (valid) {
                 this.$store.dispatch('account/login', this.input)
             }

--- a/test/unit/forge/db/controllers/User_spec.js
+++ b/test/unit/forge/db/controllers/User_spec.js
@@ -28,6 +28,21 @@ describe('User controller', function () {
             const result = await app.db.controllers.User.authenticateCredentials('invalid', 'invalid')
             result.should.be.false()
         })
+
+        it('returns true for a valid email/password', async function () {
+            const result = await app.db.controllers.User.authenticateCredentials('alice@example.com', 'aaPassword')
+            result.should.be.true()
+        })
+
+        it('returns false for valid email/invalid password', async function () {
+            const result = await app.db.controllers.User.authenticateCredentials('alice@example.com', 'invalid')
+            result.should.be.false()
+        })
+
+        it('returns false for invalid email/password', async function () {
+            const result = await app.db.controllers.User.authenticateCredentials('alice@invalid.com', 'invalid')
+            result.should.be.false()
+        })
     })
 
     describe('changePassword', function () {


### PR DESCRIPTION
fixes #705

Allow a user to sign in to FF platform using Username (current functionality) or Email address (new functionality) 