### PR TITLE
Remove invitations for deleted teams

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -43,6 +43,13 @@ module.exports = {
             },
             afterDestroy: async (team, opts) => {
                 // TODO: what needs tidying up after a team is deleted?
+                // Doing this here also clears historical invites.
+                // TeamId is null because there is a cascade rule
+                await M.Invitation.destroy({
+                    where: {
+                        teamId: null
+                    }
+                })
             }
         }
     },

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -155,7 +155,7 @@ describe('Team API', function () {
         // - Admin/Owner/Member
         // - should fail if team owns projects
 
-        it('', async function () {
+        it('removes pending invitations', async function () {
             // Alice invites Chris to TeamA
             // Delete TeamB
             await app.inject({

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -1,7 +1,7 @@
 const should = require('should') // eslint-disable-line
 const setup = require('../setup')
-// const FF_UTIL = require('flowforge-test-utils')
-// const { Roles } = FF_UTIL.require('forge/lib/roles')
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 describe('Team API', function () {
     let app
@@ -15,6 +15,9 @@ describe('Team API', function () {
         TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: app.defaultTeamType.id })
+
+        await TestObjects.BTeam.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
 
         TestObjects.tokens = {}
         await login('alice', 'aaPassword')
@@ -157,7 +160,7 @@ describe('Team API', function () {
             // Delete TeamB
             await app.inject({
                 method: 'POST',
-                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
                     user: 'chris'
@@ -165,19 +168,19 @@ describe('Team API', function () {
             })
             const inviteListA = (await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
                 cookies: { sid: TestObjects.tokens.alice }
             })).json()
             inviteListA.should.have.property('count', 1)
             const deleteResult = await app.inject({
                 method: 'DELETE',
-                url: `/api/v1/teams/${TestObjects.ATeam.hashid}`,
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
                 cookies: { sid: TestObjects.tokens.alice }
             })
             deleteResult.statusCode.should.equal(200)
             const inviteListChris = (await app.inject({
                 method: 'GET',
-                url: '/api/users/invitations',
+                url: '/api/v1/user/invitations',
                 cookies: { sid: TestObjects.tokens.chris }
             })).json()
             inviteListChris.should.have.property('count', 0)

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -138,14 +138,14 @@ describe('Team API', function () {
         // - should fail if team owns projects
 
         it('', async function () {
-            // Alice invites Elvis to TeamB
-            // Delete Elvis
+            // Alice invites Chris to TeamB
+            // Delete TeamB
             await app.inject({
                 method: 'POST',
                 url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
-                    user: 'elvis'
+                    user: 'chris'
                 }
             })
             const inviteListA = (await app.inject({
@@ -160,12 +160,12 @@ describe('Team API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             deleteResult.statusCode.should.equal(200)
-            const inviteListElvis = (await app.inject({
+            const inviteListChris = (await app.inject({
                 method: 'GET',
                 url: '/api/users/invitations',
-                cookies: { sid: TestObjects.tokens.elvis }
+                cookies: { sid: TestObjects.tokens.chris }
             })).json()
-            inviteListElvis.should.have.property('count', 0)
+            inviteListChris.should.have.property('count', 0)
         })
     })
 

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -6,6 +6,21 @@ const setup = require('../setup')
 describe('Team API', function () {
     let app
     const TestObjects = {}
+    beforeEach(async function () {
+        app = await setup()
+
+        // Alice create in setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.bob = await app.db.models.User.create({ username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
+
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+    })
 
     async function login (username, password) {
         const response = await app.inject({
@@ -138,11 +153,11 @@ describe('Team API', function () {
         // - should fail if team owns projects
 
         it('', async function () {
-            // Alice invites Chris to TeamB
+            // Alice invites Chris to TeamA
             // Delete TeamB
             await app.inject({
                 method: 'POST',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
                     user: 'chris'
@@ -150,13 +165,13 @@ describe('Team API', function () {
             })
             const inviteListA = (await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
                 cookies: { sid: TestObjects.tokens.alice }
             })).json()
             inviteListA.should.have.property('count', 1)
             const deleteResult = await app.inject({
                 method: 'DELETE',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}`,
                 cookies: { sid: TestObjects.tokens.alice }
             })
             deleteResult.statusCode.should.equal(200)

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -126,4 +126,58 @@ describe('Team API', function () {
             failResponse.json().error.should.match(/license limit/)
         })
     })
+
+    describe('Create team', async function () {
+        // POST /api/v1/teams
+        // - Admin/Owner/Member
+    })
+
+    describe('Delete team', async function () {
+        // DELETE /api/v1/teams/:teamId
+        // - Admin/Owner/Member
+        // - should fail if team owns projects
+
+        it('', async function () {
+            // Alice invites Elvis to TeamB
+            // Delete Elvis
+            await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'elvis'
+                }
+            })
+            const inviteListA = (await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })).json()
+            inviteListA.should.have.property('count', 1)
+            const deleteResult = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            deleteResult.statusCode.should.equal(200)
+            const inviteListElvis = (await app.inject({
+                method: 'GET',
+                url: '/api/users/invitations',
+                cookies: { sid: TestObjects.tokens.elvis }
+            })).json()
+            inviteListElvis.should.have.property('count', 0)
+        })
+    })
+
+    describe('Edit team details', async function () {
+        // PUT /api/v1/teams/:teamId
+    })
+
+    describe('Get current users membership', async function () {
+        // GET /api/v1/teams/:teamId/user
+    })
+
+    describe('Get team audit-log', async function () {
+        // GET /api/v1/teams/:teamId/audit-log
+    })
 })


### PR DESCRIPTION
Removes all invited will null teamId

The Invitation.teamId is set to null by a cascade rule when the team is deleted. I also did it this way because it will clean up any old orphaned Invitations from before this was added.

We should also probably delete expired invites at some point.

fixes #923 