### PR TITLE
Introduce hasPermission mixin for checking rbac in frontend

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -1,0 +1,49 @@
+const { Roles } = require('./roles.js')
+
+module.exports = {
+    Permissions: {
+        // Team Scoped Actions
+        'team:create': { description: 'Create Team', admin: false },
+        'team:edit': { description: 'Edit Team', role: Roles.Owner },
+        'team:delete': { description: 'Delete Team', role: Roles.Owner },
+        'team:audit-log': { description: 'Access Team Audit Log', role: Roles.Owner },
+        // Team Members
+        'team:user:add': { description: 'Add Members', role: Roles.Admin },
+        'team:user:invite': { description: 'Invite Members', role: Roles.Owner },
+        'team:user:remove': { description: 'Remove Member', role: Roles.Owner, self: true },
+        'team:user:change-role': { description: 'Modify Member role', role: Roles.Owner },
+        // Projects
+        'project:create': { description: 'Create Project', role: Roles.Owner },
+        'project:delete': { description: 'Delete Project', role: Roles.Owner },
+        'project:transfer': { description: 'Transfer Project', role: Roles.Owner },
+        'project:change-status': { description: 'Start/Stop Project', role: Roles.Owner },
+        'project:edit': { description: 'Edit Project Settings', role: Roles.Owner },
+        'project:edit-env': { description: 'Edit Project Environment Variables', role: Roles.Member },
+        'project:log': { description: 'Access Project Log', role: Roles.Member },
+        'project:audit-log': { description: 'Access Project Audit Log', role: Roles.Member },
+        // Project Editor
+        'project:flows:view': { description: 'View Project Flows', role: Roles.Member },
+        'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member },
+        'project:snapshot:create': { description: 'Create Project Snapshot', role: Roles.Member },
+        'project:snapshot:delete': { description: 'Delete Project Snapshot', role: Roles.Owner },
+        'project:snapshot:rollback': { description: 'Rollback Project Snapshot', role: Roles.Member },
+        // Templates
+        'template:create': { description: 'Create a Template', role: Roles.Admin },
+        'template:delete': { description: 'Delete a Template', role: Roles.Admin },
+        'template:edit': { description: 'Edit a Template', role: Roles.Admin },
+        // Stacks
+        'stack:create': { description: 'Create a Stack', role: Roles.Admin },
+        'stack:delete': { description: 'Delete a Stack', role: Roles.Admin },
+        'stack:edit': { description: 'Edit a Stack', role: Roles.Admin },
+        // Devices
+        'device:list': { description: 'List Devices', role: Roles.Admin },
+        'device:create': { description: 'Create a Device', role: Roles.Owner },
+        'device:delete': { description: 'Delete a Device', role: Roles.Owner },
+        'device:edit': { description: 'Edit a Device', role: Roles.Owner },
+        'device:edit-env': { description: 'Edit Device Environment Variables', role: Roles.Member },
+        // Project Types
+        'project-type:create': { description: 'Create a ProjectType', role: Roles.Admin },
+        'project-type:delete': { description: 'Delete a ProjectType', role: Roles.Admin },
+        'project-type:edit': { description: 'Edit a ProjectType', role: Roles.Admin }
+    }
+}

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -10,7 +10,6 @@
  */
 module.exports = async function (app) {
     const changeStatusPreHandler = { preHandler: app.needsPermission('project:change-status') }
-    const rollbackPreHandler = { preHandler: app.needsPermission('project:rollback') }
     app.post('/start', changeStatusPreHandler, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
@@ -109,7 +108,7 @@ module.exports = async function (app) {
         }
     })
 
