### PR TITLE
Allow access to team settings if billing is not configured

### DIFF
--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -47,6 +47,8 @@ export default {
         checkRoute: async function (route) {
             const allowedRoutes = [
                 '/team/' + this.team.slug + '/billing',
+                '/team/' + this.team.slug + '/settings',
+                '/team/' + this.team.slug + '/settings/general',
                 '/team/' + this.team.slug + '/settings/danger'
             ]
             if (allowedRoutes.indexOf(route.path) === -1) {


### PR DESCRIPTION
Closes #871

This adds `/settings` and `/settings/general` to the routes permitted if billing is not configured for a team.

This allows a user to reach the danger page to delete the team.