### PR TITLE
Update ui-components to 0.3.2 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@fastify/csrf-protection": "^4.0.1",
         "@fastify/helmet": "8.1.0",
         "@fastify/static": "^5.0.2",
-        "@flowforge/forge-ui-components": "^0.3.1",
+        "@flowforge/forge-ui-components": "^0.3.2",
         "@flowforge/localfs": "^0.8.0",
         "@headlessui/vue": "1.6.3",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
Upgrades the forge-ui-components dependency to include https://github.com/flowforge/forge-ui-components/pull/45 and close https://github.com/flowforge/forge-ui-components/pull/44

The above then fixes the sorting of password expired column in the Admin > Users table

https://user-images.githubusercontent.com/99246719/185608913-43ff0d9c-c2ea-44de-803d-774f751325a2.mov

