### PR TITLE
Remove /api/v1/user/projects end-point as it is unused

### DIFF
--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -70,22 +70,6 @@ module.exports = async function (app) {
     })
 
     /**
-     * Get the projects of the current logged in user
-     * @name /api/v1/user/projects
-     * @static
-     * @memberof forge.routes.api.user
-     */
-    app.get('/projects', async (request, reply) => {
-        const projects = await app.db.models.Project.byUser(request.session.User)
-        const result = await app.db.views.Project.userProjectList(projects)
-        reply.send({
-            meta: {}, // For future pagination
-            count: result.length,
-            projects: result
-        })
-    })
-
-    /**
      * Update user settings
      * @name /api/v1/user/
      * @static

--- a/frontend/src/api/project.js
+++ b/frontend/src/api/project.js
@@ -1,5 +1,4 @@
 import client from './client'
-import slugify from '@/utils/slugify'
 import daysSince from '@/utils/daysSince'
 import paginateUrl from '@/utils/paginateUrl'
 
@@ -17,18 +16,6 @@ const getProject = (projectId) => {
     })
 }
 
-const getProjects = () => {
-    return client.get('/api/v1/user/projects').then(res => {
-        res.data.projects = res.data.projects.map(r => {
-            r.createdSince = daysSince(r.createdAt)
-            r.updatedSince = daysSince(r.updatedAt)
-            r.link = { name: 'Project', params: { id: r.id } }
-            r.team.link = { name: 'Team', params: { id: slugify(r.team.name) } }
-            return r
-        })
-        return res.data
-    })
-}
 const deleteProject = async (projectId) => {
     return client.delete(`/api/v1/projects/${projectId}`)
 }
@@ -106,7 +93,6 @@ export default {
     create,
     getProject,
     deleteProject,
-    getProjects,
     getProjectLogs,
     getProjectAuditLog,
     startProject,


### PR DESCRIPTION
Closes #982

This end-point was broken, but we don't use it anywhere. Preferable to remove it rather than spend time fixing unused code.