### PR TITLE
Limit number of devices on platform based on license

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -34,8 +34,15 @@ module.exports = {
         this.belongsTo(M.ProjectSnapshot, { as: 'activeSnapshot' })
         this.hasMany(M.DeviceSettings)
     },
-    hooks: function (M) {
+    hooks: function (M, app) {
         return {
+            beforeCreate: async (device, options) => {
+                const deviceLimit = app.license.get('devices')
+                const deviceCount = await M.Device.count()
+                if (deviceCount >= deviceLimit) {
+                    throw new Error('license limit reached')
+                }
+            },
             afterDestroy: async (device, opts) => {
                 await M.AccessToken.destroy({
                     where: {

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -88,6 +88,8 @@ export default {
                     if (err.response.data) {
                         if (/name/.test(err.response.data.error)) {
                             this.errors.name = err.response.data.error
+                        } else {
+                            alerts.emit('Failed to create device: ' + err.response.data.error, 'warning', 7500)
                         }
                     }
                 })

--- a/test/unit/forge/db/models/Device_spec.js
+++ b/test/unit/forge/db/models/Device_spec.js
@@ -1,0 +1,38 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('Device model', function () {
+    // Use standard test data.
+    let app
+
+    afterEach(async function () {
+        if (app) {
+            await app.close()
+            app = null
+        }
+    })
+
+    describe('License limits', function () {
+        it('limits how many devices can be created according to license', async function () {
+            // This license has limit of 2 devices
+            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTk1MjAwLCJleHAiOjc5ODcwNzUxOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjoyLCJkZXYiOnRydWUsImlhdCI6MTY2MjY1MzkyMX0.Tj4fnuDuxi_o5JYltmVi1Xj-BRn0aEjwRPa_fL2MYa9MzSwnvJEd-8bsRM38BQpChjLt-wN-2J21U7oSq2Fp5A'
+            app = await setup({ license })
+
+            ;(await app.db.models.Device.count()).should.equal(0)
+
+            await app.db.models.Device.create({ name: 'D1', type: '', credentialSecret: '' })
+            await app.db.models.Device.create({ name: 'D2', type: '', credentialSecret: '' })
+            ;(await app.db.models.Device.count()).should.equal(2)
+
+            try {
+                await app.db.models.Device.create({ name: 'D3', type: '', credentialSecret: '' })
+                return Promise.reject(new Error('able to create device that exceeds limit'))
+            } catch (err) { }
+
+            await app.db.models.Device.destroy({ where: { name: 'D2', type: '', credentialSecret: '' } })
+            ;(await app.db.models.Device.count()).should.equal(1)
+            await app.db.models.Device.create({ name: 'D3', type: '', credentialSecret: '' })
+            ;(await app.db.models.Device.count()).should.equal(2)
+        })
+    })
+})

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -23,7 +23,11 @@ describe('Device API', async function () {
     }
 
     beforeEach(async function () {
-        app = await setup({ features: { devices: true } })
+        const setupConfig = { features: { devices: true } }
+        if (this.currentTest.license) {
+            setupConfig.license = this.currentTest.license
+        }
+        app = await setup(setupConfig)
 
         // alice : admin
         // bob
@@ -150,6 +154,24 @@ describe('Device API', async function () {
             result.should.have.property('credentials')
             result.credentials.should.have.property('token')
         })
+
+        const licenseTest = it('limits how many devices can be created according to license', async function () {
+            // Check we're at the starting point we expect
+            ;(await app.db.models.Device.count()).should.equal(0)
+
+            for (let i = 0; i < 2; i++) {
+                const response = await createDevice({ name: `D${i + 1}`, type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+                response.should.have.property('id')
+            }
+
+            ;(await app.db.models.Device.count()).should.equal(2)
+
+            const response = await createDevice({ name: 'D3', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+            response.should.have.property('error')
+            response.error.should.match(/license limit/)
+        })
+        // Limited to 2 devices
+        licenseTest.license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTk1MjAwLCJleHAiOjc5ODcwNzUxOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjoyLCJkZXYiOnRydWUsImlhdCI6MTY2MjY1MzkyMX0.Tj4fnuDuxi_o5JYltmVi1Xj-BRn0aEjwRPa_fL2MYa9MzSwnvJEd-8bsRM38BQpChjLt-wN-2J21U7oSq2Fp5A'
     })
     describe('Get device details', async function () {
         it('provides device details including project and team', async function () {


### PR DESCRIPTION
Closes #779 

This limits how many devices can be created on the platform according to the current license terms.

It is implemented (as with the user/project/team limits) as a `beforeCreate` hook on the model.

This adds tests for the model and the API to ensure proper responses.

Of note is the fact I've figured out a pattern for a test to provide a custom setup parameter that the `beforeEach` function can use. This would have saved some of the test refactoring I did in other limits-related PRs recently. Not going to re-refactor them all now, but worth keeping in mind for future work.