### PR TITLE
Include role in Team Invitation

### DIFF
--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -6,18 +6,18 @@ import Vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
     plugins: [
-      Vue(),
+        Vue()
     ],
     test: {
         globals: true,
         environment: 'jsdom',
         coverage: {
-          src: ['./frontend/src'],
-          reportsDirectory: './coverage/frontend',
-          all: true
+            src: ['./frontend/src'],
+            reportsDirectory: './coverage/frontend',
+            all: true
         }
     },
     alias: {
-      '@': fileURLToPath(new URL('../frontend/src', import.meta.url))
+        '@': fileURLToPath(new URL('../frontend/src', import.meta.url))
     }
 })

--- a/forge/db/migrations/20220922-01-add-invitation-role.js
+++ b/forge/db/migrations/20220922-01-add-invitation-role.js
@@ -1,0 +1,15 @@
+/**
+ * Add role column to Invitations
+ */
+
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.addColumn('Invitations', 'role', {
+            type: DataTypes.INTEGER
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Invitation.js
+++ b/forge/db/models/Invitation.js
@@ -20,7 +20,10 @@ module.exports = {
         external: { type: DataTypes.BOOLEAN, allowNull: false },
         expiresAt: { type: DataTypes.DATE },
         email: { type: DataTypes.STRING, allowNull: true },
-        sentAt: { type: DataTypes.DATE, allowNull: true }
+        sentAt: { type: DataTypes.DATE, allowNull: true },
+        role: {
+            type: DataTypes.INTEGER
+        }
         // invitorId
         // inviteeId
     },

--- a/forge/db/views/Invitation.js
+++ b/forge/db/views/Invitation.js
@@ -4,6 +4,7 @@ module.exports = {
             const d = t.get({ plain: true })
             const result = {
                 id: d.hashid,
+                role: d.role,
                 createdAt: d.createdAt,
                 expiresAt: d.expiresAt,
                 sentAt: d.sentAt,

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -2,7 +2,7 @@ import client from './client'
 import daysSince from '@/utils/daysSince'
 import elapsedTime from '@/utils/elapsedTime'
 import paginateUrl from '@/utils/paginateUrl'
-import { RoleNames } from '@core/lib/roles'
+import { RoleNames, Roles } from '@core/lib/roles'
 
 const getTeams = () => {
     return client.get('/api/v1/user/teams').then(res => {
@@ -58,6 +58,7 @@ const getTeamMembers = (teamId) => {
 const getTeamInvitations = (teamId) => {
     return client.get(`/api/v1/teams/${teamId}/invitations`).then(res => {
         res.data.invitations = res.data.invitations.map(r => {
+            r.roleName = RoleNames[r.role || Roles.Member]
             r.createdSince = daysSince(r.createdAt)
             r.expires = elapsedTime(r.expiresAt, Date.now())
             return r
@@ -65,9 +66,10 @@ const getTeamInvitations = (teamId) => {
         return res.data
     })
 }
-const createTeamInvitation = (teamId, userDetails) => {
+const createTeamInvitation = (teamId, userDetails, role) => {
     const opts = {
-        user: userDetails
+        user: userDetails,
+        role
     }
     return client.post(`/api/v1/teams/${teamId}/invitations`, opts).then(res => {
         return res.data

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -1,6 +1,7 @@
 import client from './client'
 import daysSince from '@/utils/daysSince'
 import elapsedTime from '@/utils/elapsedTime'
+import { RoleNames, Roles } from '@core/lib/roles'
 
 const login = (username, password, remember) => {
     return client.post('/account/login', {
@@ -49,6 +50,7 @@ const getTeamInvitations = async () => {
         res.data.invitations = res.data.invitations.map(r => {
             r.createdSince = daysSince(r.createdAt)
             r.expires = elapsedTime(r.expiresAt, Date.now())
+            r.roleName = RoleNames[r.role || Roles.Member]
             return r
         })
         return res.data

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -23,7 +23,8 @@ export default {
         return {
             invitations: [],
             inviteColumns: [
-                { label: 'Team', key: 'team', class: ['w-auto'], component: { is: markRaw(TeamCell), map: { id: 'team_id', avatar: 'team_avatar', name: 'team_name' } } },
+                { label: 'Team', key: 'team', class: ['w-auto'], component: { is: markRaw(TeamCell), map: { id: 'team.id', avatar: 'team.avatar', name: 'team.name' } } },
+                { label: 'Role', class: ['w-40'], key: 'roleName' },
                 { label: 'Sent by', key: 'invitor', class: ['w-auto'], component: { is: markRaw(InviteUserCell), map: { user: 'invitor' } } },
                 { label: 'Expires In', key: 'expires', class: ['w-auto'] }
             ]
@@ -45,12 +46,7 @@ export default {
         async fetchData () {
             const invitations = await userApi.getTeamInvitations()
             await this.$store.dispatch('account/countNotifications')
-            this.invitations = invitations.invitations.map((invite) => {
-                invite.team_id = invite.team.id
-                invite.team_name = invite.team.name
-                invite.team_avatar = invite.team.avatar
-                return invite
-            })
+            this.invitations = invitations.invitations
         }
     }
 }

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -30,6 +30,7 @@ export default {
             invitations: [],
             inviteColumns: [
                 { label: 'User', class: ['flex-grow'], component: { is: markRaw(InviteUserCell), map: { user: 'invitee' } }, key: 'invitee' },
+                { label: 'Role', class: ['w-40'], key: 'roleName' },
                 { label: 'Expires In', class: ['w-40'], key: 'expires' }
             ]
         }

--- a/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
+++ b/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
@@ -17,7 +17,7 @@
                         <FormRow id="role-member" :value="Roles.Member" v-model="input.role" type="radio">Member
                             <template v-slot:description>Members can access the team projects</template>
                         </FormRow>
-                        <FormRow id="role-member" :value="Roles.Viewer" v-model="input.role" type="radio">Viewer
+                        <FormRow id="role-viewer" :value="Roles.Viewer" v-model="input.role" type="radio">Viewer
                             <template v-slot:description>Viewers can access the team projects, but not make any changes</template>
                         </FormRow>
                     </template>
@@ -33,7 +33,7 @@ import alerts from '@/services/alerts'
 
 import FormRow from '@/components/FormRow'
 import teamApi from '@/api/team'
-import { Roles, RoleNames } from '@core/lib/roles'
+import { Roles } from '@core/lib/roles'
 
 export default {
     name: 'ChangeTeamRoleDialog',
@@ -49,8 +49,7 @@ export default {
             input: {
                 role: ''
             },
-            Roles: Roles,
-            RoleNames: RoleNames
+            Roles: Roles
         }
     },
     methods: {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         "start-server-and-test": "^1.14.0",
         "style-loader": "^3.3.1",
         "tailwindcss": "^2.2.19",
-        "vitest": "^0.12.6",
+        "vitest": "^0.23.4",
         "vue-loader": "^16.8.3",
         "vue-template-compiler": "^2.6.14",
         "webpack": "^5.68.0",

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -61,12 +61,17 @@ describe('Team Invitations API', function () {
                 url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
-                    user: 'chris'
+                    user: 'chris',
+                    role: Roles.Viewer
                 }
             })
             const result = response.json()
             result.should.have.property('status', 'okay')
             app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+
+            const invites = await app.db.models.Invitation.findAll()
+            invites.should.have.lengthOf(1)
+            invites[0].should.have.property('role', Roles.Viewer)
         })
 
         it('team member cannot invite user to team', async () => {
@@ -90,11 +95,15 @@ describe('Team Invitations API', function () {
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
                     user: 'chris'
-                }
+                },
+                role: Roles.Member
             })
             const result = response.json()
             result.should.have.property('status', 'okay')
             app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
+            const invites = await app.db.models.Invitation.findAll()
+            invites.should.have.lengthOf(1)
+            invites[0].should.have.property('role', Roles.Member)
         })
 
         it('team owner can invite multiple users to team', async () => {

--- a/test/unit/frontend/api/team.spec.js
+++ b/test/unit/frontend/api/team.spec.js
@@ -24,15 +24,9 @@ vi.mock('@/api/client', () => {
     }
 })
 
+const roles = require('../../../../forge/lib/roles')
 vi.mock('@core/lib/roles', () => {
-    return {
-        RoleNames: {
-            0: 'none',
-            30: 'member',
-            50: 'owner',
-            99: 'admin'
-        }
-    }
+    return roles
 })
 
 const mockPaginateUrl = vi.fn().mockImplementation().mockReturnValue('<paginated-url>')


### PR DESCRIPTION
Part of #1005 

This adds the ability to select the role of a user when inviting them - rather than default to Member.

This requires adding a column to the invitation table to store the role info.

Also updates the various views to include the role name in the UI.