### PR TITLE
Add 'leave team' option on User Settings/Teams view

### DIFF
--- a/frontend/src/components/tables/cells/TeamCell.vue
+++ b/frontend/src/components/tables/cells/TeamCell.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex align-center">
+    <div class="flex align-center cursor-pointer" @click='goToTeam'>
         <div class="flex flex-col justify-center"><img class="rounded-md mr-3 w-6 inline" :src="avatar"/></div>
         <div class="inline-flex flex-col">
             <div>{{ name }}</div>
@@ -10,6 +10,13 @@
 <script>
 export default {
     name: 'TeamCell',
-    props: ['avatar', 'name', 'id']
+    props: ['avatar', 'name', 'id', 'slug'],
+    methods: {
+        goToTeam () {
+            if (this.slug) {
+                this.$router.push({ name: 'Team', params: { team_slug: this.slug } })
+            }
+        }
+    }
 }
 </script>

--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -1,21 +1,30 @@
 <template>
     <div class="text-right mb-4" v-if="settings['team:create']"><CreateTeamButton /></div>
-    <ff-data-table :columns="columns" :rows="teams" :rows-selectable="true" @row-selected="teamSelected"></ff-data-table>
+    <ff-data-table :columns="columns" :rows="teams">
+        <template v-slot:context-menu="{row}">
+            <ff-list-item data-action="member-remove-from-team" label="Leave Team" kind="danger" @click="removeUserDialog(row)" />
+        </template>
+    </ff-data-table>
+
 </template>
 
 <script>
 
 import { mapState } from 'vuex'
 
+import teamApi from '@/api/team'
+
 import TeamCell from '@/components/tables/cells/TeamCell'
 import CreateTeamButton from '../components/CreateTeamButton'
+import alerts from '@/services/alerts'
+import Dialog from '@/services/dialog'
 
 import { markRaw } from 'vue'
 
 export default {
     name: 'AccountTeams',
     computed: {
-        ...mapState('account', ['teams', 'settings']),
+        ...mapState('account', ['user', 'teams', 'settings']),
         teamCount () {
             return this.teams ? this.teams.length : 0
         }
@@ -36,6 +45,33 @@ export default {
     methods: {
         teamSelected (team) {
             this.$router.push({ name: 'Team', params: { team_slug: team.slug } })
+        },
+        removeUserDialog (row) {
+            if (row.memberCount === 1) {
+                Dialog.show({
+                    header: 'Leave Team',
+                    kind: 'primary',
+                    text: 'You cannot leave a team you are the only member of.',
+                    confirmLabel: 'Leave Team',
+                    disablePrimary: true
+                })
+                return
+            }
+            Dialog.show({
+                header: 'Leave Team',
+                kind: 'danger',
+                text: `Are you sure you want to leave ${row.name}?`,
+                confirmLabel: 'Leave Team'
+            }, async () => {
+                try {
+                    await teamApi.removeTeamMember(row.id, this.user.id)
+                    alerts.emit(`${this.user.username} successfully removed from ${row.name}`, 'confirmation')
+                    this.$store.dispatch('account/refreshTeams')
+                } catch (err) {
+                    alerts.emit(`Failed to remove ${this.user.username} from ${row.name}: ${err.response.data.error}`, 'warning')
+                    console.warn(err)
+                }
+            })
         }
     }
 }


### PR DESCRIPTION
This restores the ability for a user to leave any team they are in.

This is now done via the User Settings/Teams view.

<img width="925" alt="image" src="https://user-images.githubusercontent.com/51083/191818324-c9ac7fca-eddd-4edf-8222-dafa9511dfa7.png">

Hitting a couple limitations of the data-table context menu here.

1. we know how many users are in the team. If there is one user, then they shouldn't be able to remove themselves. We have no way (that I have been able to figure out) with the current data-table context menu to make the options enable/disable on a per-row basis. So for now, the 'Leave Team' option is present for all rows, but if you select it on a team of 1, the dialog says you can't do this.
2. we do not know how many owners the team has. So we cannot prevent the user trying to leave if they are the only owner. We rely on the API response that rejects the request to then show a notification that the action failed and why.

<img width="724" alt="image" src="https://user-images.githubusercontent.com/51083/191819171-d23a132a-c556-4b9e-966e-44aa97e2236d.png">


<img width="650" alt="image" src="https://user-images.githubusercontent.com/51083/191819231-e9f73ac9-85b1-4a03-b528-de1d26760890.png">


<img width="492" alt="image" src="https://user-images.githubusercontent.com/51083/191819422-49fbe39d-fe52-4e16-8f3e-80657eb4fe2b.png">


Plenty of room for improvement, but this works.