### PR TITLE
Refresh admin user list after expiring password

### DIFF
--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -35,7 +35,7 @@ module.exports = {
                 }
 
                 if (request.body.suspended !== undefined) {
-                    if (request.user.id !== user.id) {
+                    if (request.session.User.id !== user.id) {
                         if (request.body.suspended === true) {
                             await app.db.controllers.User.suspend(user)
                             if (app.postoffice.enabled()) {

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -216,6 +216,7 @@ export default {
             usersApi.updateUser(this.user.id, { password_expired: true })
                 .then((response) => {
                     this.$refs.dialog.close()
+                    this.$emit('userUpdated', response)
                 }).catch(err => {
                     this.errors.expirePassword = err.response.data.error
                 })

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -371,7 +371,19 @@ describe('Users API', async function () {
             })
             response.should.have.property('statusCode', 200)
         })
-
+        it('Admin can suspend another user', async function () {
+            const elvis = await app.db.views.User.userProfile(TestObjects.elvis)
+            elvis.suspended = true
+            const suspendResponse = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/users/${TestObjects.elvis.hashid}`,
+                payload: { suspended: true },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            suspendResponse.should.have.property('statusCode', 200)
+            suspendResponse.json().should.have.property('id', TestObjects.elvis.hashid)
+            suspendResponse.json().should.have.property('suspended', true)
+        })
         it('Admin cannot suspend themselves', async function () {
             const alice = await app.db.views.User.userProfile(TestObjects.alice)
             alice.suspended = true


### PR DESCRIPTION
Closes #463 

Ensures the admin user list is refreshed after expiring a user's password so it shows the right state.

Also fixes a regression I discovered around suspending users - including a unit test that catches the case that regressed.