### PR TITLE
Fix Stack update logic

### DIFF
--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -164,10 +164,10 @@ module.exports = async function (app) {
             }
         }
         if (request.body.projectType) {
+            const projectTypeId = app.db.models.ProjectType.decodeHashid(request.body.projectType)
             if (!stack.ProjectTypeId) {
                 // This is assigning the stack to a project type for the first time
                 // We'll allow that as part of the migration of legacy stacks
-                const projectTypeId = app.db.models.ProjectType.decodeHashid(request.body.projectType)
                 if (projectTypeId) {
                     stack.ProjectTypeId = projectTypeId[0]
                     // We can also assign any projects using this stack to the same project-type
@@ -177,7 +177,7 @@ module.exports = async function (app) {
                         }
                     })
                 }
-            } else if (stack.ProjectTypeId !== request.body.projectType) {
+            } else if (stack.ProjectTypeId !== projectTypeId[0]) {
                 reply.code(400).send({ error: 'Cannot change stack project type' })
                 return
             }

--- a/test/unit/forge/routes/api/stack_spec.js
+++ b/test/unit/forge/routes/api/stack_spec.js
@@ -283,12 +283,20 @@ describe('Stack API', function () {
             result.should.have.property('projectCount', 1)
         })
         it('Cannot change projectType for stack that already has one', async function () {
+            const projectType2 = await app.db.models.ProjectType.create({
+                name: 'projectType2',
+                description: 'second project type',
+                active: true,
+                properties: { foo: 'bar' },
+                order: 2
+            })
+
             const response = await app.inject({
                 method: 'PUT',
                 url: `/api/v1/stacks/${TestObjects.stack1.hashid}`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
-                    projectType: TestObjects.projectType1.hashid
+                    projectType: projectType2.hashid
                 }
             })
             response.statusCode.should.equal(400)


### PR DESCRIPTION
Fixes https://github.com/flowforge/flowforge/issues/853

This now checks if the Project Type isn't set against the stack and then changes it and only throws an error if the admin is trying to change an existing project type, so other values eg CPU/Mem/Active can be changed on a stack that does not have deployed projects