### PR TITLE
Ensure device action options are shown on project/devices view for owner

### DIFF
--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -212,7 +212,7 @@ export default {
             return !this.isProjectDeviceView && this.teamMembership.role === Roles.Owner
         },
         isOwner: function () {
-            return !this.isProjectDeviceView && (this.teamMembership.role === Roles.Owner)
+            return this.teamMembership.role === Roles.Owner
         },
         columns: function () {
             const targetSnapshot = this.project?.deviceSettings.targetSnapshot


### PR DESCRIPTION
This restores the device action option in the project/devices table view that #920 removed