### PR TITLE
Remove tests and output from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ frontend/src/
 frontend/public/
 forge/containers/localfs_root/
 forge/licensing/dev-private-key_enc.pem
+test/


### PR DESCRIPTION
Making sure we don't ship the cypress videos in the npm package. Also no need to even ship the test code.

Trying to keep the packages as small as possible