### PR TITLE
Add billing to device lifecycle

### DIFF
--- a/forge/db/controllers/Invitation.js
+++ b/forge/db/controllers/Invitation.js
@@ -47,10 +47,10 @@ module.exports = {
             opts.invitorId = invitor.id
             pendingInvites.push({ userDetail, opts })
         }
-        if (team.TeamType.properties?.userLimit > 0) {
+        if (team.TeamType.getProperty('userLimit') > 0) {
             const currentTeamMemberCount = await team.memberCount()
             const currentTeamInviteCount = await team.pendingInviteCount()
-            if (currentTeamMemberCount + currentTeamInviteCount + pendingInvites.length > team.TeamType.properties.userLimit) {
+            if (currentTeamMemberCount + currentTeamInviteCount + pendingInvites.length > team.TeamType.getProperty('userLimit')) {
                 throw new Error('Team user limit reached')
             }
         }

--- a/forge/db/controllers/Team.js
+++ b/forge/db/controllers/Team.js
@@ -70,7 +70,7 @@ module.exports = {
                 include: [{ model: app.db.models.TeamType }]
             })
         }
-        const userLimit = team.TeamType.properties?.userLimit
+        const userLimit = team.TeamType.getProperty('userLimit')
         if (userLimit > 0 && currentTeamMemberCount >= userLimit) {
             throw new Error('Team user limit reached')
         }

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -226,6 +226,9 @@ module.exports = {
                 },
                 pendingInviteCount: async function () {
                     return await M.Invitation.count({ where: { teamId: this.id } })
+                },
+                deviceCount: async function () {
+                    return await M.Device.count({ where: { TeamId: this.id } })
                 }
             }
         }

--- a/forge/db/models/TeamType.js
+++ b/forge/db/models/TeamType.js
@@ -75,6 +75,9 @@ module.exports = {
                 }
             },
             instance: {
+                getProperty: function (key) {
+                    return this.properties?.[key]
+                },
                 teamCount: async function () {
                     return await M.Team.count({ where: { TeamTypeId: this.id } })
                 }

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -220,7 +220,7 @@ module.exports.init = async function (app) {
         updateTeamDeviceCount: async (team) => {
             const billingIds = getBillingIdsForTeam(team)
             if (!billingIds.device.product) {
-                app.log.info(`Unable to update device billing for team ${team.hashid} - app.config.billing.stripe.device_product not set`)
+                return
             }
             const subscription = await app.db.models.Subscription.byTeam(team.id)
             if (subscription) {

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -98,6 +98,19 @@ module.exports = async function (app) {
         }
 
         const team = teamMembership.get('Team')
+        await team.reload({
+            include: [
+                { model: app.db.models.TeamType }
+            ]
+        })
+        const teamDeviceLimit = team.TeamType.getProperty('deviceLimit')
+        if (typeof teamDeviceLimit === 'number') {
+            const currentDeviceCount = await team.deviceCount()
+            if (currentDeviceCount >= teamDeviceLimit) {
+                reply.code(400).send({ error: 'Team device limit reached' })
+                return
+            }
+        }
 
         try {
             const device = await app.db.models.Device.create({

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -168,7 +168,7 @@ describe('Billing', function () {
         })
     })
 
-    describe.only('updateTeamDeviceCount', async function () {
+    describe('updateTeamDeviceCount', async function () {
         let updateId, updateData
         describe('no existing subscription item', async function () {
             beforeEach(async function () {

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -157,7 +157,7 @@ describe('Device API', async function () {
             result.credentials.should.have.property('token')
         })
 
-        it.only('limits how many devices can be added to a team according to TeamType', async function () {
+        it('limits how many devices can be added to a team according to TeamType', async function () {
             // Set TeamType deviceLimit = 2
             const existingTeamTypeProps = TestObjects.defaultTeamType.properties
             existingTeamTypeProps.deviceLimit = 2


### PR DESCRIPTION
Part of #782 

This adds a billing step to the device lifecycle.

If `billing.stripe.device_product/device_price` are set, then whenever a device is added/removed from team, the billing subscription item is updated for the team to reflect how many devices are in the team.

If the team type includes a `deviceFreeAllocation` property, this is taken into account when identifying how many 'billable' devices a team has.

This PR does not update the UI - that will come in the final PR for this story.