### PR TITLE
Rework team create flow to a single screen when billing enabled

### DIFF
--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -9,8 +9,9 @@
         </SideNavigation>
     </Teleport>
     <main>
-        <ff-loading v-if="loading" message="Creating Team..." />
-        <div v-if="!loading && !needsBilling" class="max-w-2xl m-auto">
+        <ff-loading v-if="redirecting" message="Redirecting to Stripe..." />
+        <ff-loading v-else-if="loading" message="Creating Team..." />
+        <div v-else class="max-w-2xl m-auto">
             <form class="space-y-6" >
                 <FormHeading>Create a new team</FormHeading>
                 <div class="mb-8 text-sm text-gray-500">Teams are how you organize who collaborates on your projects.</div>
@@ -28,38 +29,21 @@
                     </template>
                 </FormRow>
 
-                <ff-button :disabled="!formValid" @click="createTeam()">
+                <template v-if="billingEnabled">
+                    <div class="mb-8 text-sm text-gray-500 space-y-2">
+                        <p>To create the team we need to setup payment details via Stripe, our secure payment provider.</p>
+                        <p>You will not be charged for creating the team. You will be charged for the projects
+                            you create within the team. For more information on billing, please read our <a class="underline" href="https://flowforge.com/docs/cloud/billing/">Billing documentation</a>.</p>
+                    </div>
+                    <ff-button @click="createTeam()">
+                        <template v-slot:icon-right><ExternalLinkIcon /></template>
+                        Create team and setup payment details
+                    </ff-button>
+                </template>
+                <ff-button v-else :disabled="!formValid" @click="createTeam()">
                     Create team
                 </ff-button>
             </form>
-        </div>
-        <div v-else-if="!loading">
-            <div class="flex">
-                <img class="w-64 mr-12" src="@/images/pictograms/node_catalog_red.png">
-                <form class="pl-12 border-l">
-                    <h3 class="font-bold">New Team: {{ newTeam ? newTeam.name : '' }}</h3>
-                    <p class="mt-3">You are about to proceed to Stripe, our payment provider, in order to setup the relevant billing details.</p>
-                    <p class="mt-3">Whilst we do not charge for creating a team, we request that payment details are provided.</p>
-                    <p class="mt-2">You will only be charged for each project that you create, when you create it.</p>
-                    <div class="mt-6">
-                        <ff-button @click="customerPortal()">
-                            <span>Proceed to Stripe</span>
-                            <template v-slot:icon-right>
-                                <ArrowRightIcon />
-                            </template>
-                        </ff-button>
-                    </div>
-                </form>
-            </div>
-            <div class="mt-12">
-                <h4 class="py-4 pl-6 border-t border-b font-semibold">Frequently Asked Questions</h4>
-                <ul v-for="qa in faqs" :key="qa.question">
-                    <li class="pl-6 pt-6 pb-3">
-                        <h5 class="font-medium">{{ qa.question }}</h5>
-                        <p class="pt-3 pl-3 text-gray-600" v-html="qa.answer"></p>
-                    </li>
-                </ul>
-            </div>
         </div>
     </main>
 </template>
@@ -75,7 +59,7 @@ import FormHeading from '@/components/FormHeading'
 import NavItem from '@/components/NavItem'
 import SideNavigation from '@/components/SideNavigation'
 
