### PR TITLE
Add limits to license and enforce Project limit

### DIFF
--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -85,9 +85,15 @@ module.exports = fp(async function (app, _opts, next) {
     await controllers.init(app)
 
     // Ensure default Team Types exist
-    const createDefaultTeamTypesMigration = require('./migrations/20220808-02-create-default-team-types')
+    const TeamTypeMigrations = [
+        './migrations/20220808-02-create-default-team-types',
+        './migrations/20220905-01-update-default-team-type-limits'
+    ]
     const queryInterface = sequelize.getQueryInterface()
-    await createDefaultTeamTypesMigration.up(queryInterface)
+    for (let i = 0; i < TeamTypeMigrations.length; i++) {
+        const migration = require(TeamTypeMigrations[i])
+        await migration.up(queryInterface)
+    }
 
     const { inject } = require('./test-data')
     await inject(app)

--- a/forge/db/migrations/20220905-01-update-default-team-type-limits.js
+++ b/forge/db/migrations/20220905-01-update-default-team-type-limits.js
@@ -1,0 +1,21 @@
+/**
+ * Update the starter teamType userLimit to 3
+ *
+ * This migration is also called whenever FlowForge starts in order to insert
+ * the default set of TeamTypes.
+ */
+
+module.exports = {
+    up: async (context) => {
+        const properties = await context.sequelize.query('select "properties" from "TeamTypes" where "name" = \'starter\'', { type: context.sequelize.QueryTypes.SELECT })
+        if (properties.length > 0) {
+            const starterProperties = JSON.parse(properties[0].properties)
+            if (starterProperties.userLimit !== 3) {
+                starterProperties.userLimit = 3
+                await context.sequelize.query(`update "TeamTypes" set "properties" = '${JSON.stringify(starterProperties)}' where "name" = 'starter'`)
+            }
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -93,8 +93,15 @@ module.exports = {
         this.belongsTo(M.ProjectTemplate)
         this.hasMany(M.ProjectSnapshot)
     },
-    hooks: function (M) {
+    hooks: function (M, app) {
         return {
+            beforeCreate: async (project, opts) => {
+                const projectLimit = app.license.get('projects')
+                const projectCount = await M.Project.count()
+                if (projectCount >= projectLimit) {
+                    throw new Error('license limit reached')
+                }
+            },
             afterDestroy: async (project, opts) => {
                 await M.AccessToken.destroy({
                     where: {

--- a/forge/db/models/index.js
+++ b/forge/db/models/index.js
@@ -120,7 +120,7 @@ async function init (app) {
         }
         if (m.hooks) {
             if (typeof m.hooks === 'function') {
-                opts.hooks = m.hooks.call(null, M)
+                opts.hooks = m.hooks.call(null, M, app)
             } else {
                 opts.hooks = m.hooks
             }
@@ -180,10 +180,10 @@ async function init (app) {
     // Do a second pass to setup associations/finders now all Models exist
     allModels.forEach(m => {
         if (m.associations) {
-            m.associations.call(m.model, M)
+            m.associations.call(m.model, M, app)
         }
         if (m.finders) {
-            const finders = m.finders.call(m.model, M)
+            const finders = m.finders.call(m.model, M, app)
             if (finders.static) {
                 Object.assign(m.model, finders.static)
             }

--- a/forge/licensing/license-generator.js
+++ b/forge/licensing/license-generator.js
@@ -77,11 +77,11 @@ const promptly = require('promptly')
             sub: licenseHolder, // Name of the license holder
             nbf: validFrom,
             exp: expiry, // Expiry of the license in epoch seconds
-            note: licenseNotes // Freeform text to associate with license
-            // tier: 'teams', // Must be 'solo' or 'teams',
-            // users: '100',
-            // teams: '100',
-            // projects: '100'
+            note: licenseNotes, // Freeform text to associate with license
+            users: 150,
+            teams: 50,
+            projects: 50,
+            devices: 50
         }
 
         if (devLicense) {

--- a/forge/licensing/loader.js
+++ b/forge/licensing/loader.js
@@ -12,6 +12,10 @@ class LicenseDetails {
         this.validFrom = new Date(claims.nbf * 1000)
         this.expiresAt = new Date(claims.exp * 1000)
         this.dev = claims.dev
+        this.users = claims.users || 0
+        this.projects = claims.projects || 0
+        this.devices = claims.devices || 0
+        this.teams = claims.teams || 0
         Object.freeze(this)
     }
 

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -183,11 +183,17 @@ module.exports = async function (app) {
             return
         }
 
-        const project = await app.db.models.Project.create({
-            name: name,
-            type: '',
-            url: ''
-        })
+        let project
+        try {
+            project = await app.db.models.Project.create({
+                name: name,
+                type: '',
+                url: ''
+            })
+        } catch (err) {
+            reply.status(400).type('application/json').send({ error: err.message })
+            return
+        }
 
         // const authClient = await app.db.controllers.AuthClient.createClientForProject(project);
         // const projectToken = await app.db.controllers.AccessToken.createTokenForProject(project, null, ["project:flows:view","project:flows:edit"])

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -92,6 +92,8 @@ import projectTypesApi from '@/api/projectTypes'
 import stacksApi from '@/api/stacks'
 import templatesApi from '@/api/templates'
 
+import Alerts from '@/services/alerts'
+
 import NavItem from '@/components/NavItem'
 import SectionTopMenu from '@/components/SectionTopMenu'
 
@@ -237,10 +239,13 @@ export default {
             projectApi.create(createPayload).then(result => {
                 this.$router.push({ name: 'Project', params: { id: result.id } })
             }).catch(err => {
-                console.log(err)
                 this.loading = false
                 if (err.response?.status === 409) {
                     this.errors.name = err.response.data.error
+                } else if (err.response?.status === 400) {
+                    Alerts.emit('Failed to create project: ' + err.response.data.error, 'warning', 7500)
+                } else {
+                    console.log(err)
                 }
             })
         },

--- a/test/e2e/frontend/cypress/tests/team-membership.spec.js
+++ b/test/e2e/frontend/cypress/tests/team-membership.spec.js
@@ -22,6 +22,33 @@ describe('FlowForge - Team Membership', () => {
         cy.get('[data-el="members-table"] tbody').find('.ff-kebab-menu').should('have.length', 0)
     })
 
+    it('admin/owner can remove a member from the team', () => {
+        cy.intercept('DELETE', '/api/*/teams/*/members/*').as('removeTeamMember')
+
+        cy.visit('team/ateam/members/general')
+        cy.wait(['@getTeamMembers'])
+
+        // check we have 3 members
+        cy.get('[data-el="members-table"] tbody').find('tr').should('have.length', 3)
+
+        // open click kebab menu of 3rd member (charlie)
+        cy.get('[data-el="members-table"] tbody').find('.ff-kebab-menu').eq(2).click()
+
+        // click "member-remove-from-team"
+        cy.get('[data-el="members-table"] tbody .ff-kebab-menu .ff-kebab-options').find('[data-action="member-remove-from-team"]').click()
+
+        cy.get('.ff-dialog-box').should('be.visible')
+
+        // confirm deletion
+        cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Remove').click()
+
+        // wait for deletion to finish
+        cy.wait('@removeTeamMember')
+
+        // check it has been deleted
+        cy.get('[data-el="members-table"] tbody').find('tr').should('have.length', 2)
+    })
+
     it('owner/admin can invite user', () => {
         cy.intercept('/api/*/teams/*/invitations').as('getTeamsInvitations')
         cy.visit('team/ateam/members/general')
@@ -70,32 +97,5 @@ describe('FlowForge - Team Membership', () => {
         // check it has been removed (note: tr will have 1 td with "No Data Found" and a class of .status-message when empty)
         cy.get('[data-el="table"] tbody tr').should('have.length', 1) // 1 row stating "No Data Found"
         cy.get('[data-el="table"] tbody tr td').contains('No Data Found')
-    })
-
-    it('admin/owner can remove a member from the team', () => {
-        cy.intercept('DELETE', '/api/*/teams/*/members/*').as('removeTeamMember')
-
-        cy.visit('team/ateam/members/general')
-        cy.wait(['@getTeamMembers'])
-
-        // check we now have 4 members (dave was added in previous test)
-        cy.get('[data-el="members-table"] tbody').find('tr').should('have.length', 4)
-
-        // open click kebab menu of 4th member (dave)
-        cy.get('[data-el="members-table"] tbody').find('.ff-kebab-menu').eq(3).click()
-
-        // click "member-remove-from-team"
-        cy.get('[data-el="members-table"] tbody .ff-kebab-menu .ff-kebab-options').find('[data-action="member-remove-from-team"]').click()
-
-        cy.get('.ff-dialog-box').should('be.visible')
-
-        // confirm deletion
-        cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Remove').click()
-
-        // wait for deletion to finish
-        cy.wait('@removeTeamMember')
-
-        // check it has been deleted
-        cy.get('[data-el="members-table"] tbody').find('tr').should('have.length', 3)
     })
 })

--- a/test/unit/forge/comms/authRoutes_spec.js
+++ b/test/unit/forge/comms/authRoutes_spec.js
@@ -16,7 +16,7 @@ describe('Broker Auth API', async function () {
     }
     async function setupEE () {
         app = await setup({
-            license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkJlbiBIYXJkaWxsIiwibmJmIjoxNjQ4MTY2NDAwLCJleHAiOjE2Nzk3ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjQ4MjA1MDA3fQ.2swXs50ZJgiQLA9MeoKIepN6BJGGnDqIUQ0FuKUadVjTcUzFekId5RaTpedi14f2iA7qC1w50Ym2egaBFSg1JA'
+            license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg'
         })
         await setupTestObjects()
     }

--- a/test/unit/forge/containers/index_spec.js
+++ b/test/unit/forge/containers/index_spec.js
@@ -149,7 +149,7 @@ describe('Container Wrapper', function () {
 
         beforeEach(async function () {
             app = await setup({
-                license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjM5NzUxMTc1LCJleHAiOjcyNTgxMTg0MDAsIm5vdGUiOiJGb3IgZGV2ZWxvcG1lbnQgb25seSIsInRpZXIiOiJ0ZWFtcyIsInVzZXJzIjoiMTAwIiwidGVhbXMiOiIxMDAiLCJwcm9qZWN0cyI6IjEwMCIsImlhdCI6MTYzOTc1MTE3NX0.CZwIbUV9-vC1dPHaJqVJx1YchK_4JgRMBCd5UEQfNYblXNJKiaR9BFY7T-Qvzg1HsR3rbDhmraiiVMfGuR75gw',
+                license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg',
                 billing: {
                     stripe: {}
                 }

--- a/test/unit/forge/db/controllers/Invitation_spec.js
+++ b/test/unit/forge/db/controllers/Invitation_spec.js
@@ -116,5 +116,15 @@ describe('Invitation controller', function () {
             Object.keys(result).should.have.length(1)
             checkExternalInvite(result['dave@example.com'], 1, 'dave@example.com', team.id)
         })
+
+        it('rejects if team user limit will be exceeded', async function () {
+            const invitor = await app.db.models.User.byUsername('alice')
+            const team = await app.db.models.Team.byName('ATeam')
+            const userList = ['dave@example.com', 'edward@example.com']
+            try {
+                await app.db.controllers.Invitation.createInvitations(invitor, team, userList)
+                return Promise.reject(new Error('allowed team user limit to be exceeded'))
+            } catch (err) {}
+        })
     })
 })

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -3,7 +3,7 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 module.exports = async function (config = {}) {
     config = {
-        license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkJlbiBIYXJkaWxsIiwibmJmIjoxNjQ4MTY2NDAwLCJleHAiOjE2Nzk3ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjQ4MjA1MDA3fQ.2swXs50ZJgiQLA9MeoKIepN6BJGGnDqIUQ0FuKUadVjTcUzFekId5RaTpedi14f2iA7qC1w50Ym2egaBFSg1JA',
+        license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg',
         billing: {
             stripe: {
                 key: 1234

--- a/test/unit/forge/licensing/index_spec.js
+++ b/test/unit/forge/licensing/index_spec.js
@@ -1,0 +1,69 @@
+const should = require('should') // eslint-disable-line
+const FF_UTIL = require('flowforge-test-utils')
+
+describe('License API', async function () {
+    let app
+
+    afterEach(async function () {
+        if (app) {
+            await app.close()
+            app = null
+        }
+    })
+
+    it('Uses default limits when no license applied', async function () {
+        app = await FF_UTIL.setupApp({})
+        app.license.get('users').should.equal(app.license.defaults.users)
+        app.license.get('teams').should.equal(app.license.defaults.teams)
+        app.license.get('projects').should.equal(app.license.defaults.projects)
+        app.license.get('devices').should.equal(app.license.defaults.devices)
+    })
+
+    it('Uses license provided limits', async function () {
+        /*
+            License Details:
+            {
+                "iss": "FlowForge Inc.",
+                "sub": "FlowForge Inc.",
+                "nbf": 1662422400,
+                "exp": 7986902399,
+                "note": "Development-mode Only. Not for production",
+                "users": 4,
+                "teams": 5,
+                "projects": 6,
+                "devices": 7,
+                "dev": true
+            }
+        */
+        app = await FF_UTIL.setupApp({
+            license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo0LCJ0ZWFtcyI6NSwicHJvamVjdHMiOjYsImRldmljZXMiOjcsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNDc2OTg5fQ.XJfAKSKH0ndmrD8z-GX1eWr7OdMnStIdP0ebtC3mKWvnT22TZK0pUx0jDMPFRROFDAJo_eh50T5OUHHfwSp1YQ'
+        })
+        app.license.get('users').should.equal(4)
+        app.license.get('teams').should.equal(5)
+        app.license.get('projects').should.equal(6)
+        app.license.get('devices').should.equal(7)
+    })
+
+    it('Returns 0 for any limits if license does not include claim', async function () {
+        /*
+        {
+            "iss": "FlowForge Inc.",
+            "sub": "FlowForge Inc.",
+            "nbf": 1662422400,
+            "exp": 7986902399,
+            "note": "Development-mode Only. Not for production",
+            "dev": true
+        }
+        */
+        const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNDgxOTY4fQ.kvFn4k9zPMEX8fL_VYrr4ElarqBd8MfrRh7UtIczqfPtWynijux37KjjPZPfMTKKr1hGWvb5rejn-mmceX9NfQ'
+
+        app = await FF_UTIL.setupApp({
+            license: TEST_LICENSE
+        })
+        app.license.get('organisation').should.equal('FlowForge Inc.')
+        app.license.get('users').should.equal(0)
+        app.license.get('teams').should.equal(0)
+        app.license.get('projects').should.equal(0)
+        app.license.get('devices').should.equal(0)
+    })
+})

--- a/test/unit/forge/licensing/loader_spec.js
+++ b/test/unit/forge/licensing/loader_spec.js
@@ -2,7 +2,7 @@ const should = require('should') // eslint-disable-line
 const FF_UTIL = require('flowforge-test-utils')
 const licensing = FF_UTIL.require('forge/licensing/loader.js')
 
-describe('Licensing', function () {
+describe('License Loader', function () {
     it('should load a valid license', async function () {
         // {
         //     iss: "FlowForge Inc.",

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -8,7 +8,9 @@ describe('Users API', async function () {
     const TestObjects = {}
 
     beforeEach(async function () {
-        app = await setup({ features: { devices: true } })
+        app = await setup({
+            features: { devices: true }
+        })
 
         // alice : admin, team owner
         // bob : admin, team owner
@@ -285,20 +287,21 @@ describe('Users API', async function () {
         })
 
         it('Deleting a user removes pending invites for them', async function () {
-            // Alice invites Elvis to TeamB
+            // Chris invites Elvis to TeamC
             // Delete Elvis
-            await app.inject({
+            const response = await app.inject({
                 method: 'POST',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
-                cookies: { sid: TestObjects.tokens.alice },
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.chris },
                 payload: {
                     user: 'elvis'
                 }
             })
+            response.statusCode.should.equal(200)
             const inviteListA = (await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
-                cookies: { sid: TestObjects.tokens.alice }
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.chris }
             })).json()
             inviteListA.should.have.property('count', 1)
             const deleteResult = await app.inject({
@@ -309,8 +312,8 @@ describe('Users API', async function () {
             deleteResult.statusCode.should.equal(200)
             const inviteListB = (await app.inject({
                 method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
-                cookies: { sid: TestObjects.tokens.alice }
+                url: `/api/v1/teams/${TestObjects.CTeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.chris }
             })).json()
             inviteListB.should.have.property('count', 0)
         })


### PR DESCRIPTION
Closes #776 #780 

This PR builds on #946 - that should get merged first.

This adds claims to the license to cover projects, users, teams and devices.

If no license is applied (CE edition), they default to the values described in #780 

If a license is applied, it uses the values from the license, defaulting to `0` if not present.

When the platform starts up, it reports on the counts:

```
[2022-09-06T18:45:57.482Z] INFO: License verified:
[2022-09-06T18:45:57.482Z] INFO:   ****************************
[2022-09-06T18:45:57.482Z] INFO:   * Development-mode License *
[2022-09-06T18:45:57.482Z] INFO:   ****************************
[2022-09-06T18:45:57.482Z] INFO:  Org:     FlowForge Inc. Development
[2022-09-06T18:45:57.482Z] INFO:  Valid From : 2022-09-06T00:00:00.000Z
[2022-09-06T18:45:57.482Z] INFO:  Expires    : 2223-02-04T23:59:59.000Z
[2022-09-06T18:45:57.491Z] INFO: Usage:
[2022-09-06T18:45:57.491Z] INFO:  Users    : 3/150
[2022-09-06T18:45:57.491Z] INFO:  Teams    : 3/50
[2022-09-06T18:45:57.491Z] INFO:  Projects : 5/50
[2022-09-06T18:45:57.492Z] INFO:  Devices  : 4/50
```

In the second commit, changes are added to enforce the Project limit. This is done as a hook on the model itself - so any code path that tries to create a project in the database will be handled.

The UI side does a fairly default Alert notification that the license limit has been reached. That can be refined as I work through policing the other limits.

# NOTE TO DEVELOPERS

Once this PR is merged, you will need to update the development license you are running with locally otherwise you will no longer be able to create projects (unless you run with no license at all). As before, this is provided in `forge/licensing/index.js`.