### PR TITLE
Ensure admins have team-owner level access to all views in frontend

### DIFF
--- a/docs/user/team/README.md
+++ b/docs/user/team/README.md
@@ -24,10 +24,10 @@ user which expires in 7 days. Once accepted the user is added as "Member".
 Owners can remove a member from a team by clicking the dropdown menu next to the username and selecting 
 `Remove from team`. The team member will no longer have access to any team data.
 
-## Role based access control
+## Role-based access control
 
-Members can have 1 role for all projects in the team. Below there's a table to
-describe the different Roles apply for all projects in the team
+The role a user has in a team determines what they are able to do. The following
+table summaries what actions are available to the different roles.
 
 | Role                                 | Owner | Member |
 |:-------------------------------------|:-----:|:------:|
@@ -96,6 +96,8 @@ describe the different Roles apply for all projects in the team
 |                                      |       |        |
 | **Audit Log**                        | ✓     | -      |
 | **Team Settings**                    | ✓     | -      |
+
+*Note* Administrators users have owner-level access to all teams.
 
 #### Changing roles
 

--- a/frontend/src/components/SideNavigationTeamOptions.vue
+++ b/frontend/src/components/SideNavigationTeamOptions.vue
@@ -47,7 +47,7 @@ export default {
     computed: {
         ...mapState('account', ['user', 'team', 'teamMembership', 'features', 'notifications']),
         showAdmin: function () {
-            return this.teamMembership.role === Roles.Admin || this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         },
         nested: function () {
             return (this.$slots['nested-menu'] && this.loaded) || this.closeNested

--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -6,6 +6,7 @@
                 <!-- Each view uses a <Teleport> to fill this -->
             </div>
             <div class="ff-view">
+                <div id="platform-banner"></div>
                 <slot></slot>
             </div>
             <TransitionGroup class="ff-notifications" name="notifictions-list" tag="div">

--- a/frontend/src/pages/device/Settings/Danger.vue
+++ b/frontend/src/pages/device/Settings/Danger.vue
@@ -46,7 +46,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role !== Roles.Owner) {
+            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/device/Settings/General.vue
+++ b/frontend/src/pages/device/Settings/General.vue
@@ -46,7 +46,7 @@ export default {
     computed: {
         ...mapState('account', ['teamMembership']),
         isOwner: function () {
-            return this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         }
     },
     mounted () {

--- a/frontend/src/pages/device/Settings/index.vue
+++ b/frontend/src/pages/device/Settings/index.vue
@@ -24,25 +24,23 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership', 'team']),
-        isOwner: function () {
-            return this.teamMembership.role === Roles.Owner
-        }
+        ...mapState('account', ['teamMembership', 'team'])
     },
     mounted () {
         this.checkAccess()
     },
     methods: {
         checkAccess: async function () {
+            if (!this.teamMembership) {
+                useRouter().push({ replace: true, path: 'overview' })
+                return
+            }
             this.sideNavigation = [
                 { name: 'General', path: './general' },
                 { name: 'Environment', path: './environment' }
             ]
-            if (this.teamMembership && this.teamMembership.role === Roles.Owner) {
+            if (this.teamMembership && this.teamMembership.role >= Roles.Owner) {
                 this.sideNavigation.push({ name: 'Danger', path: './danger' })
-            }
-            if (!this.teamMembership || (this.teamMembership.role !== Roles.Owner && this.teamMembership.role !== Roles.Member)) {
-                useRouter().push({ replace: true, path: 'overview' })
             }
         }
     },

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -22,6 +22,9 @@
             </template>
         </SectionTopMenu>
         <div class="text-sm sm:px-6 mt-4 sm:mt-8">
+            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+                <div class="ff-banner">You are viewing this device as an Administrator</div>
+            </Teleport>
             <router-view :device="device" @device-updated="loadDevice()"></router-view>
         </div>
     </main>
@@ -30,6 +33,9 @@
 <script>
 // APIs
 import deviceApi from '@/api/devices'
+
+import { mapState } from 'vuex'
+import { Roles } from '@core/lib/roles'
 
 // components
 import NavItem from '@/components/NavItem'
@@ -56,6 +62,12 @@ export default {
             mounted: false,
             device: null,
             navigation: navigation
+        }
+    },
+    computed: {
+        ...mapState('account', ['teamMembership', 'team']),
+        isVisitingAdmin: function () {
+            return this.teamMembership.role === Roles.Admin
         }
     },
     mounted () {

--- a/frontend/src/pages/project/Settings/Danger.vue
+++ b/frontend/src/pages/project/Settings/Danger.vue
@@ -150,7 +150,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role !== Roles.Owner) {
+            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/project/Settings/Editor.vue
+++ b/frontend/src/pages/project/Settings/Editor.vue
@@ -81,7 +81,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role !== Roles.Owner) {
+            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/project/Settings/Palette.vue
+++ b/frontend/src/pages/project/Settings/Palette.vue
@@ -71,7 +71,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role !== Roles.Owner) {
+            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -9,7 +9,6 @@
 
 <script>
 import SectionSideMenu from '@/components/SectionSideMenu'
-import { useRouter } from 'vue-router'
 import { mapState } from 'vuex'
 import { Roles } from '@core/lib/roles'
 

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -39,13 +39,10 @@ export default {
                 { name: 'General', path: './general' },
                 { name: 'Environment', path: './environment' }
             ]
-            if (this.teamMembership && this.teamMembership.role === Roles.Owner) {
+            if (this.teamMembership && this.teamMembership.role >= Roles.Owner) {
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
                 this.sideNavigation.push({ name: 'Palette', path: './palette' })
                 this.sideNavigation.push({ name: 'Danger', path: './danger' })
-            }
-            if (this.teamMembership && (this.teamMembership.role !== Roles.Owner && this.teamMembership.role !== Roles.Member)) {
-                useRouter().push({ path: '../overview' })
             }
         }
     }

--- a/frontend/src/pages/project/Snapshots/index.vue
+++ b/frontend/src/pages/project/Snapshots/index.vue
@@ -131,10 +131,10 @@ export default {
     computed: {
         ...mapState('account', ['features', 'teamMembership']),
         canDelete: function () {
-            return this.teamMembership?.role === Roles.Owner
+            return this.teamMembership?.role >= Roles.Owner
         },
         canCreateSnapshot: function () {
-            return this.teamMembership?.role === Roles.Owner || this.teamMembership?.role === Roles.Member
+            return this.teamMembership?.role >= Roles.Member
         },
         columns: function () {
             const devicesEnabled = this.features.devices

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -33,6 +33,9 @@
             </template>
         </SectionTopMenu>
         <div class="text-sm mt-4 sm:mt-8">
+            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+                <div class="ff-banner">You are viewing this project as an Administrator</div>
+            </Teleport>
             <router-view :project="project" @projectUpdated="updateProject"></router-view>
         </div>
     </main>
@@ -83,6 +86,9 @@ export default {
         ...mapState('account', ['teamMembership', 'team', 'features']),
         isOwner: function () {
             return this.teamMembership.role === Roles.Owner
+        },
+        isVisitingAdmin: function () {
+            return this.teamMembership.role === Roles.Admin
         },
         options: function () {
             const flowActionsDisabled = !(this.project.meta && this.project.meta.state !== 'suspended')

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -85,7 +85,7 @@ export default {
     computed: {
         ...mapState('account', ['teamMembership', 'team', 'features']),
         isOwner: function () {
-            return this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         },
         isVisitingAdmin: function () {
             return this.teamMembership.role === Roles.Admin

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -29,9 +29,9 @@ export default {
             return await teamApi.getTeamAuditLog(projectId, cursor)
         },
         fetchData: async function (newVal) {
-            if (this.team.id && this.teamMembership && this.teamMembership.role === Roles.Owner) {
+            if (this.team.id && this.teamMembership && this.teamMembership.role >= Roles.Owner) {
                 this.verifiedTeam = this.team
-            } else if (this.teamMembership && this.teamMembership.role !== Roles.Owner) {
+            } else if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
                 this.$router.push({ path: `/team/${this.team.slug}/overview` })
             }
         }

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -229,10 +229,10 @@ export default {
             return this.project && this.project.id
         },
         addDeviceEnabled: function () {
-            return !this.isProjectDeviceView && this.teamMembership.role === Roles.Owner
+            return !this.isProjectDeviceView && this.teamMembership.role >= Roles.Owner
         },
         isOwner: function () {
-            return this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         },
         columns: function () {
             const targetSnapshot = this.project?.deviceSettings.targetSnapshot

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -23,6 +23,7 @@
 
 <script>
 import { markRaw } from 'vue'
+import { mapState } from 'vuex'
 
 import UserCell from '@/components/tables/cells/UserCell'
 import UserRoleCell from '@/components/tables/cells/UserRoleCell'
@@ -51,8 +52,9 @@ export default {
         team: 'fetchData'
     },
     computed: {
+        ...mapState('account', ['user']),
         isOwner: function () {
-            return this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         }
     },
     mounted () {
@@ -84,8 +86,7 @@ export default {
             this.users = members.members
             this.ownerCount = 0
 
-            const currentUser = this.users.find(user => user.username === this.$store.state.account.user.username)
-            this.canModifyMembers = this.$store.state.account.user.admin || (currentUser && (currentUser.role === Roles.Owner))
+            this.canModifyMembers = this.teamMembership.role >= Roles.Owner
 
             this.userColumns = [
                 { label: 'User', key: 'name', sortable: true, class: ['flex-grow'], component: { is: markRaw(UserCell) } },

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -49,7 +49,7 @@ export default {
         async fetchData () {
             this.loading = true
             if (this.team && this.teamMembership) {
-                if (this.teamMembership.role !== Roles.Owner && this.teamMembership.role !== Roles.Admin) {
+                if (this.teamMembership.role < Roles.Owner) {
                     useRouter().push({ path: `/team/${useRoute().params.team_slug}/members/general` })
                     return
                 }

--- a/frontend/src/pages/team/Members/index.vue
+++ b/frontend/src/pages/team/Members/index.vue
@@ -40,7 +40,7 @@ export default {
             this.sideNavigation = [
                 { name: 'Team Members', path: './general' }
             ]
-            if (this.user.admin || (this.teamMembership && this.teamMembership.role === Roles.Owner)) {
+            if (this.teamMembership.role >= Roles.Owner) {
                 const invitations = await teamApi.getTeamInvitations(this.team.id)
                 this.sideNavigation.push({ name: `Invitations (${invitations.count})`, path: './invitations' })
             }

--- a/frontend/src/pages/team/Overview.vue
+++ b/frontend/src/pages/team/Overview.vue
@@ -55,7 +55,7 @@ export default {
     },
     computed: {
         createProjectEnabled: function () {
-            return this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         },
         showingMessage: function () {
             return this.show.thankyou

--- a/frontend/src/pages/team/Projects.vue
+++ b/frontend/src/pages/team/Projects.vue
@@ -77,7 +77,7 @@ export default {
     },
     computed: {
         createProjectEnabled: function () {
-            return this.teamMembership.role === Roles.Owner
+            return this.teamMembership.role >= Roles.Owner
         }
     },
     props: ['team', 'teamMembership'],

--- a/frontend/src/pages/team/Settings/index.vue
+++ b/frontend/src/pages/team/Settings/index.vue
@@ -39,7 +39,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role !== Roles.Owner) {
+            if (this.teamMembership.role < Roles.Owner) {
                 useRouter().push({ path: `/team/${this.team.slug}/overview` })
             }
         }

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -7,6 +7,9 @@
             <Loading />
         </template>
         <div v-else-if="team">
+            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+                <div class="ff-banner">You are viewing this team as an Administrator</div>
+            </Teleport>
             <router-view :team="team" :teamMembership="teamMembership"></router-view>
         </div>
     </main>
@@ -16,13 +19,17 @@
 import Loading from '@/components/Loading'
 import { useRoute } from 'vue-router'
 import { mapState } from 'vuex'
+import { Roles } from '@core/lib/roles'
 
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
 
 export default {
     name: 'TeamPage',
     computed: {
-        ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features'])
+        ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features']),
+        isVisitingAdmin: function () {
+            return (this.teamMembership.role === Roles.Admin)
+        }
     },
     components: {
         Loading,

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -234,7 +234,13 @@ $nav_height: 60px;
         }
     }
 }
-
+.ff-banner {
+    background-color: $ff-grey-800;
+    color: $ff-grey-300;
+    padding: 8px;
+    text-align: center;
+    border-bottom: 2px solid $ff-red-500;
+}
 .ff-header {
     z-index: 10;
     background-color: $ff-grey-800;


### PR DESCRIPTION
Part of #940 

(includes #987)

This takes advantage of how roles are defined in `forge/lib/roles.js`

```
const Roles = {
    None: 0,
    Member: 30,
    Owner: 50,
    Admin: 99
}
```

Rather than check `role === Roles.Owner || role === Roles.Admin` we can more concisely do `role >= Roles.Owner`.