### PR TITLE
Ensures stack/template are preselected on Create Project page

### DIFF
--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -105,6 +105,12 @@ module.exports = async function (app) {
                         replacedBy: replacedStack.id
                     }
                 })
+                // Update all ProjectTypes that have this as their defaultStack
+                await app.db.models.ProjectType.update({ defaultStackId: stack.id }, {
+                    where: {
+                        defaultStackId: replacedStack.id
+                    }
+                })
                 replacedStack.active = false
                 replacedStack.replacedBy = stack.id
                 await replacedStack.save()

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -52,7 +52,7 @@
                     </ff-tile-selection>
                 </div>
                 <!-- Template -->
-                <div class="flex flex-wrap gap-1 items-stretch">
+                <div v-if="templates.length !== 1" class="flex flex-wrap gap-1 items-stretch">
                     <label class="w-full block text-sm font-medium text-gray-700 mb-1">Template</label>
                     <label v-if="!input.projectType && !input.stack" class="text-sm text-gray-400">Please select a Project Type &amp; Stack first.</label>
                     <label v-if="errors.template" class="text-sm text-gray-400">{{ errors.template }}</label>
@@ -173,6 +173,10 @@ export default {
                     this.errors.stack = ''
                     if (projectType.defaultStack) {
                         this.input.stack = projectType.defaultStack
+                        const defaultStack = this.stacks.find(st => st.id === this.input.stack)
+                        if (!defaultStack) {
+                            this.input.stack = this.stacks[0].id
+                        }
                     } else {
                         this.input.stack = this.stacks[0].value
                     }
@@ -186,7 +190,6 @@ export default {
 
         const templateList = await templatesApi.getTemplates()
         this.templates = templateList.templates.filter(template => template.active)
-
         this.init = true
 
         setTimeout(() => {
@@ -198,8 +201,8 @@ export default {
             }
 
             if (!this.sourceProjectId) {
-                this.input.stack = this.stacks.length > 0 ? this.stacks[0].value : ''
-                this.input.template = this.templates.length > 0 ? this.templates[0].value : ''
+                this.input.stack = this.stacks.length > 0 ? this.stacks[0].id : ''
+                this.input.template = this.templates.length > 0 ? this.templates[0].id : ''
             }
 
             if (this.templates.length === 0) {

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -171,15 +171,25 @@ export default {
                     this.errors.stack = 'No stacks available. Ask an Administrator to create a new stack definition'
                 } else {
                     this.errors.stack = ''
-                    if (projectType.defaultStack) {
-                        this.input.stack = projectType.defaultStack
-                        const defaultStack = this.stacks.find(st => st.id === this.input.stack)
-                        if (!defaultStack) {
-                            this.input.stack = this.stacks[0].id
+                    this.$nextTick(() => {
+                        if (this.sourceProject) {
+                            if (this.stacks.find(st => st.id === this.sourceProject.stack.id)) {
+                                this.input.stack = this.sourceProject.stack.id
+                            } else {
+                                this.input.stack = this.stacks[0].id
+                            }
+                        } else {
+                            if (projectType.defaultStack) {
+                                this.input.stack = projectType.defaultStack
+                                const defaultStack = this.stacks.find(st => st.id === this.input.stack)
+                                if (!defaultStack) {
+                                    this.input.stack = this.stacks[0].id
+                                }
+                            } else {
+                                this.input.stack = this.stacks[0].id
+                            }
                         }
-                    } else {
-                        this.input.stack = this.stacks[0].value
-                    }
+                    })
                 }
             }
         }
@@ -192,10 +202,7 @@ export default {
         this.templates = templateList.templates.filter(template => template.active)
         this.init = true
 
-        setTimeout(() => {
-            // There must be a better Vue way of doing this, but I can't find it.
-            // Without the setTimeout, the select box doesn't update
-
+        this.$nextTick(() => {
             if (this.projectTypes.length === 0) {
                 this.errors.projectTypes = 'No project types available. Ask an Administrator to create a new project type'
             }
@@ -208,7 +215,7 @@ export default {
             if (this.templates.length === 0) {
                 this.errors.template = 'No templates available. Ask an Administrator to create a new template definition'
             }
-        }, 100)
+        })
     },
     async beforeMount () {
         if (this.features.billing && !this.team.billingSetup) {
@@ -222,8 +229,9 @@ export default {
         if (this.sourceProjectId) {
             projectApi.getProject(this.sourceProjectId).then(project => {
                 this.sourceProject = project
-                this.input.stack = this.sourceProject.stack?.id || ''
-                this.input.template = this.sourceProject.template?.id || ''
+                this.input.projectType = this.sourceProject.projectType?.id || ''
+                this.input.stack = this.sourceProject.stack?.id || this.stacks?.[0]?.id || ''
+                this.input.template = this.sourceProject.template?.id || this.templates?.[0]?.id || ''
             }).catch(err => {
                 console.log('Failed to load project', err)
             })


### PR DESCRIPTION
Closes #989 

 - Ensures `ProjectType.defaultStack` is preselected when the ProjectType is selected.
 - Falls back to selecting first in list if defaultStack isn't found
 - Hides the Template selection entirely if only 1 template found
 - Ensures the `ProjectType.defaultStack` is updated when a stack is replaced
 - Ensures the options are selected properly in the copy-project flow