### PR TITLE
Fix creating teams when billing enabled

### DIFF
--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -4,6 +4,10 @@ module.exports = {
 
     createTeamForUser: async function (app, teamDetails, user) {
         const newTeam = await app.db.models.Team.create(teamDetails)
+        await newTeam.setTeamType(teamDetails.type)
+        await newTeam.reload({
+            include: [{ model: app.db.models.TeamType }]
+        })
         await app.db.controllers.Team.addUser(newTeam, user, Roles.Owner)
 
         // Reinflate the object now the user has been added

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -183,7 +183,6 @@ module.exports = async function (app) {
                 type: teamType
             }, request.session.User)
 
-            // await team.setTeamType(teamType)
 
             // await team.reload({
             //     include: [{ model: app.db.models.TeamType }]

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -183,7 +183,6 @@ module.exports = async function (app) {
                 type: teamType
             }, request.session.User)
 
-
             const teamView = app.db.views.Team.team(team)
 
             if (app.license.active() && app.billing) {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -179,14 +179,15 @@ module.exports = async function (app) {
         try {
             const team = await app.db.controllers.Team.createTeamForUser({
                 name: request.body.name,
-                slug: request.body.slug
+                slug: request.body.slug,
+                type: teamType
             }, request.session.User)
 
-            await team.setTeamType(teamType)
+            // await team.setTeamType(teamType)
 
-            await team.reload({
-                include: [{ model: app.db.models.TeamType }]
-            })
+            // await team.reload({
+            //     include: [{ model: app.db.models.TeamType }]
+            // })
             const teamView = app.db.views.Team.team(team)
 
             if (app.license.active() && app.billing) {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -184,9 +184,6 @@ module.exports = async function (app) {
             }, request.session.User)
 
 
-            // await team.reload({
-            //     include: [{ model: app.db.models.TeamType }]
-            // })
             const teamView = app.db.views.Team.team(team)
 
             if (app.license.active() && app.billing) {


### PR DESCRIPTION
Moved adding TeamType to before it's used and gated the updating of the team membership count until after the subscription is setup.