### PR TITLE
Trust client IP address from upstream proxy

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -22,6 +22,7 @@ module.exports = async (options = {}) => {
     }
     const server = fastify({
         maxParamLength: 500,
+        trustProxy: true,
         logger: {
             level: loggerLevel,
             prettyPrint: {


### PR DESCRIPTION
So the logs have the right value

https://www.fastify.io/docs/latest/Reference/Server/#trustproxy