-    app.post('/rollback', rollbackPreHandler, async (request, reply) => {
+    app.post('/rollback', { preHandler: app.needsPermission('project:snapshot:rollback') }, async (request, reply) => {
         let restartProject = false
         try {
             // get (and check) snapshot is valid / owned by project before any actions

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -1,56 +1,9 @@
 const fp = require('fastify-plugin')
-const { Roles } = require('../../lib/roles.js')
-
-const defaultPermissions = {
-    // Team Scoped Actions
-    'team:create': { description: 'Create Team', admin: false },
-    'team:edit': { description: 'Edit Team', role: Roles.Owner },
-    'team:delete': { description: 'Delete Team', role: Roles.Owner },
-    'team:audit-log': { description: 'Access Team Audit Log', role: Roles.Owner },
-    // Team Members
-    'team:user:add': { description: 'Add Members', role: Roles.Admin },
-    'team:user:invite': { description: 'Invite Members', role: Roles.Owner },
-    'team:user:remove': { description: 'Remove Member', role: Roles.Owner, self: true },
-    'team:user:change-role': { description: 'Modify Member role', role: Roles.Owner },
-    // Projects
-    'project:create': { description: 'Create Project', role: Roles.Owner },
-    'project:delete': { description: 'Delete Project', role: Roles.Owner },
-    'project:transfer': { description: 'Transfer Project', role: Roles.Owner },
-    'project:change-status': { description: 'Start/Stop Project', role: Roles.Owner },
-    'project:rollback': { description: 'Start/Stop Project', role: Roles.Member },
-    'project:edit': { description: 'Edit Project Settings', role: Roles.Owner },
-    'project:edit-env': { description: 'Edit Project Environment Variables', role: Roles.Member },
-    'project:log': { description: 'Access Project Log', role: Roles.Member },
-    'project:audit-log': { description: 'Access Project Audit Log', role: Roles.Member },
-    // Project Editor
-    'project:flows:view': { description: 'View Project Flows', role: Roles.Member },
-    'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member },
-    'project:snapshot:create': { description: 'Create Project Snapshot', role: Roles.Member },
-    'project:snapshot:delete': { description: 'Delete Project Snapshot', role: Roles.Owner },
-    // Templates
-    'template:create': { description: 'Create a Template', role: Roles.Admin },
-    'template:delete': { description: 'Delete a Template', role: Roles.Admin },
-    'template:edit': { description: 'Edit a Template', role: Roles.Admin },
-    // Stacks
-    'stack:create': { description: 'Create a Stack', role: Roles.Admin },
-    'stack:delete': { description: 'Delete a Stack', role: Roles.Admin },
-    'stack:edit': { description: 'Edit a Stack', role: Roles.Admin },
-    // Devices
-    'device:list': { description: 'List Devices', role: Roles.Admin },
-    'device:create': { description: 'Create a Device', role: Roles.Owner },
-    'device:delete': { description: 'Delete a Device', role: Roles.Owner },
-    'device:edit': { description: 'Edit a Device', role: Roles.Owner },
-    'device:edit-env': { description: 'Edit Device Environment Variables', role: Roles.Member },
-    // Project Types
-    'project-type:create': { description: 'Create a ProjectType', role: Roles.Admin },
-    'project-type:delete': { description: 'Delete a ProjectType', role: Roles.Admin },
-    'project-type:edit': { description: 'Edit a ProjectType', role: Roles.Admin }
-
-}
+const { Permissions } = require('../../lib/permissions')
 
 module.exports = fp(async function (app, opts, done) {
     function needsPermission (scope) {
-        if (!defaultPermissions[scope]) {
+        if (!Permissions[scope]) {
             throw new Error(`Unrecognised scope requested: '${scope}'`)
         }
         return async (request, reply) => {
@@ -65,7 +18,7 @@ module.exports = fp(async function (app, opts, done) {
 
             // For all Team based permissions, the request should already have
             // request.team and request.teamMembership set
-            const permission = defaultPermissions[scope]
+            const permission = Permissions[scope]
             if (permission.admin) {
                 // Requires admin user - which would have already been approved
                 // if they were an admin

--- a/frontend/src/components/SideNavigationTeamOptions.vue
+++ b/frontend/src/components/SideNavigationTeamOptions.vue
@@ -10,11 +10,11 @@
                     <nav-item :label="route.label" :icon="route.icon"></nav-item>
                 </router-link>
             </ul>
-            <span v-if="showAdmin" class="ff-navigation-divider">
+            <span v-if="hasPermission('team:edit')" class="ff-navigation-divider">
                 <label>Team Admin Zone</label>
             </span>
             <!-- Team Options: Admin -->
-            <ul v-if="showAdmin" class="ff-side-navigation--admin">
+            <ul v-if="hasPermission('team:edit')" class="ff-side-navigation--admin">
                 <router-link v-for="route in routes.admin" :key="route.label"
                              :to="'/team/' + team.slug + route.to"
                              :data-nav="route.tag">
@@ -31,7 +31,7 @@
 <script>
 import { mapState } from 'vuex'
 
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 import ProjectsIcon from '@/components/icons/Projects'
 import { ChipIcon, UsersIcon, DatabaseIcon, TemplateIcon, CurrencyDollarIcon, CogIcon } from '@heroicons/vue/solid'
@@ -41,14 +41,12 @@ export default {
     name: 'FFSideNavigationTeamOptions',
     props: ['mobile-menu-open'],
     emits: ['option-selected'],
+    mixins: [permissionsMixin],
     components: {
         NavItem
     },
     computed: {
         ...mapState('account', ['user', 'team', 'teamMembership', 'features', 'notifications']),
-        showAdmin: function () {
-            return this.teamMembership.role >= Roles.Owner
-        },
         nested: function () {
             return (this.$slots['nested-menu'] && this.loaded) || this.closeNested
         }

--- a/frontend/src/mixins/Permissions.js
+++ b/frontend/src/mixins/Permissions.js
@@ -1,0 +1,22 @@
+import { Permissions } from '@core/lib/permissions'
+
+export default {
+    methods: {
+        hasPermission (scope) {
+            if (!Permissions[scope]) {
+                throw new Error(`Unrecognised scope requested: '${scope}'`)
+            }
+            const permission = Permissions[scope]
+            // if (<check settings>) {
+            if (permission.role) {
+                if (!this.teamMembership) {
+                    return false
+                }
+                if (this.teamMembership.role < permission.role) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -23,7 +23,7 @@
                             v-model="item.name"
                             :error="item.error"
                             :disabled="item.encrypted"
-                            :type="(editTemplate || item.policy === undefined)?'text':'uneditable'"></FormRow>
+                            :type="(!readOnly && (editTemplate || item.policy === undefined))?'text':'uneditable'"></FormRow>
                         <!-- <ff-text-input  v-model="item.name" :disabled="item.encrypted"  /> -->
                     </td>
                     <td class="px-4 py-4 border w-auto align-top" :class="{'align-middle':item.encrypted}">
@@ -31,12 +31,12 @@
                             <FormRow
                                 class="font-mono"
                                 v-model="item.value"
-                                :type="(editTemplate || item.policy === undefined || item.policy)?'text':'uneditable'"></FormRow>
+                                :type="(!readOnly && (editTemplate || item.policy === undefined || item.policy))?'text':'uneditable'"></FormRow>
                         </div>
                         <div v-else class="pt-1 text-gray-400"><LockClosedIcon class="inline w-4" /> encrypted</div>
                     </td>
                     <td class="border w-16 align-middle">
-                        <div v-if="(editTemplate|| item.policy === undefined )" class="flex justify-center ">
+                        <div v-if="(!readOnly && (editTemplate|| item.policy === undefined))" class="flex justify-center ">
                             <ff-button kind="tertiary" @click="removeEnv(itemIdx)" size="small">
                                 <template v-slot:icon>
                                     <TrashIcon />
@@ -44,7 +44,7 @@
                             </ff-button>
                         </div>
                     </td>
-                    <td v-if="editTemplate" class="px-4 py-4 align-middle">
+                    <td v-if="!readOnly && editTemplate" class="px-4 py-4 align-middle">
                         <LockSetting :editTemplate="editTemplate" v-model="item.policy"></LockSetting>
                     </td>
                 </tr>
@@ -54,10 +54,10 @@
                     </td>
                 </tr>
                 <!-- Empty row to differentiate between the existing env vars, and the iput form row-->
-                <tr>
+                <tr v-if="!readOnly">
                     <td :colspan="editTemplate?4:3" class="p-4 bg-gray-50"></td>
                 </tr>
-                <tr class="">
+                <tr v-if="!readOnly" class="">
                     <td class="px-4 pt-4 border w-auto align-top">
                         <FormRow class="font-mono" v-model="input.name" :error="input.error" placeholder="Name"></FormRow>
                     </td>
@@ -92,7 +92,7 @@ import { TrashIcon, PlusSmIcon, LockClosedIcon } from '@heroicons/vue/outline'
 
 export default {
     name: 'TemplateEnvironmentEditor',
-    props: ['editTemplate', 'modelValue'],
+    props: ['editTemplate', 'modelValue', 'readOnly'],
     emits: ['update:modelValue'],
     data () {
         return {

--- a/frontend/src/pages/device/Settings/Danger.vue
+++ b/frontend/src/pages/device/Settings/Danger.vue
@@ -16,9 +16,9 @@
 <script>
 import { mapState } from 'vuex'
 import { useRouter } from 'vue-router'
-import { Roles } from '@core/lib/roles'
 
 import deviceApi from '@/api/devices'
+import permissionsMixin from '@/mixins/Permissions'
 
 import FormHeading from '@/components/FormHeading'
 import ConfirmDeviceDeleteDialog from './dialogs/ConfirmDeviceDeleteDialog'
@@ -27,6 +27,7 @@ export default {
     name: 'DeviceSettingsDanger',
     props: ['device'],
     emits: ['device-updated'],
+    mixins: [permissionsMixin],
     components: {
         ConfirmDeviceDeleteDialog,
         FormHeading
@@ -46,7 +47,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
+            if (!this.hasPermission('device:edit')) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/device/Settings/Environment.vue
+++ b/frontend/src/pages/device/Settings/Environment.vue
@@ -1,20 +1,24 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsEnvironment v-model="editable" :editTemplate="false" />
-        <div class="space-x-4 whitespace-nowrap">
+        <TemplateSettingsEnvironment :readOnly="!hasPermission('device:edit-env')" v-model="editable" :editTemplate="false" />
+        <div v-if="hasPermission('device:edit-env')" class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save Settings</ff-button>
         </div>
     </form>
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import deviceApi from '@/api/devices'
+import permissionsMixin from '@/mixins/Permissions'
 import TemplateSettingsEnvironment from '../../admin/Template/sections/Environment'
 
 export default {
     name: 'DeviceSettingsEnvironment',
     props: ['device'],
     emits: ['device-updated'],
+    mixins: [permissionsMixin],
     watch: {
         device: 'getSettings',
         'editable.settings.env': {
@@ -77,6 +81,9 @@ export default {
     },
     mounted () {
         this.getSettings()
+    },
+    computed: {
+        ...mapState('account', ['teamMembership'])
     },
     methods: {
         getSettings: async function () {

--- a/frontend/src/pages/device/Settings/General.vue
+++ b/frontend/src/pages/device/Settings/General.vue
@@ -8,7 +8,7 @@
             Name
         </FormRow>
 
-        <div v-if="isOwner">
+        <div v-if="hasPermission('device:edit')">
             <ff-button v-if="!editing.deviceName" kind="primary" @click="editDevice">Edit Device</ff-button>
             <ff-button v-else kind="primary" @click="updateDevice">Save Changes</ff-button>
         </div>
@@ -20,12 +20,13 @@ import deviceApi from '@/api/devices'
 import FormRow from '@/components/FormRow'
 
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'DeviceSettings',
     props: ['device'],
     emits: ['device-updated'],
+    mixins: [permissionsMixin],
     data () {
         return {
             editing: {
@@ -44,10 +45,7 @@ export default {
         device: 'fetchData'
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
-        isOwner: function () {
-            return this.teamMembership.role >= Roles.Owner
-        }
+        ...mapState('account', ['teamMembership'])
     },
     mounted () {
         this.fetchData()

--- a/frontend/src/pages/device/Settings/index.vue
+++ b/frontend/src/pages/device/Settings/index.vue
@@ -12,12 +12,13 @@ import SectionSideMenu from '@/components/SectionSideMenu'
 
 import { mapState } from 'vuex'
 import { useRouter } from 'vue-router'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'DeviceSettins',
     props: ['device'],
     emits: ['device-updated'],
+    mixins: [permissionsMixin],
     data: function () {
         return {
             sideNavigation: []
@@ -39,7 +40,7 @@ export default {
                 { name: 'General', path: './general' },
                 { name: 'Environment', path: './environment' }
             ]
-            if (this.teamMembership && this.teamMembership.role >= Roles.Owner) {
+            if (this.hasPermission('device:edit')) {
                 this.sideNavigation.push({ name: 'Danger', path: './danger' })
             }
         }

--- a/frontend/src/pages/project/Settings/Danger.vue
+++ b/frontend/src/pages/project/Settings/Danger.vue
@@ -114,6 +114,7 @@ import projectApi from '@/api/project'
 
 import Dialog from '@/services/dialog'
 import alerts from '@/services/alerts'
+import permissionsMixin from '@/mixins/Permissions'
 
 import FormHeading from '@/components/FormHeading'
 import ConfirmProjectDeleteDialog from './dialogs/ConfirmProjectDeleteDialog'
@@ -122,12 +123,12 @@ import ChangeTypeDialog from './dialogs/ChangeTypeDialog'
 import ExportToProjectDialog from './dialogs/ExportToProjectDialog'
 import { useRouter } from 'vue-router'
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
 
 export default {
     name: 'ProjectSettingsDanger',
     props: ['project'],
     emits: ['projectUpdated'],
+    mixins: [permissionsMixin],
     computed: {
         ...mapState('account', ['team', 'features', 'teamMembership']),
         isLoading: function () {
@@ -150,7 +151,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
+            if (!this.hasPermission('project:edit')) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/project/Settings/Editor.vue
+++ b/frontend/src/pages/project/Settings/Editor.vue
@@ -12,7 +12,7 @@ import alerts from '@/services/alerts'
 
 import { useRouter } from 'vue-router'
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 import projectApi from '@/api/project'
 import TemplateSettingsEditor from '../../admin/Template/sections/Editor'
@@ -45,6 +45,7 @@ export default {
         }
     },
     props: ['project'],
+    mixins: [permissionsMixin],
     computed: {
         ...mapState('account', ['team', 'teamMembership'])
     },
@@ -81,7 +82,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
+            if (!this.hasPermission('project:edit')) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/project/Settings/Palette.vue
+++ b/frontend/src/pages/project/Settings/Palette.vue
@@ -21,7 +21,7 @@ import {
 
 import { useRouter } from 'vue-router'
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'ProjectSettingsEditor',
@@ -46,6 +46,7 @@ export default {
         }
     },
     props: ['project'],
+    mixins: [permissionsMixin],
     computed: {
         ...mapState('account', ['team', 'teamMembership'])
     },
@@ -71,7 +72,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
+            if (!this.hasPermission('project:edit')) {
                 useRouter().push({ replace: true, path: 'general' })
             }
         },

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -10,11 +10,12 @@
 <script>
 import SectionSideMenu from '@/components/SectionSideMenu'
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'ProjectSettings',
     props: ['project'],
+    mixins: [permissionsMixin],
     computed: {
         ...mapState('account', ['team', 'teamMembership'])
     },
@@ -38,7 +39,7 @@ export default {
                 { name: 'General', path: './general' },
                 { name: 'Environment', path: './environment' }
             ]
-            if (this.teamMembership && this.teamMembership.role >= Roles.Owner) {
+            if (this.hasPermission('project:edit')) {
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
                 this.sideNavigation.push({ name: 'Palette', path: './palette' })
                 this.sideNavigation.push({ name: 'Danger', path: './danger' })

--- a/frontend/src/pages/project/Snapshots/index.vue
+++ b/frontend/src/pages/project/Snapshots/index.vue
@@ -29,7 +29,6 @@
 
 import { markRaw } from 'vue'
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
 import permissionsMixin from '@/mixins/Permissions'
 
 import Alerts from '@/services/alerts'

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -7,11 +7,12 @@
 import teamApi from '@/api/team'
 import SectionTopMenu from '@/components/SectionTopMenu'
 import AuditLog from '@/components/AuditLog'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'TeamAuditLog',
     props: ['team', 'teamMembership'],
+    mixins: [permissionsMixin],
     watch: {
         team: 'fetchData',
         teamMembership: 'fetchData'
@@ -29,9 +30,9 @@ export default {
             return await teamApi.getTeamAuditLog(projectId, cursor)
         },
         fetchData: async function (newVal) {
-            if (this.team.id && this.teamMembership && this.teamMembership.role >= Roles.Owner) {
+            if (this.hasPermission('team:audit-log')) {
                 this.verifiedTeam = this.team
-            } else if (this.teamMembership && this.teamMembership.role < Roles.Owner) {
+            } else {
                 this.$router.push({ path: `/team/${this.team.slug}/overview` })
             }
         }

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -3,22 +3,22 @@
     <form v-else class="space-y-6 mb-8">
         <div class="text-right"></div>
         <ff-data-table data-el="members-table" :columns="userColumns" :rows="users" :show-search="true" search-placeholder="Search Team Members..." :search-fields="['name', 'username', 'role']">
-            <template v-if="isOwner" v-slot:actions>
+            <template v-if="hasPermission('team:user:invite')" v-slot:actions>
                 <ff-button data-action="member-invite-button" kind="primary" @click="inviteMember">
                     <template v-slot:icon-left><PlusSmIcon class="w-4" /></template>
                     Invite Member
                 </ff-button>
             </template>
-            <template v-if="isOwner" v-slot:context-menu="{row}">
-                <ff-list-item data-action="member-change-role" label="Change Role" @click="changeRoleDialog(row)" />
-                <ff-list-item data-action="member-remove-from-team" label="Remove From Team" kind="danger" @click="removeUserDialog(row)" />
+            <template v-if="canEditUser" v-slot:context-menu="{row}">
+                <ff-list-item v-if="hasPermission('team:user:change-role')" data-action="member-change-role" label="Change Role" @click="changeRoleDialog(row)" />
+                <ff-list-item v-if="hasPermission('team:user:remove')" data-action="member-remove-from-team" label="Remove From Team" kind="danger" @click="removeUserDialog(row)" />
             </template>
         </ff-data-table>
     </form>
 
     <ChangeTeamRoleDialog @roleUpdated="roleUpdated" ref="changeTeamRoleDialog" />
     <ConfirmTeamUserRemoveDialog @userRemoved="userRemoved" ref="confirmTeamUserRemoveDialog" />
-    <InviteMemberDialog @invitationSent="$emit('invites-updated')" :team="team" :inviteCount="inviteCount" :userCount="userCount" v-if="canModifyMembers" ref="inviteMemberDialog" />
+    <InviteMemberDialog @invitationSent="$emit('invites-updated')" :team="team" :inviteCount="inviteCount" :userCount="userCount" v-if="hasPermission('team:user:invite')" ref="inviteMemberDialog" />
 </template>
 
 <script>
@@ -31,6 +31,7 @@ import ChangeTeamRoleDialog from '../dialogs/ChangeTeamRoleDialog'
 import ConfirmTeamUserRemoveDialog from '../dialogs/ConfirmTeamUserRemoveDialog'
 import InviteMemberDialog from '../dialogs/InviteMemberDialog'
 
+import permissionsMixin from '@/mixins/Permissions'
 import teamApi from '@/api/team'
 import { PlusSmIcon } from '@heroicons/vue/outline'
 import { Roles } from '@core/lib/roles'
@@ -39,14 +40,14 @@ export default {
     name: 'TeamUsersGeneral',
     props: ['team', 'teamMembership', 'inviteCount'],
     emits: ['invites-updated'],
+    mixins: [permissionsMixin],
     data () {
         return {
             loading: false,
             users: [],
             userCount: 0,
             userColumns: [],
-            ownerCount: 0,
-            canModifyMembers: false
+            ownerCount: 0
         }
     },
     watch: {
@@ -54,8 +55,8 @@ export default {
     },
     computed: {
         ...mapState('account', ['user']),
-        isOwner: function () {
-            return this.teamMembership.role >= Roles.Owner
+        canEditUser: function () {
+            return this.hasPermission('team:user:remove') || this.hasPermission('team:user:change-role')
         }
     },
     mounted () {
@@ -87,21 +88,16 @@ export default {
             this.users = members.members
             this.ownerCount = 0
 
-            this.canModifyMembers = this.teamMembership.role >= Roles.Owner
-
             this.userColumns = [
                 { label: 'User', key: 'name', sortable: true, class: ['flex-grow'], component: { is: markRaw(UserCell) } },
                 { label: 'Role', key: 'role', sortable: true, class: ['w-40'], component: { is: markRaw(UserRoleCell) } }
             ]
-
-            if (this.canModifyMembers) {
-                if (this.users) {
-                    this.users.forEach(u => {
-                        if (u.role === Roles.Owner) {
-                            this.ownerCount++
-                        }
-                    })
-                }
+            if (this.users) {
+                this.users.forEach(u => {
+                    if (u.role === Roles.Owner) {
+                        this.ownerCount++
+                    }
+                })
             }
             this.loading = false
         }

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -17,12 +17,13 @@ import teamApi from '@/api/team'
 import { markRaw } from 'vue'
 import InviteUserCell from '@/components/tables/cells/InviteUserCell'
 import { useRoute, useRouter } from 'vue-router'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'MemberInviteTable',
     props: ['team', 'teamMembership', 'inviteCount'],
     emits: ['updated', 'invites-updated'],
+    mixins: [permissionsMixin],
     data () {
         return {
             loading: false,
@@ -49,7 +50,7 @@ export default {
         async fetchData () {
             this.loading = true
             if (this.team && this.teamMembership) {
-                if (this.teamMembership.role < Roles.Owner) {
+                if (!this.hasPermission('team:user:invite')) {
                     useRouter().push({ path: `/team/${useRoute().params.team_slug}/members/general` })
                     return
                 }

--- a/frontend/src/pages/team/Members/index.vue
+++ b/frontend/src/pages/team/Members/index.vue
@@ -13,11 +13,12 @@ import { mapState } from 'vuex'
 import teamApi from '@/api/team'
 
 import SectionTopMenu from '@/components/SectionTopMenu'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'TeamUsers',
     props: ['team', 'teamMembership'],
+    mixins: [permissionsMixin],
     computed: {
         ...mapState('account', ['user'])
     },
@@ -41,7 +42,7 @@ export default {
             this.sideNavigation = [
                 { name: 'Team Members', path: './general' }
             ]
-            if (this.teamMembership.role >= Roles.Owner) {
+            if (this.hasPermission('team:user:invite')) {
                 const invitations = await teamApi.getTeamInvitations(this.team.id)
                 this.inviteCount = invitations.count
                 this.sideNavigation.push({ name: `Invitations (${invitations.count})`, path: './invitations' })

--- a/frontend/src/pages/team/Overview.vue
+++ b/frontend/src/pages/team/Overview.vue
@@ -3,8 +3,8 @@
     <div v-else class="block md:flex">
         <div class="flex-grow">
             <SectionTopMenu hero="Projects">
-                <template v-if="createProjectEnabled" v-slot:tools>
-                    <ff-button v-if="createProjectEnabled" kind="primary" size="small" to="./projects/create" data-nav="create-project"><template v-slot:icon-left><PlusSmIcon /></template>Create Project</ff-button>
+                <template v-if="hasPermission('project:create')" v-slot:tools>
+                    <ff-button kind="primary" size="small" to="./projects/create" data-nav="create-project"><template v-slot:icon-left><PlusSmIcon /></template>Create Project</ff-button>
                 </template>
             </SectionTopMenu>
             <template v-if="projectCount > 0">
@@ -28,7 +28,7 @@
 
 <script>
 
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 import teamApi from '@/api/team'
 
@@ -40,6 +40,7 @@ import { PlusSmIcon } from '@heroicons/vue/outline'
 export default {
     name: 'TeamOverview',
     props: ['team', 'teamMembership'],
+    mixins: [permissionsMixin],
     data: function () {
         return {
             loading: false,
@@ -54,9 +55,6 @@ export default {
         }
     },
     computed: {
-        createProjectEnabled: function () {
-            return this.teamMembership.role >= Roles.Owner
-        },
         showingMessage: function () {
             return this.show.thankyou
         }

--- a/frontend/src/pages/team/Projects.vue
+++ b/frontend/src/pages/team/Projects.vue
@@ -1,7 +1,7 @@
 <template>
     <SectionTopMenu hero="Projects">
         <template v-slot:tools>
-            <ff-button data-action="create-project-1" v-if="createProjectEnabled" kind="primary" size="small" to="./projects/create" data-nav="create-project"><template v-slot:icon-left><PlusSmIcon /></template>Create Project</ff-button>
+            <ff-button data-action="create-project-1" v-if="hasPermission('project:create')" kind="primary" size="small" to="./projects/create" data-nav="create-project"><template v-slot:icon-left><PlusSmIcon /></template>Create Project</ff-button>
         </template>
     </SectionTopMenu>
     <form class="space-y-6">
@@ -10,7 +10,7 @@
             <ff-data-table data-el="projects-table" :columns="columns" :rows="projects" :show-search="true" search-placeholder="Search Projects..."
                            :rows-selectable="true" @row-selected="openProject"/>
         </template>
-        <template v-else-if="createProjectEnabled && !loading">
+        <template v-else-if="hasPermission('project:create') && !loading">
             <div class="flex justify-center mb-4 p-8">
                 <ff-button data-action="create-project-2" to="./projects/create">
                     <template v-slot:icon-right>
@@ -31,7 +31,8 @@
 
 <script>
 import { markRaw } from 'vue'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
+
 import teamApi from '@/api/team'
 import { PlusSmIcon } from '@heroicons/vue/outline'
 import SectionTopMenu from '@/components/SectionTopMenu'
@@ -40,6 +41,7 @@ import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
 
 export default {
     name: 'TeamProjects',
+    mixins: [permissionsMixin],
     data () {
         return {
             loading: false,
@@ -73,11 +75,6 @@ export default {
                     id: project.id
                 }
             })
-        }
-    },
-    computed: {
-        createProjectEnabled: function () {
-            return this.teamMembership.role >= Roles.Owner
         }
     },
     props: ['team', 'teamMembership'],

--- a/frontend/src/pages/team/Settings/index.vue
+++ b/frontend/src/pages/team/Settings/index.vue
@@ -12,11 +12,12 @@ import { mapState } from 'vuex'
 
 import SectionTopMenu from '@/components/SectionTopMenu'
 import { useRouter } from 'vue-router'
-import { Roles } from '@core/lib/roles'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'TeamSettings',
     props: ['team', 'teamMembership'],
+    mixins: [permissionsMixin],
     components: {
         SectionTopMenu
     },
@@ -39,7 +40,7 @@ export default {
     },
     methods: {
         checkAccess: async function () {
-            if (this.teamMembership.role < Roles.Owner) {
+            if (!this.hasPermission('team:edit')) {
                 useRouter().push({ path: `/team/${this.team.slug}/overview` })
             }
         }


### PR DESCRIPTION
Prereq of #657 

This PR changes how the frontend verifies if a user is allowed to access something.

It refactors the permissions table we use to secure the API so that it can also be used in the frontend via a new mixin called `hasPermission`.

`hasPermission(scope)` will return true/false depending on whether the current user has the necessarily team role for the given scope.

This is a much more declarative approach than testing specific role levels in each view. It also means we have a single source of truth for the rbac table.

---

You may note the mixin is called `hasPermission`, whilst its backend equivalent is called `needsPermission`. This reflects the differences in behaviour between the two.

 - `hasPermission` returns a boolean
 - `needsPermission` is a route preHandler that will reject an http request if the permission check fails
