### PR TITLE
Set starter team userLimit to 3 and enforce member limits in api

### DIFF
--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -85,9 +85,15 @@ module.exports = fp(async function (app, _opts, next) {
     await controllers.init(app)
 
     // Ensure default Team Types exist
-    const createDefaultTeamTypesMigration = require('./migrations/20220808-02-create-default-team-types')
+    const TeamTypeMigrations = [
+        './migrations/20220808-02-create-default-team-types',
+        './migrations/20220905-01-update-default-team-type-limits'
+    ]
     const queryInterface = sequelize.getQueryInterface()
-    await createDefaultTeamTypesMigration.up(queryInterface)
+    for (let i = 0; i < TeamTypeMigrations.length; i++) {
+        const migration = require(TeamTypeMigrations[i])
+        await migration.up(queryInterface)
+    }
 
     const { inject } = require('./test-data')
     await inject(app)

--- a/forge/db/migrations/20220905-01-update-default-team-type-limits.js
+++ b/forge/db/migrations/20220905-01-update-default-team-type-limits.js
@@ -1,0 +1,21 @@
+/**
+ * Update the starter teamType userLimit to 3
+ *
+ * This migration is also called whenever FlowForge starts in order to insert
+ * the default set of TeamTypes.
+ */
+
+module.exports = {
+    up: async (context) => {
+        const properties = await context.sequelize.query('select "properties" from "TeamTypes" where "name" = \'starter\'', { type: context.sequelize.QueryTypes.SELECT })
+        if (properties.length > 0) {
+            const starterProperties = JSON.parse(properties[0].properties)
+            if (starterProperties.userLimit !== 3) {
+                starterProperties.userLimit = 3
+                await context.sequelize.query(`update "TeamTypes" set "properties" = '${JSON.stringify(starterProperties)}' where "name" = 'starter'`)
+            }
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/test/unit/forge/db/controllers/Invitation_spec.js
+++ b/test/unit/forge/db/controllers/Invitation_spec.js
@@ -116,5 +116,15 @@ describe('Invitation controller', function () {
             Object.keys(result).should.have.length(1)
             checkExternalInvite(result['dave@example.com'], 1, 'dave@example.com', team.id)
         })
+
+        it('rejects if team user limit will be exceeded', async function () {
+            const invitor = await app.db.models.User.byUsername('alice')
+            const team = await app.db.models.Team.byName('ATeam')
+            const userList = ['dave@example.com', 'edward@example.com']
+            try {
+                await app.db.controllers.Invitation.createInvitations(invitor, team, userList)
+                return Promise.reject(new Error('allowed team user limit to be exceeded'))
+            } catch (err) {}
+        })
     })
 })


### PR DESCRIPTION
Closes #781 

This PR modifies the default `starter` team type to have a limit of 3 members.

It also adds additional checks to both the Team and Invitation controllers to ensure the userLimit is honoured.