### PR TITLE
Always respond to stripe webhooks with 200 status unless fatal

### DIFF
--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -65,7 +65,7 @@ module.exports = async function (app) {
                 try {
                     event = stripe.webhooks.constructEvent(request.rawBody, sig, app.config.billing.stripe.wh_secret)
                 } catch (err) {
-                    console.log(err)
+                    app.log.error(`Stripe event failed signature: ${err.toString()}`)
                     response.code(400).type('text/hml').send('Failed Signature')
                     return
                 }
@@ -78,7 +78,8 @@ module.exports = async function (app) {
             if (teamId) {
                 team = await app.db.models.Team.byId(teamId)
                 if (!team) {
-                    response.status(404).type('text/html').send('Not Found')
+                    app.log.error(`Stripe event received for unknown team '${teamId}'`)
+                    response.status(200).send()
                     return
                 }
             } else {
@@ -87,7 +88,8 @@ module.exports = async function (app) {
                     team = sub?.Team
                 }
                 if (!team) {
-                    response.status(404).type('text/html').send('Not Found')
+                    app.log.error(`Stripe event received for unknown customer '${customer}'`)
+                    response.status(200).send()
                     return
                 }
             }

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -69,7 +69,7 @@ describe('Stripe Callbacks', function () {
                 type: 'charge.failed'
             }
         })
-        should(response).have.property('statusCode', 404)
+        should(response).have.property('statusCode', 200)
     })
 
     it('Recieve checkout.session.completed callback', async function () {


### PR DESCRIPTION
Fixes #862 

This ensures stripe won't keep retrying webhook calls for teams that don't exist.