### PR TITLE
Add TeamType.properties.deviceLimit to restrict devices in team

### DIFF
--- a/forge/db/controllers/Invitation.js
+++ b/forge/db/controllers/Invitation.js
@@ -47,10 +47,10 @@ module.exports = {
             opts.invitorId = invitor.id
             pendingInvites.push({ userDetail, opts })
         }
-        if (team.TeamType.properties?.userLimit > 0) {
+        if (team.TeamType.getProperty('userLimit') > 0) {
             const currentTeamMemberCount = await team.memberCount()
             const currentTeamInviteCount = await team.pendingInviteCount()
-            if (currentTeamMemberCount + currentTeamInviteCount + pendingInvites.length > team.TeamType.properties.userLimit) {
+            if (currentTeamMemberCount + currentTeamInviteCount + pendingInvites.length > team.TeamType.getProperty('userLimit')) {
                 throw new Error('Team user limit reached')
             }
         }

--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -70,7 +70,7 @@ module.exports = {
                 include: [{ model: app.db.models.TeamType }]
             })
         }
-        const userLimit = team.TeamType.properties?.userLimit
+        const userLimit = team.TeamType.getProperty('userLimit')
         if (userLimit > 0 && currentTeamMemberCount >= userLimit) {
             throw new Error('Team user limit reached')
         }

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -226,6 +226,9 @@ module.exports = {
                 },
                 pendingInviteCount: async function () {
                     return await M.Invitation.count({ where: { teamId: this.id } })
+                },
+                deviceCount: async function () {
+                    return await M.Device.count({ where: { TeamId: this.id } })
                 }
             }
         }

--- a/forge/db/models/TeamType.js
+++ b/forge/db/models/TeamType.js
@@ -75,6 +75,9 @@ module.exports = {
                 }
             },
             instance: {
+                getProperty: function (key) {
+                    return this.properties?.[key]
+                },
                 teamCount: async function () {
                     return await M.Team.count({ where: { TeamTypeId: this.id } })
                 }

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -98,6 +98,19 @@ module.exports = async function (app) {
         }
 
         const team = teamMembership.get('Team')
+        await team.reload({
+            include: [
+                { model: app.db.models.TeamType }
+            ]
+        })
+        const teamDeviceLimit = team.TeamType.getProperty('deviceLimit')
+        if (typeof teamDeviceLimit === 'number') {
+            const currentDeviceCount = await team.deviceCount()
+            if (currentDeviceCount >= teamDeviceLimit) {
+                reply.code(400).send({ error: 'Team device limit reached' })
+                return
+            }
+        }
 
         try {
             const device = await app.db.models.Device.create({


### PR DESCRIPTION
Part of #782 

This PR adds `TeamType.properties.deviceLimit` as a way to limit how many devices may be added to a team of a given type. If the property isn't set, no limit is applied.

- Adds a TeamType.getProperty() accessor function to make it easier to access individual properties
- When creating a device in a team, if checks if `TeamType.properties.deviceLimit` is set, and if so, checks the limit won't be exceeded.
