### PR TITLE
Extend login sessions to one week with idle timeout

### DIFF
--- a/forge/db/controllers/Session.js
+++ b/forge/db/controllers/Session.js
@@ -1,6 +1,14 @@
 const { generateToken } = require('../utils')
 
-const DEFAULT_WEB_SESSION_EXPIRY = 1000 * 60 * 60 * 24 // One day session
+const HOUR = 1000 * 60 * 60
+// This is the maximum time a user can be logged in for before being asked to reauth
+const DEFAULT_WEB_SESSION_EXPIRY = HOUR * 24 * 7 // One week expiry
+// If a session is inactive for this time, it will be expired
+const DEFAULT_WEB_SESSION_IDLE_TIMEOUT = HOUR * 32 // 32 hours
+// We only update the idle time if there is activity within this period prior
+// to idle timeout. That avoids the need to update idle timeout on every single request
+const DEFAULT_WEB_SESSION_IDLE_GRACE = HOUR * 6 // 6 hours
+
 const DEFAULT_TOKEN_SESSION_EXPIRY = 1000 * 60 * 30 // 30 mins session - with refresh token support
 
 module.exports = {
@@ -13,6 +21,7 @@ module.exports = {
             return app.db.models.Session.create({
                 sid: generateToken(32, 'ffu'),
                 expiresAt: Date.now() + DEFAULT_WEB_SESSION_EXPIRY,
+                idleAt: Date.now() + DEFAULT_WEB_SESSION_IDLE_TIMEOUT,
                 UserId: user.id
             })
         }
@@ -68,13 +77,25 @@ module.exports = {
             where: { sid },
             include: app.db.models.User
         })
+        const now = Date.now()
         if (session) {
-            if (session.expiresAt.getTime() < Date.now()) {
+            if (session.expiresAt.getTime() < now) {
                 if (!session.refreshToken) {
                     // A web login session that can be removed
                     await session.destroy()
                 }
                 session = null
+            } else if (!session.refreshToken) {
+                // Only do idle test for web tokens
+                const idleIn = (session.idleAt?.getTime() || now) - now
+                if (idleIn >= 0 && idleIn < DEFAULT_WEB_SESSION_IDLE_GRACE) {
+                    session.idleAt = Date.now() + DEFAULT_WEB_SESSION_IDLE_TIMEOUT
+                    await session.save()
+                } else if (idleIn < 0) {
+                    // idled out
+                    await session.destroy()
+                    session = null
+                }
             }
         }
         return session

--- a/forge/db/controllers/Session.js
+++ b/forge/db/controllers/Session.js
@@ -7,7 +7,7 @@ const DEFAULT_WEB_SESSION_EXPIRY = HOUR * 24 * 7 // One week expiry
 const DEFAULT_WEB_SESSION_IDLE_TIMEOUT = HOUR * 32 // 32 hours
 // We only update the idle time if there is activity within this period prior
 // to idle timeout. That avoids the need to update idle timeout on every single request
-const DEFAULT_WEB_SESSION_IDLE_GRACE = HOUR * 6 // 6 hours
+const DEFAULT_WEB_SESSION_IDLE_GRACE = HOUR * 31 // 31 hours
 
 const DEFAULT_TOKEN_SESSION_EXPIRY = 1000 * 60 * 30 // 30 mins session - with refresh token support
 

--- a/forge/db/migrations/20220920-01-add-session-idle-timeout.js
+++ b/forge/db/migrations/20220920-01-add-session-idle-timeout.js
@@ -1,0 +1,15 @@
+/**
+ * Adds idleAt column to Session column
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.addColumn('Sessions', 'idleAt', {
+            type: DataTypes.DATE,
+            allowNull: true
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Session.js
+++ b/forge/db/models/Session.js
@@ -11,6 +11,7 @@ module.exports = {
     schema: {
         sid: { type: DataTypes.STRING, primaryKey: true, allowNull: false },
         expiresAt: { type: DataTypes.DATE, allowNull: false },
+        idleAt: { type: DataTypes.DATE },
         refreshToken: {
             type: DataTypes.STRING,
             set (value) {

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -2,11 +2,10 @@ import client from './client'
 import daysSince from '@/utils/daysSince'
 import elapsedTime from '@/utils/elapsedTime'
 
-const login = (username, password, remember) => {
+const login = (username, password) => {
     return client.post('/account/login', {
         username,
-        password,
-        remember
+        password
     }).then((res) => {
         return res.data
     })

--- a/frontend/src/components/auth/Credentials.vue
+++ b/frontend/src/components/auth/Credentials.vue
@@ -8,9 +8,6 @@
             <ff-text-input ref="login-password" label="password" :error="errors.password" v-model="input.password" @enter="login" type="password"/>
             <label class="ff-error-inline">{{ errors.password }}</label>
         </div>
-        <div>
-            <ff-checkbox v-model="input.remember" label="Remember Me"></ff-checkbox>
-        </div>
         <label class="ff-error-inline">{{ errors.general }}</label>
         <div class="ff-actions">
             <ff-button @click="login()" data-action="login">Login</ff-button>
@@ -30,8 +27,7 @@ export default {
         return {
             input: {
                 username: '',
-                password: '',
-                remember: false
+                password: ''
             },
             errors: {
                 general: null,

--- a/frontend/src/components/auth/UpdateExpiredPassword.vue
+++ b/frontend/src/components/auth/UpdateExpiredPassword.vue
@@ -25,8 +25,7 @@ export default {
         return {
             input: {
                 username: '',
-                password: '',
-                remember: false
+                password: ''
             },
             errors: {
                 username: null,

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -237,7 +237,7 @@ const actions = {
     async login (state, credentials) {
         try {
             state.commit('setLoginInflight')
-            await userApi.login(credentials.username, credentials.password, credentials.remember)
+            await userApi.login(credentials.username, credentials.password)
             state.dispatch('checkState', state.getters.redirectUrlAfterLogin)
         } catch (err) {
             if (err.response.status === 401) {


### PR DESCRIPTION
Fixes #972 

This modifies how we handle login sessions as described in https://github.com/flowforge/flowforge/issues/972#issuecomment-1252266637

More specifically:

 - adds `idleAt` timestamp to Session object
 - sets `Session.expiresAt` to `now + 7 days`
 - sets `Session.idleAt` to `now + 32 hours`
 - When accessing API:
    - if `Session.expiresAt` is in the past - destroy session and logout
    - if `Session.idleAt` is in the past - destroy session and logout
    - if `Session.idleAt` is < 31 hours in the future, update it to `now + 32 hours` - this keeps extending the session as long as the user is 'active', whilst avoiding hammering the db by updating the idle time with every single request.

 - Removes the `remember me` checkbox from the UI and API - we didn't have the logic right for it.