### PR TITLE
Add billingEnabled flag to team api response to save subscription check

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -67,7 +67,7 @@ module.exports = async function (app) {
         const result = app.db.views.Team.team(team)
         if (app.license.active() && app.billing) {
             const subscription = await app.db.models.Subscription.byTeam(team.id)
-            result.billingEnabled = !!subscription
+            result.billingSetup = !!subscription
         }
         reply.send(result)
     }

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -91,7 +91,7 @@ export default {
     watch: { },
     async mounted () {
         this.loading = true
-        if (!this.team.billingEnabled) {
+        if (!this.team.billingSetup) {
             this.loading = false
         } else {
             try {

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -87,7 +87,6 @@
 <script>
 import { mapState } from 'vuex'
 
-import teamApi from '@/api/team'
 import projectApi from '@/api/project'
 import projectTypesApi from '@/api/projectTypes'
 import stacksApi from '@/api/stacks'
@@ -101,7 +100,6 @@ import SideNavigation from '@/components/SideNavigation'
 import FormRow from '@/components/FormRow'
 import NameGenerator from '@/utils/name-generator'
 import { RefreshIcon } from '@heroicons/vue/outline'
-import { Roles } from '@core/lib/roles'
 
 import ExportProjectComponents from '../project/components/ExportProjectComponents'
 
@@ -119,15 +117,12 @@ export default {
                 chevronLeft: ChevronLeftIcon
             },
             init: false,
-            currentTeam: null,
-            teams: [],
             stacks: [],
             templates: [],
             projectTypes: [],
             billingDescription: '',
             input: {
                 name: NameGenerator(),
-                team: '',
                 stack: '',
                 template: '',
                 billingConfirmation: false,
@@ -152,7 +147,7 @@ export default {
             return !!this.sourceProjectId
         },
         createEnabled () {
-            return this.input.stack && this.input.team && this.input.name && !this.errors.name && this.input.template && (this.features.billing ? this.input.billingConfirmation : true)
+            return this.input.stack && this.input.name && !this.errors.name && this.input.template && (this.features.billing ? this.input.billingConfirmation : true)
         }
     },
     watch: {
@@ -184,24 +179,6 @@ export default {
         }
     },
     async created () {
-        const data = await teamApi.getTeams()
-        const filteredTeams = []
-
-        data.teams.forEach((t) => {
-            if (t.role !== Roles.Owner) {
-                return
-            }
-            if (t.slug === this.$route.params.team_slug) {
-                this.currentTeam = t.id
-            }
-            filteredTeams.push({ value: t.id, label: t.name })
-        })
-
-        if (this.currentTeam == null && filteredTeams.length > 0) {
-            this.currentTeam = filteredTeams[0].value
-        }
-        this.teams = filteredTeams
-
         const projectTypes = await projectTypesApi.getProjectTypes()
         this.projectTypes = projectTypes.types
 
@@ -213,7 +190,6 @@ export default {
         setTimeout(() => {
             // There must be a better Vue way of doing this, but I can't find it.
             // Without the setTimeout, the select box doesn't update
-            this.input.team = this.currentTeam
 
             if (this.projectTypes.length === 0) {
                 this.errors.projectTypes = 'No project types available. Ask an Administrator to create a new project type'
@@ -228,6 +204,13 @@ export default {
                 this.errors.template = 'No templates available. Ask an Administator to create a new template definition'
             }
         }, 100)
+    },
+    async beforeMount () {
+        if (this.features.billing && !this.team.billingEnabled) {
+            this.$router.push({
+                path: `/team/${this.team.slug}/billing`
+            })
+        }
     },
     mounted () {
         this.mounted = true
@@ -244,7 +227,7 @@ export default {
     methods: {
         createProject () {
             this.loading = true
-            const createPayload = { ...this.input }
+            const createPayload = { ...this.input, team: this.team.id }
             if (this.isCopyProject) {
                 createPayload.sourceProject = {
                     id: this.sourceProjectId,

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -206,7 +206,7 @@ export default {
         }, 100)
     },
     async beforeMount () {
-        if (this.features.billing && !this.team.billingEnabled) {
+        if (this.features.billing && !this.team.billingSetup) {
             this.$router.push({
                 path: `/team/${this.team.slug}/billing`
             })

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -13,8 +13,6 @@
 </template>
 
 <script>
-import billingApi from '@/api/billing'
-
 import Loading from '@/components/Loading'
 import { useRoute } from 'vue-router'
 import { mapState } from 'vuex'
@@ -51,18 +49,10 @@ export default {
         },
         checkBilling: async function () {
             // Team Billing
-            if (this.features.billing) {
-                try {
-                    await billingApi.getSubscriptionInfo(this.team.id)
-                } catch (err) {
-                    const path = '/team/' + this.team.slug + '/billing'
-                    // if 404 - no billing setup, but are we running in EE?
-                    if (err.response.status === 404) {
-                        this.$router.push({
-                            path
-                        })
-                    }
-                }
+            if (this.features.billing && !this.team.billingEnabled) {
+                this.$router.push({
+                    path: `/team/${this.team.slug}/billing`
+                })
             }
         }
     },

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -49,7 +49,7 @@ export default {
         },
         checkBilling: async function () {
             // Team Billing
-            if (this.features.billing && !this.team.billingEnabled) {
+            if (this.features.billing && !this.team.billingSetup) {
                 this.$router.push({
                     path: `/team/${this.team.slug}/billing`
                 })


### PR DESCRIPTION
This PR adds a `billingEnabled` flag on the response to `/api/v1/teams/:teamId` (when the billing feature is enabled on the platform). This indicates whether the team has an active billing subscription.

This removes the need for the platform to make the extra call to get the subscription info just to check if it has to redirect to the billing setup page.

If `billingEnabled` is false, it will redirect straight to the billing page for the team.

This PR also tidies up the `createProject` page. In the early days, this page allowed you to pick which team you would create the project in. We removed that as an option some time ago, but the code was still there to load the list of teams and figure out which one it should create the team in. But that meant the page couldn't do a sensible billing check - and a user was enable to enter the url of the page directly to access it and then try to create a project.

The page now uses the `team` from the account store - ie the current team - which means it can also check the `billingEnabled` flag, and redirect to the billing page if needed.