-import { ChevronLeftIcon, ArrowRightIcon } from '@heroicons/vue/solid'
+import { ChevronLeftIcon, ExternalLinkIcon } from '@heroicons/vue/solid'
 
 export default {
     name: 'CreateTeam',
@@ -83,10 +67,10 @@ export default {
         return {
             mounted: false,
             loading: false,
+            redirecting: false,
             icons: {
                 chevronLeft: ChevronLeftIcon
             },
-            teams: [],
             input: {
                 name: '',
                 slug: '',
@@ -95,25 +79,6 @@ export default {
             },
             needsBilling: false,
             newTeam: null,
-            faqs: [{
-                question: 'Why do I need to enter payment details?',
-                answer: '<p>FlowForge charges for each project in your team on a recurring monthly basis, by setting up your card now your subscription is then automatically adjusted as you create projects.</p><p class="mt-3">We ask for a card to manage the risk of abuse that comes with offering a platform that can run arbitrary code.</p>'
-            }, {
-                question: 'Do you offer a free tier?',
-                answer: '<p>At present, we do not offer a free tier. However, you can have multiple members of your team, all sharing access to the same project at no additional cost.</p>'
-            }, {
-                question: 'What will I get charged?',
-                answer: '<p>Your card will be charged $15 when you create a project, and then $15 each month that the project is on your account.</p><p class="mt-3">Each team will get a single monthly charge for all the projects on the account, this will be on the same date that the team was created.</p><p class="mt-3>Any new projects created in the previous month will have a pro-rata credit on the invoice.</p>'
-            }, {
-                question: 'How do I cancel?',
-                answer: '<p>When you delete a project from your team your account receives a credit for any unused time in the month. This credit is then held against the next invoice.</p><p class="mt-3">If you wish to cancel service completely then please delete all projects and email <a href="mailto:support@flowforge.com" class="text-blue-500">support@flowforge.com</a> to request a refund to your card.</p>'
-            }, {
-                question: 'Are my details safe?',
-                answer: '<p>Your card details are held only by Stripe, one of the largest payment providers in the world, FlowForge do not store or have access to your card information.</p>'
-            }, {
-                question: 'Who are FlowForge?',
-                answer: '<p>FlowForge is a US company registered in Delaware, we were founded in April 2021 and are backed by <a class="text-blue-500" href="https://opencoreventures.com/" target="_blank">Open Core Ventures</a></p><p class="mt-3">The team are all remote, located around the world, you can see more about the individuals on our <a class="text-blue-500" href="https://flowforge.com/team/">Team page</a></p>'
-            }],
             errors: {}
         }
     },
@@ -135,9 +100,12 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team']),
+        ...mapState('account', ['team', 'features']),
         formValid () {
-            return this.input.name && !this.input.slugError && !this.errors.name
+            return this.input.teamType && this.input.name && !this.input.slugError && !this.errors.name
+        },
+        billingEnabled () {
+            return this.features.billing
         }
     },
     mounted () {
@@ -157,11 +125,10 @@ export default {
                 await this.$store.dispatch('account/setTeam', result)
                 // are we in EE?
                 if (result.billingURL) {
-                    this.newTeam = result
-                    this.needsBilling = true
+                    this.redirecting = true
+                    window.open(result.billingURL, '_self')
                 } else {
-                    // TODO: Re-route this to a holding billing page that will redirect to Stripe
-                    this.goToNewTeam(result.slug)
+                    this.$router.push({ name: 'Team', params: { team_slug: result.slug } })
                 }
             }).catch(err => {
                 if (err.response.data) {
@@ -172,12 +139,6 @@ export default {
             }).finally(() => {
                 this.loading = false
             })
-        },
-        goToNewTeam (slug) {
-            this.$router.push({ name: 'Team', params: { team_slug: slug } })
-        },
-        customerPortal () {
-            window.open(this.newTeam.billingURL, '_self')
         }
     },
     components: {
@@ -185,7 +146,7 @@ export default {
         FormHeading,
         SideNavigation,
         NavItem,
-        ArrowRightIcon
+        ExternalLinkIcon
     }
 }
 </script>

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -102,7 +102,7 @@ export default {
     computed: {
         ...mapState('account', ['team', 'features']),
         formValid () {
-            return this.input.teamType && this.input.name && !this.input.slugError && !this.errors.name
+            return this.input.name && !this.input.slugError && !this.errors.name
         },
         billingEnabled () {
             return this.features.billing

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -35,7 +35,7 @@
                         <p>You will not be charged for creating the team. You will be charged for the projects
                             you create within the team. For more information on billing, please read our <a class="underline" href="https://flowforge.com/docs/cloud/billing/">Billing documentation</a>.</p>
                     </div>
-                    <ff-button @click="createTeam()">
+                    <ff-button :disabled="!formValid" @click="createTeam()">
                         <template v-slot:icon-right><ExternalLinkIcon /></template>
                         Create team and setup payment details
                     </ff-button>


### PR DESCRIPTION
This simplifies the Create Team workflow when billing is enabled.

The previous flow involved two screens:

(ignore the TeamType selection in the top image... forgot to remove that when I took the screenshot)

<img width="604" alt="image (2)" src="https://user-images.githubusercontent.com/51083/183896354-47b9ae8e-0a1f-443e-b92a-7e78b3bbf9b0.png">

Having created lots of teams as part of the TeamTypes work, I find the two screen approach to be cumbersome and doesn't flow very well.

This PR simplifies it to a single screen:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/51083/183896685-a27a5c8e-5bdb-44dd-8c7f-79dbaecba5cc.png">

By linking to the FF Cloud docs on Billing we can centralise all FAQ about billing. Note that if someone else wanted to run an EE version of FF with billing enabled, they would want to provide their own URL for the FAQ. Easy enough to add in the future what that's an actual requirement.

Under the covers, nothing has changed. Clicking the button will create the team on the platform, and the API call responds with the billingURL. The front end now redirects straight away rather than ask the user to click another button.

When TeamTypes are added, the text above the button will dynamically update to reflect what costs the team type selection will incur. This PR hardcodes it to reflect the status quo of teams not costing anything.