### PR TITLE
Add notice about user limit in team invite dialog

### DIFF
--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -18,7 +18,7 @@
 
     <ChangeTeamRoleDialog @roleUpdated="roleUpdated" ref="changeTeamRoleDialog" />
     <ConfirmTeamUserRemoveDialog @userRemoved="userRemoved" ref="confirmTeamUserRemoveDialog" />
-    <InviteMemberDialog @invitationSent="$emit('invites-updated')" :team="team" v-if="canModifyMembers" ref="inviteMemberDialog" />
+    <InviteMemberDialog @invitationSent="$emit('invites-updated')" :team="team" :inviteCount="inviteCount" :userCount="userCount" v-if="canModifyMembers" ref="inviteMemberDialog" />
 </template>
 
 <script>
@@ -36,6 +36,7 @@ import { Roles } from '@core/lib/roles'
 
 export default {
     name: 'TeamUsersGeneral',
+    props: ['team', 'teamMembership', 'inviteCount'],
     emits: ['invites-updated'],
     data () {
         return {
@@ -104,7 +105,6 @@ export default {
             this.loading = false
         }
     },
-    props: ['team', 'teamMembership'],
     components: {
         ChangeTeamRoleDialog,
         ConfirmTeamUserRemoveDialog,

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -21,8 +21,8 @@ import { Roles } from '@core/lib/roles'
 
 export default {
     name: 'MemberInviteTable',
-    props: ['team', 'teamMembership'],
-    emits: ['updated'],
+    props: ['team', 'teamMembership', 'inviteCount'],
+    emits: ['updated', 'invites-updated'],
     data () {
         return {
             loading: false,

--- a/frontend/src/pages/team/Members/index.vue
+++ b/frontend/src/pages/team/Members/index.vue
@@ -2,7 +2,7 @@
     <div class="">
         <SectionTopMenu hero="Members" :options="sideNavigation" />
         <div class="flex-grow">
-            <router-view :team="team" :teamMembership="teamMembership" @invites-updated="checkAccess()"></router-view>
+            <router-view :team="team" :teamMembership="teamMembership" :inviteCount="inviteCount" @invites-updated="checkAccess()"></router-view>
         </div>
     </div>
 </template>
@@ -26,7 +26,8 @@ export default {
     },
     data: function () {
         return {
-            sideNavigation: []
+            sideNavigation: [],
+            inviteCount: 0
         }
     },
     watch: {
@@ -42,6 +43,7 @@ export default {
             ]
             if (this.user.admin || (this.teamMembership && this.teamMembership.role === Roles.Owner)) {
                 const invitations = await teamApi.getTeamInvitations(this.team.id)
+                this.inviteCount = invitations.count
                 this.sideNavigation.push({ name: `Invitations (${invitations.count})`, path: './invitations' })
             }
         }

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -1,11 +1,13 @@
 <template>
-    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disableConfirm">
+    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disableConfirm" :closeOnConfirm="false">
         <template v-slot:default>
             <form class="space-y-6" @submit.prevent>
                 <div class="space-y-2">
                     <template v-if="!responseErrors">
-                        <p>Invite a user to join the team.</p>
-                        <FormRow id="userInfo" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')"></FormRow>
+                        <p v-if="!exceedsUserLimit">Invite a user to join the team by username <span v-if="externalEnabled">or email</span>.</p>
+                        <p v-if="hasUserLimit">Your team can have a maximum of {{team.type.properties.userLimit}} members.</p>
+                        <p v-if="exceedsUserLimit">You currently have {{totalMembers}} (including existing invites) so cannot invite any more.</p>
+                        <FormRow id="userInfo" v-if="!exceedsUserLimit" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')"></FormRow>
                     </template>
                     <template v-else>
                         <ul>
@@ -33,7 +35,7 @@ export default {
     components: {
         FormRow
     },
-    props: ['team'],
+    props: ['team', 'userCount', 'inviteCount'],
     data () {
         return {
             input: {
@@ -52,6 +54,16 @@ export default {
         },
         disableConfirm () {
             return this.responseErrors || !this.input.userInfo.trim() || this.errors.userInfo
+        },
+        totalMembers () {
+            const count = this.userCount + this.inviteCount
+            return count + ' member' + (count > 1 ? 's' : '')
+        },
+        hasUserLimit () {
+            return this.team.type.properties.userLimit > 0
+        },
+        exceedsUserLimit () {
+            return this.hasUserLimit && (this.userCount + this.inviteCount) >= this.team.type.properties.userLimit
         }
     },
     watch: {

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -1,22 +1,22 @@
 <template>
-    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disableConfirm" :closeOnConfirm="false">
+    <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disableConfirm">
         <template v-slot:default>
-            <form class="space-y-6" @submit.prevent>
-                <div class="space-y-2">
-                    <template v-if="!responseErrors">
-                        <p v-if="!exceedsUserLimit">Invite a user to join the team by username <span v-if="externalEnabled">or email</span>.</p>
-                        <p v-if="hasUserLimit">Your team can have a maximum of {{team.type.properties.userLimit}} members.</p>
-                        <p v-if="exceedsUserLimit">You currently have {{totalMembers}} (including existing invites) so cannot invite any more.</p>
-                        <FormRow id="userInfo" v-if="!exceedsUserLimit" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')"></FormRow>
-                    </template>
-                    <template v-else>
-                        <ul>
-                            <li class="text-sm" v-for="(value, name) in responseErrors" :key="name">
-                                <span class="font-medium">{{name}}</span>: <span>{{value}}</span>
-                            </li>
-                        </ul>
-                    </template>
-                </div>
+            <form class="space-y-2" @submit.prevent>
+                <template v-if="!responseErrors">
+                    <p v-if="!exceedsUserLimit">Invite a user to join the team by username <span v-if="externalEnabled">or email</span>.</p>
+                    <p v-if="hasUserLimit">Your team can have a maximum of {{team.type.properties.userLimit}} members.</p>
+                    <p v-if="exceedsUserLimit">You currently have {{totalMembers}} (including existing invites) so cannot invite any more.</p>
+                    <div v-if="!exceedsUserLimit" class="pt-4">
+                        <FormRow id="userInfo" v-model="input.userInfo" :error="errors.userInfo" :placeholder="'username'+(externalEnabled?' or email':'')"></FormRow>
+                    </div>
+                </template>
+                <template v-else>
+                    <ul>
+                        <li class="text-sm" v-for="(value, name) in responseErrors" :key="name">
+                            <span class="font-medium">{{name}}</span>: <span>{{value}}</span>
+                        </li>
+                    </ul>
+                </template>
             </form>
         </template>
     </ff-dialog>
@@ -53,7 +53,7 @@ export default {
             return this.settings.email && this.settings['team:user:invite:external']
         },
         disableConfirm () {
-            return this.responseErrors || !this.input.userInfo.trim() || this.errors.userInfo
+            return this.exceedsUserLimit || this.responseErrors || !this.input.userInfo.trim() || this.errors.userInfo
         },
         totalMembers () {
             const count = this.userCount + this.inviteCount


### PR DESCRIPTION
Closes #781 

This PR adds better UI around the team user limit.

If a team type has a user limit, the invite user dialog includes information on what that limit is:

<img width="601" alt="image" src="https://user-images.githubusercontent.com/51083/189960784-10ee2bd3-8d2e-47f2-8b2c-c87c46eef518.png">

If a team as at (or exceeds) the limit, the dialog doesn't allow any more invites to be sent:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/51083/189960324-dfcc1cae-cf77-49f8-9bbe-56ef85e43894.png">
