### PR TITLE
Prompt user to confirm per-device charge when registering charge

### DIFF
--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -189,6 +189,9 @@ billing:
     team_product: ***
     project_price: ***
     project_product: ***
+    device_price: ***
+    device_product: ***
+    deviceCost: 10
     teams:
       starter:
         price: ***

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -185,7 +185,10 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    let limit = parseInt(pagination.limit)
+                    if (isNaN(limit)) {
+                        limit = 30
+                    }
                     if (pagination.cursor) {
                         where.id = { [Op.gt]: M.Device.decodeHashid(pagination.cursor) }
                     }
@@ -208,7 +211,7 @@ module.exports = {
                     })
                     return {
                         meta: {
-                            next_cursor: rows.length === limit ? rows[rows.length - 1].hashid : undefined
+                            next_cursor: (rows.length === limit && limit > 0) ? rows[rows.length - 1].hashid : undefined
                         },
                         count: count,
                         devices: rows

--- a/forge/db/views/TeamType.js
+++ b/forge/db/views/TeamType.js
@@ -1,9 +1,10 @@
 module.exports = {
     teamType: function (app, teamType) {
         const properties = { ...teamType.properties }
-        if (app.config.billing?.stripe.teams?.[teamType.name]) {
+        if (app.license.active() && app.billing) {
             properties.billing = {
-                userCost: app.config.billing.stripe.teams[teamType.name].userCost || 0
+                userCost: app.config.billing.stripe.teams[teamType.name].userCost || 0,
+                deviceCost: app.config.billing.stripe.deviceCost || 0
             }
         }
         return {


### PR DESCRIPTION
This is the final part of #782 

This provides the 'confirm additional charge' checkbox when registering a Device. This is only shown if:

 - billing is enabled
 - `billing.stripe.deviceCost` is set to a value > 0
 - the team already has its `deviceFreeAllocation` worth of devices (if set on the TeamType)
As we do with projects, it shows the cost, derived from `billing.stripe.deviceCost`, assuming it is a $ amount to be billed per month.

