### PR TITLE
Apply license limits to number of users

### DIFF
--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -38,9 +38,14 @@ module.exports = {
     scopes: {
         admins: { where: { admin: true } }
     },
-    hooks: function (M) {
+    hooks: function (M, app) {
         return {
-            beforeCreate: (user, options) => {
+            beforeCreate: async (user, options) => {
+                const userLimit = app.license.get('users')
+                const userCount = await M.User.count()
+                if (userCount >= userLimit) {
+                    throw new Error('license limit reached')
+                }
                 if (!user.avatar) {
                     user.avatar = generateUserAvatar(user.name || user.username)
                 }

--- a/test/unit/forge/db/models/User_spec.js
+++ b/test/unit/forge/db/models/User_spec.js
@@ -6,112 +6,124 @@ const { Roles } = FF_UTIL.require('forge/lib/roles')
 describe('User model', function () {
     // Use standard test data.
     let app
-    beforeEach(async function () {
-        app = await setup()
-    })
 
     afterEach(async function () {
-        await app.close()
-    })
-
-    it('User email can be null', async function () {
-        await app.db.models.User.create({ username: 'nullEmail', password: '12345678' })
-        await app.db.models.User.create({ username: 'nullEmail2', password: '12345678' })
-    })
-
-    it('User email, if set, must be unique', async function () {
-        await app.db.models.User.create({ username: 'duplicateEmail', email: 'duplicate@email.com', password: '12345678' })
-        try {
-            await app.db.models.User.create({ username: 'duplicateEmail2', email: 'duplicate@email.com', password: '12345678' })
-            throw new Error('Created user with duplicate email')
-        } catch (err) {
-            /SequelizeUniqueConstraintError/.test(err.toString()).should.be.true()
+        if (app) {
+            await app.close()
+            app = null
         }
     })
 
-    it('User email, if set, must be valid email', async function () {
-        try {
-            await app.db.models.User.create({ username: 'badEmail', email: 'not-n-email', password: '12345678' })
-            throw new Error('Created user with invalid email')
-        } catch (err) {
-            /SequelizeValidationError/.test(err.toString()).should.be.true()
-        }
+    describe('Model properties', function () {
+        beforeEach(async function () {
+            app = await setup()
+        })
+
+        it('User email can be null', async function () {
+            await app.db.models.User.create({ username: 'nullEmail', password: '12345678' })
+            await app.db.models.User.create({ username: 'nullEmail2', password: '12345678' })
+        })
+
+        it('User email, if set, must be unique', async function () {
+            await app.db.models.User.create({ username: 'duplicateEmail', email: 'duplicate@email.com', password: '12345678' })
+            try {
+                await app.db.models.User.create({ username: 'duplicateEmail2', email: 'duplicate@email.com', password: '12345678' })
+                throw new Error('Created user with duplicate email')
+            } catch (err) {
+                /SequelizeUniqueConstraintError/.test(err.toString()).should.be.true()
+            }
+        })
+
+        it('User email, if set, must be valid email', async function () {
+            try {
+                await app.db.models.User.create({ username: 'badEmail', email: 'not-n-email', password: '12345678' })
+                throw new Error('Created user with invalid email')
+            } catch (err) {
+                /SequelizeValidationError/.test(err.toString()).should.be.true()
+            }
+        })
+
+        it('User password must be at least 8 chars', async function () {
+            try {
+                await app.db.models.User.create({ username: 'shortPassword', email: 'a@b.com', password: '123' })
+                throw new Error('Created user with short password')
+            } catch (err) {
+                / Password too short/.test(err.toString()).should.be.true()
+            }
+        })
+
+        it('User password is hashed', async function () {
+            const user = await app.db.models.User.create({ username: 'hashedPassword', email: 'a@b.com', password: '12345678' })
+            user.password.should.not.equal('12345678')
+        })
+
+        it('User.admins returns all admin users', async function () {
+            const admins = await app.db.models.User.admins()
+            admins.should.have.length(1)
+            admins[0].get('email').should.eql('alice@example.com')
+        })
+
+        it('getTeamMembership', async function () {
+            const user = await app.db.models.User.byEmail('bob@example.com')
+            const team1 = await app.db.models.Team.findOne({ where: { name: 'ATeam' } })
+            const team2 = await app.db.models.Team.findOne({ where: { name: 'BTeam' } })
+            const team3 = await app.db.models.Team.findOne({ where: { name: 'CTeam' } })
+
+            const membership1 = await user.getTeamMembership(team1.id, true)
+            should.equal(membership1.role, Roles.Member)
+            should.equal(membership1.TeamId, team1.id)
+            should.exist(membership1.Team)
+            should.equal(membership1.Team.id, team1.id)
+            should.equal(membership1.Team.name, 'ATeam')
+
+            const membership2 = await user.getTeamMembership(team2.id)
+            should.equal(membership2.role, Roles.Owner)
+            should.not.exist(membership2.Team)
+
+            const membership3 = await user.getTeamMembership(team3.id)
+            should.not.exist(membership3)
+        })
+
+        it('User Real Name with URL', async function () {
+            let user
+            try {
+                user = await app.db.models.User.create({
+                    username: 'foo',
+                    password: '123456abc',
+                    email: 'foo@example.com',
+                    name: 'http://example.com'
+                })
+            } catch (err) {
+                // console.log(err)
+            }
+
+            should.not.exist(user)
+        })
     })
 
-    it('User password must be at least 8 chars', async function () {
-        try {
-            await app.db.models.User.create({ username: 'shortPassword', email: 'a@b.com', password: '123' })
-            throw new Error('Created user with short password')
-        } catch (err) {
-            / Password too short/.test(err.toString()).should.be.true()
-        }
+    describe('License limits', function () {
+        it('limits how many users can be created according to license', async function () {
+            // This license has limit of 5 users (3 created by default test setup)
+            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
+            app = await setup({ license })
+            // Default setup creates 3 users
+            ;(await app.db.models.User.count()).should.equal(3)
+
+            await app.db.models.User.create({ username: 'u4', password: '12345678' })
+            ;(await app.db.models.User.count()).should.equal(4)
+
+            await app.db.models.User.create({ username: 'u5', password: '12345678' })
+            ;(await app.db.models.User.count()).should.equal(5)
+            try {
+                await app.db.models.User.create({ username: 'u6', password: '12345678' })
+                return Promise.reject(new Error('able to create user that exceeds limit'))
+            } catch (err) { }
+
+            await app.db.models.User.destroy({ where: { username: 'u4' } })
+            ;(await app.db.models.User.count()).should.equal(4)
+
+            await app.db.models.User.create({ username: 'u6', password: '12345678' })
+            ;(await app.db.models.User.count()).should.equal(5)
+        })
     })
-
-    it('User password is hashed', async function () {
-        const user = await app.db.models.User.create({ username: 'hashedPassword', email: 'a@b.com', password: '12345678' })
-        user.password.should.not.equal('12345678')
-    })
-
-    it('User.admins returns all admin users', async function () {
-        const admins = await app.db.models.User.admins()
-        admins.should.have.length(1)
-        admins[0].get('email').should.eql('alice@example.com')
-    })
-
-    it('getTeamMembership', async function () {
-        const user = await app.db.models.User.byEmail('bob@example.com')
-        const team1 = await app.db.models.Team.findOne({ where: { name: 'ATeam' } })
-        const team2 = await app.db.models.Team.findOne({ where: { name: 'BTeam' } })
-        const team3 = await app.db.models.Team.findOne({ where: { name: 'CTeam' } })
-
-        const membership1 = await user.getTeamMembership(team1.id, true)
-        should.equal(membership1.role, Roles.Member)
-        should.equal(membership1.TeamId, team1.id)
-        should.exist(membership1.Team)
-        should.equal(membership1.Team.id, team1.id)
-        should.equal(membership1.Team.name, 'ATeam')
-
-        const membership2 = await user.getTeamMembership(team2.id)
-        should.equal(membership2.role, Roles.Owner)
-        should.not.exist(membership2.Team)
-
-        const membership3 = await user.getTeamMembership(team3.id)
-        should.not.exist(membership3)
-    })
-
-    it('User Real Name with URL', async function () {
-        let user
-        try {
-            user = await app.db.models.User.create({
-                username: 'foo',
-                password: '123456abc',
-                email: 'foo@example.com',
-                name: 'http://example.com'
-            })
-        } catch (err) {
-            // console.log(err)
-        }
-
-        should.not.exist(user)
-    })
-
-    // it("random", async function() {
-    //     const user = await app.db.models.User.byEmail("chris@example.com");
-    //     const proj = await app.db.models.Project.findOne({where:{name:"project2"}});
-    //     const membership = await user.getTeamMembership(proj.TeamId);
-    //     console.log(user.name, proj.name, membership.role);
-    // })
-
-    // it("User.inTeam returns all users in a team", async function() {
-    //     const team1Members = await app.db.models.User.inTeam('ATeam');
-    //     team1Members.should.have.length(3);
-    //
-    //     console.log(team1Members[0].get('Teams'));
-    //
-    //     const team2Members = await app.db.models.User.inTeam('BTeam');
-    //     team2Members.should.have.length(2);
-    //
-    //     const team3Members = await app.db.models.User.inTeam('CTeam');
-    //     team3Members.should.have.length(2);
-    // })
 })

--- a/test/unit/forge/db/models/User_spec.js
+++ b/test/unit/forge/db/models/User_spec.js
@@ -84,7 +84,7 @@ describe('User model', function () {
             should.not.exist(membership3)
         })
 
-        it('User Real Name with URL', async function () {
+        it('Should not create a User where Real Name is a URL', async function () {
             let user
             try {
                 user = await app.db.models.User.create({

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -1,0 +1,132 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('Accounts API', async function () {
+    let app
+
+    afterEach(async function () {
+        if (app) {
+            await app.close()
+            app = null
+        }
+    })
+
+    async function registerUser (payload) {
+        return app.inject({
+            method: 'POST',
+            url: '/account/register',
+            payload
+        })
+    }
+
+    describe('Register User', async function () {
+        async function expectRejection (opts, reason) {
+            const response = await registerUser(opts)
+            response.statusCode.should.equal(400)
+            response.json().error.should.match(reason)
+        }
+
+        it('rejects user registration if not enabled', async function () {
+            app = await setup()
+            app.settings.get('user:signup').should.be.false()
+            app.settings.get('team:user:invite:external').should.be.false()
+            await expectRejection({
+                username: 'u1',
+                password: 'p1',
+                name: 'u1',
+                email: 'u1@example.com'
+            }, /user registration not enabled/)
+        })
+        it('allows user to register', async function () {
+            app = await setup()
+            app.settings.set('user:signup', true)
+
+            const response = await registerUser({
+                username: 'u1',
+                password: '12345678',
+                name: 'u1',
+                email: 'u1@example.com'
+            })
+            response.statusCode.should.equal(200)
+        })
+
+        it('rejects reserved user names', async function () {
+            app = await setup()
+            app.settings.set('user:signup', true)
+
+            await expectRejection({
+                username: 'admin',
+                password: '12345678',
+                name: 'u1',
+                email: 'u1@example.com'
+            }, /invalid username/)
+
+            await expectRejection({
+                username: 'root',
+                password: '12345678',
+                name: 'u1',
+                email: 'u1@example.com'
+            }, /invalid username/)
+        })
+
+        it('rejects duplicate username', async function () {
+            app = await setup()
+            app.settings.set('user:signup', true)
+
+            await registerUser({
+                username: 'u1',
+                password: '12345678',
+                name: 'u1',
+                email: 'u1@example.com'
+            })
+
+            await expectRejection({
+                username: 'u1',
+                password: '12345678',
+                name: 'u1.2',
+                email: 'u1-2@example.com'
+            }, /username must be unique/)
+        })
+        it('rejects duplicate email', async function () {
+            app = await setup()
+            app.settings.set('user:signup', true)
+
+            await registerUser({
+                username: 'u1',
+                password: '12345678',
+                name: 'u1',
+                email: 'u1@example.com'
+            })
+
+            await expectRejection({
+                username: 'u1-2',
+                password: '12345678',
+                name: 'u1.2',
+                email: 'u1@example.com'
+            }, /email must be unique/)
+        })
+
+        it('limits how many users can be created according to license', async function () {
+            // This license has limit of 5 users (1 created by default test setup (test/unit/forge/routes/setup.js))
+            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
+            app = await setup({ license })
+            app.settings.set('user:signup', true)
+            // Register 4 more users to reach the limit
+            for (let i = 1; i <= 4; i++) {
+                const resp = await registerUser({
+                    username: `u${i}`,
+                    password: '12345678',
+                    name: `u${i}`,
+                    email: `u${i}@example.com`
+                })
+                resp.statusCode.should.equal(200)
+            }
+            await expectRejection({
+                username: 'u6',
+                password: '12345678',
+                name: 'u6',
+                email: 'u6@example.com'
+            }, /license limit reached/)
+        })
+    })
+})


### PR DESCRIPTION
Closes #777 

Builds on #947 - that should be reviewed and merged first.

This PR adds enforcement of the User limit on the platform as a whole (rather than within individual teams).

It adds unit tests around the paths that can create new users.