### PR TITLE
Standardise format of error responses

### DIFF
--- a/docs/contribute/api-design.md
+++ b/docs/contribute/api-design.md
@@ -113,6 +113,34 @@ app.post('/', { preHandler: app.needsPermission("team:user:add") }, async (reque
 });
 ```
 
+## Error formats
+
+If a route needs to return an error it should respond with a payload in the format:
+
+```
+{
+    code: 'error_code',
+    error: 'Human-readable message'
+}
+```
+
+The `code` property should be a well-defined string that can be used to programmatically
+identify the error without relying on the human-readable message.
+
+There are a set of predefined codes that should be used where appropriate:
+
+ - `unauthorized`
+ - `invalid_request`
+ - `unexpected_error`
+
+If the error is relating to an invalid option/parameter/object selection, then the code
+should be:
+
+ - `invalid_<name of property>`
+
+For example: `invalid_project_name`.
+
+
 ## Pagination
 
 All routes that return collections of things must use pagination to allow for

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -51,14 +51,14 @@ module.exports = async function (app) {
             } else if (request.body.action === 'inspect') {
                 reply.send(await app.license.inspect(request.body.license))
             } else {
-                reply.code(400).send({ error: 'Invalid action' })
+                reply.code(400).send({ code: 'invalid_license_action', error: 'Invalid action' })
             }
         } catch (err) {
             let responseMessage = err.toString()
             if (/malformed/.test(responseMessage)) {
                 responseMessage = 'Failed to parse license'
             }
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'invalid_license', error: responseMessage })
         }
     })
 

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -93,7 +93,7 @@ module.exports = async function (app) {
         // If we have roles that limit creation, that will need to be checked here.
 
         if (!teamMembership) {
-            reply.code(401).send({ error: 'Current user not in team ' + request.body.team })
+            reply.code(401).send({ code: 'unauthorized', error: 'Current user not in team ' + request.body.team })
             return
         }
 
@@ -107,7 +107,7 @@ module.exports = async function (app) {
         if (typeof teamDeviceLimit === 'number') {
             const currentDeviceCount = await team.deviceCount()
             if (currentDeviceCount >= teamDeviceLimit) {
-                reply.code(400).send({ error: 'Team device limit reached' })
+                reply.code(400).send({ code: 'device_limit_reached', error: 'Team device limit reached' })
                 return
             }
         }
@@ -144,7 +144,7 @@ module.exports = async function (app) {
             }
             reply.send(response)
         } catch (err) {
-            reply.code(400).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -176,7 +176,7 @@ module.exports = async function (app) {
             }
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -225,11 +225,11 @@ module.exports = async function (app) {
                     // Check if the specified project is in the same team
                     const project = await app.db.models.Project.byId(request.body.project)
                     if (!project) {
-                        reply.code(400).send({ error: 'invalid project' })
+                        reply.code(400).send({ code: 'invalid_project', error: 'invalid project' })
                         return
                     }
                     if (project.Team.id !== request.device.Team.id) {
-                        reply.code(400).send({ error: 'invalid project' })
+                        reply.code(400).send({ code: 'invalid_project', error: 'invalid project' })
                         return
                     }
                     // Project exists and is in the right team

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -13,7 +13,7 @@
 module.exports = async function (app) {
     app.addHook('preHandler', (request, reply, done) => {
         if (request.session.ownerType !== 'device' || request.session.ownerId !== ('' + request.device.id)) {
-            reply.code(401).send({ error: 'unauthorised' })
+            reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
         } else {
             done()
         }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -196,7 +196,7 @@ module.exports = async function (app) {
                 url: ''
             })
         } catch (err) {
-            reply.status(400).type('application/json').send({code: 'unexpected_error', error: err.message })
+            reply.status(400).type('application/json').send({ code: 'unexpected_error', error: err.message })
             return
         }
 

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -360,7 +360,7 @@ module.exports = async function (app) {
             )
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
+            reply.code(500).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -40,14 +40,14 @@ module.exports = async function (app) {
             }
             reply.send()
         } catch (err) {
-            reply.code(500).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
     app.post('/stop', changeStatusPreHandler, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
-                reply.code(400).send({ error: 'Project suspended' })
+                reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
                 return
             }
             app.db.controllers.Project.setInflightState(request.project, 'stopping')
@@ -62,14 +62,14 @@ module.exports = async function (app) {
             app.db.controllers.Project.clearInflightState(request.project)
             reply.send(result)
         } catch (err) {
-            reply.code(500).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
     app.post('/restart', changeStatusPreHandler, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
-                reply.code(400).send({ error: 'Project suspended' })
+                reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
                 return
             }
             app.db.controllers.Project.setInflightState(request.project, 'restarting')
@@ -84,14 +84,14 @@ module.exports = async function (app) {
             app.db.controllers.Project.clearInflightState(request.project)
             reply.send(result)
         } catch (err) {
-            reply.code(500).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
     app.post('/suspend', changeStatusPreHandler, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
-                reply.code(400).send({ error: 'Project suspended' })
+                reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
                 return
             }
             app.db.controllers.Project.setInflightState(request.project, 'suspending')
@@ -104,7 +104,7 @@ module.exports = async function (app) {
             )
             reply.send()
         } catch (err) {
-            reply.code(500).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -136,7 +136,7 @@ module.exports = async function (app) {
             }
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(500).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 }

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -40,7 +40,7 @@ module.exports = async function (app) {
             }
             reply.send()
         } catch (err) {
-            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
+            reply.code(500).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -62,7 +62,7 @@ module.exports = async function (app) {
             app.db.controllers.Project.clearInflightState(request.project)
             reply.send(result)
         } catch (err) {
-            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
+            reply.code(500).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -84,7 +84,7 @@ module.exports = async function (app) {
             app.db.controllers.Project.clearInflightState(request.project)
             reply.send(result)
         } catch (err) {
-            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
+            reply.code(500).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -104,7 +104,7 @@ module.exports = async function (app) {
             )
             reply.send()
         } catch (err) {
-            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
+            reply.code(500).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -114,10 +114,12 @@ module.exports = async function (app) {
             // get (and check) snapshot is valid / owned by project before any actions
             const snapshot = await app.db.models.ProjectSnapshot.byId(request.body.snapshot)
             if (!snapshot) {
-                throw new Error(`snapshot '${request.body.snapshotId}' not found for project '${request.body.snapshotId}'`)
+                reply.code(400).send({ code: 'invalid_snapshot', error: `snapshot '${request.body.snapshotId}' not found for project '${request.project.id}'` })
+                return
             }
             if (snapshot.ProjectId !== request.project.id) {
-                throw new Error(`snapshot '${request.body.snapshotId}' is only valid for project ${snapshot.ProjectId}`)
+                reply.code(400).send({ code: 'invalid_snapshot', error: `snapshot '${request.body.snapshotId}' not found for project '${request.project.id}'` })
+                return
             }
             if (request.project.state === 'running') {
                 restartProject = true

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -138,7 +138,7 @@ module.exports = async function (app) {
             }
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
+            reply.code(500).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 }

--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -45,11 +45,11 @@ module.exports = async function (app) {
             const targetSnapshot = await app.db.models.ProjectSnapshot.byId(request.body.targetSnapshot)
 
             if (!targetSnapshot) {
-                reply.code(400).send({ error: 'Invalid snapshot' })
+                reply.code(400).send({ code: 'invalid_snapshot', error: 'Invalid snapshot' })
                 return
             }
             if (targetSnapshot.ProjectId !== request.project.id) {
-                reply.code(400).send({ error: 'Invalid snapshot' })
+                reply.code(400).send({ code: 'invalid_snapshot', error: 'Invalid snapshot' })
                 return
             }
 

--- a/forge/routes/api/projectType.js
+++ b/forge/routes/api/projectType.js
@@ -85,7 +85,7 @@ module.exports = async function (app) {
             } else {
                 responseMessage = err.toString()
             }
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     })
 
@@ -105,7 +105,7 @@ module.exports = async function (app) {
         if (inUse && request.body.properties) {
             // Don't allow the properties to be edited - this contains the billing
             // information and we don't want to have to update live projects
-            reply.code(400).send({ error: 'Cannot edit in-use ProjectType' })
+            reply.code(400).send({ code: 'invalid_request', error: 'Cannot edit in-use ProjectType' })
             return
         }
         try {
@@ -139,7 +139,7 @@ module.exports = async function (app) {
             } else {
                 responseMessage = err.toString()
             }
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     })
 
@@ -160,10 +160,10 @@ module.exports = async function (app) {
                 await projectType.destroy()
                 reply.send({ status: 'okay' })
             } catch (err) {
-                reply.code(400).send({ error: err.toString() })
+                reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
             }
         } else {
-            reply.code(404).send({ status: 'Not Found' })
+            reply.code(404).send({ code: 'not_found', status: 'Not Found' })
         }
     })
 }

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -64,7 +64,7 @@ module.exports = {
                             user.suspended = false
                         }
                     } else {
-                        reply.code(400).send({ error: 'cannot suspend self' })
+                        reply.code(400).send({ code: 'invalid_request', error: 'cannot suspend self' })
                         return
                     }
                 }
@@ -75,7 +75,7 @@ module.exports = {
                 if (membership) {
                     user.defaultTeamId = membership.TeamId
                 } else {
-                    reply.code(400).send({ error: 'invalid team' })
+                    reply.code(400).send({ code: 'invalid_team', error: 'invalid team' })
                     return
                 }
             }
@@ -90,7 +90,7 @@ module.exports = {
             }
             console.log(err.toString())
             console.log(responseMessage)
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     }
 }

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -87,13 +87,13 @@ module.exports = async function (app) {
             if (request.body.replace) {
                 replacedStack = await app.db.models.ProjectStack.byId(request.body.replace)
                 if (!replacedStack) {
-                    reply.code(400).send({ error: 'unknown replace stack' })
+                    reply.code(400).send({ code: 'invalid_stack', error: 'unknown replace stack' })
                     return
                 } else if (replacedStack.getDataValue('replacedBy')) {
-                    reply.code(400).send({ error: 'stack already replaced' })
+                    reply.code(400).send({ code: 'invalid_request', error: 'stack already replaced' })
                     return
                 } else if (replacedStack.ProjectTypeId !== stackProperties.ProjectTypeId) {
-                    reply.code(400).send({ error: 'cannot replace stack with different project type' })
+                    reply.code(400).send({ code: 'invalid_request', error: 'cannot replace stack with different project type' })
                     return
                 }
             }
@@ -125,7 +125,7 @@ module.exports = async function (app) {
             } else {
                 responseMessage = err.toString()
             }
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     })
 
@@ -146,10 +146,10 @@ module.exports = async function (app) {
                 await stack.destroy()
                 reply.send({ status: 'okay' })
             } catch (err) {
-                reply.code(400).send({ error: err.toString() })
+                reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
             }
         } else {
-            reply.code(404).send({ status: 'Not Found' })
+            reply.code(404).send({ code: 'not_found', status: 'Not Found' })
         }
     })
 
@@ -165,7 +165,7 @@ module.exports = async function (app) {
         const stack = await app.db.models.ProjectStack.byId(request.params.stackId)
         if (request.body.name !== undefined || request.body.properties !== undefined) {
             if (stack.getDataValue('projectCount') > 0) {
-                reply.code(400).send({ error: 'Cannot edit in-use stack' })
+                reply.code(400).send({ code: 'invalid_request', error: 'Cannot edit in-use stack' })
                 return
             }
         }
@@ -184,7 +184,7 @@ module.exports = async function (app) {
                     })
                 }
             } else if (stack.ProjectTypeId !== projectTypeId[0]) {
-                reply.code(400).send({ error: 'Cannot change stack project type' })
+                reply.code(400).send({ code: 'invalid_request', error: 'Cannot change stack project type' })
                 return
             }
         }

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -111,7 +111,7 @@ module.exports = async function (app) {
                 reply.code(404).type('text/html').send('Not Found')
             }
         } else if (!request.session.User.admin) {
-            reply.code(401).send({ error: 'unauthorized' })
+            reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
         } else {
             // Admin request for all teams
             const paginationOptions = app.getPaginationOptions(request)
@@ -160,19 +160,19 @@ module.exports = async function (app) {
             // preHandler. To do so will require the perms model to know
             // to also check enabled features (and know that admin is allowed to
             // override in this instance)
-            reply.code(403).send({ error: 'unauthorized' })
+            reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
         }
 
         // TODO check license allows multiple teams
 
         if (request.body.slug === 'create') {
-            reply.code(400).send({ error: 'slug not available' })
+            reply.code(400).send({ code: 'invalid_slug', error: 'slug not available' })
             return
         }
 
         const teamType = await app.db.models.TeamType.byId(request.body.type)
         if (!teamType || !teamType.enabled) {
-            reply.code(400).send({ error: 'unknown team type' })
+            reply.code(400).send({ code: 'invalid_team_type', error: 'unknown team type' })
             return
         }
 
@@ -216,7 +216,7 @@ module.exports = async function (app) {
                 responseMessage = err.toString()
             }
             reply.clearCookie('ff_coupon', { path: '/' })
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     })
 
@@ -247,7 +247,7 @@ module.exports = async function (app) {
             await request.team.destroy()
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 
@@ -276,7 +276,7 @@ module.exports = async function (app) {
             }
             if (request.body.slug) {
                 if (request.body.slug === 'create') {
-                    reply.code(400).send({ error: 'slug not available' })
+                    reply.code(400).send({ code: 'invalid_slug', error: 'slug not available' })
                     return
                 }
                 const oldSlug = request.team.slug
@@ -297,7 +297,7 @@ module.exports = async function (app) {
             } else {
                 responseMessage = err.toString()
             }
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     })
 

--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -34,14 +34,14 @@ module.exports = async function (app) {
         const userDetails = request.body.user.split(',').map(u => u.trim()).filter(Boolean)
         const role = request.body.role || Roles.Member
         if (!TeamRoles.includes(role)) {
-            reply.code(400).send({ status: 'error', message: 'invalid team role' })
+            reply.code(400).send({ code: 'invalid_team_role', error: 'invalid team role' })
             return
         }
         let invites = []
         try {
             invites = await app.db.controllers.Invitation.createInvitations(request.session.User, request.team, userDetails, role)
         } catch (err) {
-            reply.code(400).send({ status: 'error', message: err.message })
+            reply.code(400).send({ code: 'invitation_failed', error: err.message })
             return
         }
 
@@ -98,11 +98,11 @@ module.exports = async function (app) {
             )
         }
         if (errorCount > 0) {
-            result.status = 'error'
-        } else {
-            delete result.message
+            result.code = 'invitation_failed'
+            result.error = result.message
+            delete result.status
         }
-        // TODO: set proper status code if error
+        delete result.message
         reply.send(result)
     })
 

--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -82,7 +82,7 @@ module.exports = async function (app) {
             }
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ error: 'cannot remove only owner' })
+            reply.code(400).send({ code: 'invalid_request', error: 'cannot remove only owner' })
         }
     })
 
@@ -109,7 +109,7 @@ module.exports = async function (app) {
                 reply.code(403).type('text/html').send('Forbidden')
             }
         } else {
-            reply.code(400).send({ error: 'invalid role' })
+            reply.code(400).send({ code: 'invalid_team_role', error: 'invalid role' })
         }
     })
 }

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -80,7 +80,7 @@ module.exports = async function (app) {
             } else {
                 responseMessage = err.toString()
             }
-            reply.code(400).send({ error: responseMessage })
+            reply.code(400).send({ code: 'unexpected_error', error: responseMessage })
         }
     })
 
@@ -100,7 +100,7 @@ module.exports = async function (app) {
             await template.destroy()
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ error: err.toString() })
+            reply.code(400).send({ code: 'unexpected_error', error: err.toString() })
         }
     })
 

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -49,7 +49,7 @@ module.exports = async function (app) {
             await app.db.controllers.User.changePassword(request.session.User, request.body.old_password, request.body.password)
             reply.send({ status: 'okay' })
         } catch (err) {
-            reply.code(400).send({ error: 'password change failed' })
+            reply.code(400).send({ code: 'password_change_failed', error: 'password change failed' })
         }
     })
 

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -132,8 +132,9 @@ describe('Team Invitations API', function () {
                 }
             })
             const result = response.json()
-            result.should.have.property('status', 'error')
-            result.message.should.have.property('bob', 'Already a member of the team')
+            result.should.have.property('code', 'invitation_failed')
+            result.should.have.property('error')
+            result.error.should.have.property('bob', 'Already a member of the team')
             app.config.email.transport.getMessageQueue().should.have.lengthOf(0)
         })
 
@@ -148,8 +149,9 @@ describe('Team Invitations API', function () {
                 }
             })
             const result = response.json()
-            result.should.have.property('status', 'error')
-            result.message.should.have.property('bob', 'Already a member of the team')
+            result.should.have.property('code', 'invitation_failed')
+            result.should.have.property('error')
+            result.error.should.have.property('bob', 'Already a member of the team')
             // But an email is still sent to chris
             app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
         })
@@ -166,8 +168,9 @@ describe('Team Invitations API', function () {
                     }
                 })
                 const result = response.json()
-                result.should.have.property('status', 'error')
-                result.message.should.have.property('dave@example.com', 'External invites not permitted')
+                result.should.have.property('code', 'invitation_failed')
+                result.should.have.property('error')
+                result.error.should.have.property('dave@example.com', 'External invites not permitted')
 
                 app.config.email.transport.getMessageQueue().should.have.lengthOf(0)
             })


### PR DESCRIPTION
Closes #956 

All error responses must now be of the format:

```
{
   code: 'an_error_code',
   error: 'A human readable message'
}
```

I've added words to the API design pages on the format of this response and what `code` should be.

This PR generally doesn't touch the existing error messages, just adds appropriate `code` properties.

One bigger change is the response of the Create Invitation end point - the one that was most different to the rest. This brings it more into line with this standard. It also fixes the reporting of the error in the UI
