### PR TITLE
Limit password length to 1024 chars

### DIFF
--- a/frontend/src/components/auth/Credentials.vue
+++ b/frontend/src/components/auth/Credentials.vue
@@ -53,6 +53,10 @@ export default {
                 valid = false
                 this.errors.password = 'Required field'
             }
+            if (this.input.password.length > 1024) {
+                valid = false
+                this.errors.password = 'Too long'
+            }
             if (valid) {
                 this.$store.dispatch('account/login', this.input)
             }

--- a/frontend/src/pages/account/PasswordReset.vue
+++ b/frontend/src/pages/account/PasswordReset.vue
@@ -52,6 +52,10 @@ export default {
                 this.errors.password = 'Password too short'
                 return false
             }
+            if (this.input.password.length > 1024) {
+                this.errors.password = 'Password too long'
+                return false
+            }
             if (this.input.password !== this.input.confirm) {
                 this.errors.confirm = 'Passwords do not match'
                 return false

--- a/frontend/src/pages/setup/CreateAdminUser.vue
+++ b/frontend/src/pages/setup/CreateAdminUser.vue
@@ -95,6 +95,11 @@ export default {
             } else {
                 this.errors.password = ''
             }
+            if (this.input.password && this.input.password.length > 1024) {
+                this.errors.password = 'Password too long'
+            } else {
+                this.errors.password = ''
+            }
         },
         createUser () {
             // eslint-disable-next-line no-undef

--- a/test/e2e/frontend/cypress/tests/auth.spec.js
+++ b/test/e2e/frontend/cypress/tests/auth.spec.js
@@ -38,4 +38,22 @@ describe('FlowForge', () => {
         // check where we are
         cy.url().should('include', '/overview')
     })
+    it('prevent long password', () => {
+        cy.visit('')
+        // fill out credentials
+        cy.get('div[label=username] input').type('alice')
+        let passwd = ''
+        for (let i = 0; i < 1030; i++) {
+            passwd += 'x'
+        }
+        console.log(passwd.length)
+        cy.get('div[label=password] input').type(passwd)
+        // click "login"
+        cy.get('.ff-actions button').click()
+        // should have error
+        cy.get('div[label=password]').should('have.class', 'ff-input--error')
+        cy.get('.ff-error-inline').should('be.visible')
+        // check where we are
+        cy.url().should('not.include', '/overview')
+    })
 })


### PR DESCRIPTION
The fastify body parser already limits the body of any post to 1mb
this just makes sure we don't hit that with a stupidly long password.

We can bcrypt hash a 1mb payload in aproxy 102ms with nodejs so
shouldn't be a problem, but 1024 seams like an excsively long password.

fixes #921