### PR TITLE
Ensure team is set when loading device page

### DIFF
--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -78,6 +78,7 @@ export default {
         loadDevice: async function () {
             const device = await deviceApi.getDevice(this.$route.params.id)
             this.device = device
+            this.$store.dispatch('account/setTeam', this.device.team.slug)
         }
     }
 }


### PR DESCRIPTION
Fixes #986 

This fix is consistent with how the Project page solves this problem - by setting the team once the device has been loaded so we know what team we're in.

This solves the immediate issue, but does lead to an unpleasant flicker of the team name as it is initialised to the user's default team before it gets 'corrected' by the device/project page.