### PR TITLE
Hide loading graphic when project is susspended and viewing logs

### DIFF
--- a/frontend/src/pages/project/Logs.vue
+++ b/frontend/src/pages/project/Logs.vue
@@ -34,6 +34,9 @@ export default {
         project: 'fetchData'
     },
     mounted () {
+        if (this.project.meta && this.project.meta.state === 'suspended') {
+            this.loading = false
+        }
         this.fetchData()
         this.checkInterval = setInterval(() => {
             if (this.project.meta && this.project.meta.state !== 'suspended') {


### PR DESCRIPTION
When trying to view the logs from a suspended project the loading graphic is shown. It should show the "No logs available" message.