### PR TITLE
Add page banner to notify if browsing team as admin

### DIFF
--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -6,6 +6,7 @@
                 <!-- Each view uses a <Teleport> to fill this -->
             </div>
             <div class="ff-view">
+                <div id="platform-banner"></div>
                 <slot></slot>
             </div>
             <TransitionGroup class="ff-notifications" name="notifictions-list" tag="div">

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -22,6 +22,9 @@
             </template>
         </SectionTopMenu>
         <div class="text-sm sm:px-6 mt-4 sm:mt-8">
+            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+                <div class="ff-banner">You are viewing this device as an Administrator</div>
+            </Teleport>
             <router-view :device="device" @device-updated="loadDevice()"></router-view>
         </div>
     </main>
@@ -30,6 +33,9 @@
 <script>
 // APIs
 import deviceApi from '@/api/devices'
+
+import { mapState } from 'vuex'
+import { Roles } from '@core/lib/roles'
 
 // components
 import NavItem from '@/components/NavItem'
@@ -56,6 +62,12 @@ export default {
             mounted: false,
             device: null,
             navigation: navigation
+        }
+    },
+    computed: {
+        ...mapState('account', ['teamMembership', 'team']),
+        isVisitingAdmin: function () {
+            return this.teamMembership.role === Roles.Admin
         }
     },
     mounted () {

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -33,6 +33,9 @@
             </template>
         </SectionTopMenu>
         <div class="text-sm mt-4 sm:mt-8">
+            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+                <div class="ff-banner">You are viewing this project as an Administrator</div>
+            </Teleport>
             <router-view :project="project" @projectUpdated="updateProject"></router-view>
         </div>
     </main>
@@ -83,6 +86,9 @@ export default {
         ...mapState('account', ['teamMembership', 'team', 'features']),
         isOwner: function () {
             return this.teamMembership.role === Roles.Owner
+        },
+        isVisitingAdmin: function () {
+            return this.teamMembership.role === Roles.Admin
         },
         options: function () {
             const flowActionsDisabled = !(this.project.meta && this.project.meta.state !== 'suspended')

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -7,6 +7,9 @@
             <Loading />
         </template>
         <div v-else-if="team">
+            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+                <div class="ff-banner">You are viewing this team as an Administrator</div>
+            </Teleport>
             <router-view :team="team" :teamMembership="teamMembership"></router-view>
         </div>
     </main>
@@ -16,13 +19,17 @@
 import Loading from '@/components/Loading'
 import { useRoute } from 'vue-router'
 import { mapState } from 'vuex'
+import { Roles } from '@core/lib/roles'
 
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
 
 export default {
     name: 'TeamPage',
     computed: {
-        ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features'])
+        ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features']),
+        isVisitingAdmin: function () {
+            return (this.teamMembership.role === Roles.Admin)
+        }
     },
     components: {
         Loading,

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -234,7 +234,13 @@ $nav_height: 60px;
         }
     }
 }
-
+.ff-banner {
+    background-color: $ff-grey-800;
+    color: $ff-grey-300;
+    padding: 8px;
+    text-align: center;
+    border-bottom: 2px solid $ff-red-500;
+}
 .ff-header {
     z-index: 10;
     background-color: $ff-grey-800;


### PR DESCRIPTION
Part of #940 

This adds a banner to the page if you are viewing a team/device/project as an admin *but you are not a member of the team*.

This is part of the strategy around #940. If admins can view things in teams they are not members of, we want to make sure they know that's happening so they don't accidentally do something whilst thinking it's their own team.

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/51083/190232156-6b213b4e-1c9f-48bc-9d33-288211d8cad4.png">
