### PR TITLE
Add case-insensitive unique constraint on User.username and email

### DIFF
--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -1,17 +1,18 @@
 const { compareHash, sha256 } = require('../utils')
 const jwt = require('jsonwebtoken')
+const { fn, col, where } = require('sequelize')
 
 module.exports = {
     /**
      * Validate the username/password
      */
     authenticateCredentials: async function (app, username, password) {
-        let clause = { username: username }
-        if (/.+@.+/.test(username)) {
-            clause = { email: username }
-        }
+        const column = /.+@.+/.test(username) ? 'email' : 'username'
         const user = await app.db.models.User.findOne({
-            where: clause,
+            where: where(
+                fn('lower', col(column)),
+                username.toLowerCase()
+            ),
             attributes: ['password']
         })
         // Always call compareSync, even if no user found, to ensure

--- a/forge/db/migrations/20220915-01-add-username-email-index.js
+++ b/forge/db/migrations/20220915-01-add-username-email-index.js
@@ -1,0 +1,12 @@
+/**
+ * Adds unique indexes on User.username and User.email with lower-case applied
+ */
+
+module.exports = {
+    up: async (context) => {
+        await context.addIndex('Users', { name: 'user_username_lower_unique', fields: [context.sequelize.fn('lower', context.sequelize.col('username'))], unique: true })
+        await context.addIndex('Users', { name: 'user_email_lower_unique', fields: [context.sequelize.fn('lower', context.sequelize.col('email'))], unique: true })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -112,9 +112,9 @@ module.exports = async function (app) {
         } catch (err) {
             let responseMessage
             if (/user_username_lower_unique/.test(err.parent?.toString())) {
-                responseMessage = 'username not unique'
+                responseMessage = 'username not available'
             } else if (/user_email_lower_unique/.test(err.parent?.toString())) {
-                responseMessage = 'email not unique'
+                responseMessage = 'email not available'
             } else if (err.errors) {
                 responseMessage = err.errors.map(err => err.message).join(',')
             } else {

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -111,7 +111,11 @@ module.exports = async function (app) {
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage
-            if (err.errors) {
+            if (/user_username_lower_unique/.test(err.parent?.toString())) {
+                responseMessage = 'username not unique'
+            } else if (/user_email_lower_unique/.test(err.parent?.toString())) {
+                responseMessage = 'email not unique'
+            } else if (err.errors) {
                 responseMessage = err.errors.map(err => err.message).join(',')
             } else {
                 responseMessage = err.toString()

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -292,7 +292,11 @@ module.exports = fp(async function (app, opts, done) {
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage
-            if (err.errors) {
+            if (/user_username_lower_unique/.test(err.parent?.toString())) {
+                responseMessage = 'username not available'
+            } else if (/user_email_lower_unique/.test(err.parent?.toString())) {
+                responseMessage = 'email not available'
+            } else if (err.errors) {
                 responseMessage = err.errors.map(err => err.message).join(',')
             } else {
                 responseMessage = err.toString()

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -4,16 +4,16 @@
             <h2>Sign Up</h2>
             <div>
                 <label>Username</label>
-                <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" @enter="focusPassword"/>
+                <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
                 <label class="ff-error-inline">{{ errors.username }}</label>
                 <label>Full Name</label>
-                <ff-text-input ref="signup-fullname" label="Full Name" :error="errors.name" v-model="input.name" @enter="focusPassword"/>
+                <ff-text-input ref="signup-fullname" label="Full Name" :error="errors.name" v-model="input.name" />
                 <label class="ff-error-inline">{{ errors.name }}</label>
                 <label>E-Mail Address</label>
-                <ff-text-input ref="signup-email" label="E-Mail Address" :error="errors.email" v-model="input.email" @enter="focusPassword"/>
+                <ff-text-input ref="signup-email" label="E-Mail Address" :error="errors.email" v-model="input.email" />
                 <label class="ff-error-inline">{{ errors.email }}</label>
                 <label>Password</label>
-                <ff-text-input ref="signup-password" label="password" :error="errors.password" v-model="input.password" @enter="login" type="password"/>
+                <ff-text-input ref="signup-password" label="password" :error="errors.password" v-model="input.password" type="password"/>
                 <label class="ff-error-inline">{{ errors.password }}</label>
             </div>
             <div v-if="settings['user:tcs-required']">
@@ -126,8 +126,8 @@ export default {
                     if (/password/.test(err.response.data.error)) {
                         this.errors.password = 'Invalid username'
                     }
-                    if (err.response.data.error === 'email must be unique') {
-                        this.errors.email = 'Email already registered'
+                    if (/email/.test(err.response.data.error)) {
+                        this.errors.email = 'Email unavailable'
                     }
                     if (err.response.data.error === 'user registration not enabled') {
                         // TODO Where to show this error?

--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -124,8 +124,8 @@ export default {
                     if (/password/.test(err.response.data.error)) {
                         this.errors.password = 'Invalid username'
                     }
-                    if (err.response.data.error === 'email must be unique') {
-                        this.errors.email = 'Email already registered'
+                    if (/email/.test(err.response.data.error)) {
+                        this.errors.email = 'Email unavailable'
                     }
                 }
             })

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -85,7 +85,7 @@ describe('Accounts API', async function () {
                 password: '12345678',
                 name: 'u1.2',
                 email: 'u1-2@example.com'
-            }, /username must be unique/)
+            }, /username not available/)
         })
         it('rejects duplicate email', async function () {
             app = await setup()
@@ -103,7 +103,7 @@ describe('Accounts API', async function () {
                 password: '12345678',
                 name: 'u1.2',
                 email: 'u1@example.com'
-            }, /email must be unique/)
+            }, /email not available/)
         })
 
         it('limits how many users can be created according to license', async function () {


### PR DESCRIPTION
Closes #983 

It took some digging, but I found a sequelize unit test for adding a unique index that uses the `lower` function. This means we can add a unique index to the table, without having to add another column:

```
indexes: [
   { name: 'user_username_lower_unique', fields: [sequelize.fn('lower', sequelize.col('username'))], unique: true }
]
```

I have tested and verified this constrain works as required on both sqlite and postgres.

Alongside this, I've updated the `User.byUsername/email` getter functions to do case insensitive queries and improved the feedback in the Admin Create User page and User Registration page.