### PR TITLE
Roundup Billing

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -91,7 +91,7 @@ module.exports = {
      * @returns {Promise} Resolves when the project has been stopped
      */
 
-    stop: async (project) => {
+    stop: async (project, roundupBilling=false) => {
         if (project.state === 'suspended') {
             // Already in the right state, nothing to do
             return
@@ -105,7 +105,7 @@ module.exports = {
             const subscription = await this._app.db.models.Subscription.byTeam(project.Team.id)
             if (subscription) {
                 try {
-                    await this._app.billing.removeProject(project.Team, project)
+                    await this._app.billing.removeProject(project.Team, project, roundupBilling)
                 } catch (err) {
                     // Rethrow or wrap?
                     throw new Error('Problem with removing project from subscription')

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -131,14 +131,14 @@ module.exports = {
      * @param {*} project The project to remove
      * @returns {Promise} Resolves when the project has been stopped
      */
-    remove: async (project) => {
+    remove: async (project, roundupBilling) => {
         if (project.state !== 'suspended') {
             // Only updated billing if the project isn't already suspended
             if (this._app.license.active() && this._app.billing) {
                 const subscription = this._app.db.models.Subscription.byTeam(project.Team.id)
                 if (subscription) {
                     try {
-                        await this._app.billing.removeProject(project.Team, project)
+                        await this._app.billing.removeProject(project.Team, project, roundupBilling)
                     } catch (err) {
                         // Rethrow or wrap?
                         throw new Error('Problem with removing project from subscription')

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -91,7 +91,7 @@ module.exports = {
      * @returns {Promise} Resolves when the project has been stopped
      */
 
-    stop: async (project, roundupBilling=false) => {
+    stop: async (project, roundupBilling = false) => {
         if (project.state === 'suspended') {
             // Already in the right state, nothing to do
             return

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -39,17 +39,16 @@ module.exports.init = async function (app) {
     }
 
     function timeTomorrow (ts) {
-        const d = new Date(ts*1000)
+        const d = new Date(ts * 1000)
         const today = new Date()
         const tmw = new Date(today)
         tmw.setDate(tmw.getDate() + 1)
         d.setDate(tmw.getDate())
         d.setMonth(tmw.getMonth())
         d.setFullYear(tmw.getFullYear())
-        return d.getTime()/1000
+        return d.getTime() / 1000
     }
-    
-    
+
     return {
         createSubscriptionSession: async (team) => {
             const billingIds = getBillingIdsForTeam(team)
@@ -83,7 +82,7 @@ module.exports.init = async function (app) {
             app.log.info(`Creating Subscription for team ${team.hashid}`)
             return session
         },
-        addProject: async (team, project, roundupBilling=false) => {
+        addProject: async (team, project, roundupBilling = false) => {
             let projectProduct = app.config.billing.stripe.project_product
             let projectPrice = app.config.billing.stripe.project_price
             const projectType = await project.getProjectType()
@@ -119,7 +118,7 @@ module.exports.init = async function (app) {
                     quantity: projectItem.quantity + 1,
                     proration_behavior: 'always_invoice'
                 }
-                if (roundupBilling){
+                if (roundupBilling) {
                     update.proration_date = timeTomorrow(projectItem.created)
                 }
                 // TODO update meta data?

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -38,6 +38,18 @@ module.exports.init = async function (app) {
         return result
     }
 
+    function timeTomorrow (ts) {
+        const d = new Date(ts*1000)
+        const today = new Date()
+        const tmw = new Date(today)
+        tmw.setDate(tmw.getDate() + 1)
+        d.setDate(tmw.getDate())
+        d.setMonth(tmw.getMonth())
+        d.setFullYear(tmw.getFullYear())
+        return d.getTime()/1000
+    }
+    
+    
     return {
         createSubscriptionSession: async (team) => {
             const billingIds = getBillingIdsForTeam(team)
@@ -71,7 +83,7 @@ module.exports.init = async function (app) {
             app.log.info(`Creating Subscription for team ${team.hashid}`)
             return session
         },
-        addProject: async (team, project) => {
+        addProject: async (team, project, roundupBilling=false) => {
             let projectProduct = app.config.billing.stripe.project_product
             let projectPrice = app.config.billing.stripe.project_price
             const projectType = await project.getProjectType()
@@ -106,6 +118,9 @@ module.exports.init = async function (app) {
                 const update = {
                     quantity: projectItem.quantity + 1,
                     proration_behavior: 'always_invoice'
+                }
+                if (roundupBilling){
+                    update.proration_date = timeTomorrow(projectItem.created)
                 }
                 // TODO update meta data?
                 try {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -326,7 +326,7 @@ module.exports = async function (app) {
      */
     app.delete('/:projectId', { preHandler: app.needsPermission('project:delete') }, async (request, reply) => {
         try {
-            await app.containers.remove(request.project)
+            await app.containers.remove(request.project, true) // roundupBilling set to true when user deletes project
 
             if (app.comms) {
                 app.comms.devices.sendCommandToProjectDevices(request.project.Team.hashid, request.project.id, 'update', {

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -96,7 +96,7 @@ module.exports = async function (app) {
                 return
             }
             app.db.controllers.Project.setInflightState(request.project, 'suspending')
-            await app.containers.stop(request.project)
+            await app.containers.stop(request.project, true) // roundupBilling set to true when user suspends project
             app.db.controllers.Project.clearInflightState(request.project)
             await app.db.controllers.AuditLog.projectLog(
                 request.project.id,


### PR DESCRIPTION
Currently we remove the project from stripe billing whenever a container is stopped, this can occur:
- When a user changes the stack of a project (container is stopped then new one is started)
- When a user chooses to suspend the project

(There are possibly other places that the stop is called I have missed.)

When a user chooses to suspend a container we want to ensure that the minimum time charged is 1 day, this is to discourage frequent short runs of a project.

This change introduces a new parameter in the stripe update to set the proration date which is where the charge will be calculated to, we set this to the start time of the container (in HH:MM:SS) on tomorrows date. Which has the effect of rounding up the bill to a full day.

Because there are scenarios where the container is stopped but we don't want to roundup I have added this as a new param flag to the addProject billing call and set the default to false (the current behaviour) so any other places that call this do not need to be explicit.

Opening as draft for discussion with @knolleary and @hardillb on if this is a good approach, another option would be to not touch billing at all for the stack changes but I can see merit in removing and readding billing should the new container fail to start.

Stripe bills by the second so the net result on the bill is zero because they are credited the remaining time when it is stopped then charged that same time when it is started.
