### PR TITLE
Handle postgres constraint errors with username/email uniqueness

### DIFF
--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -112,10 +112,10 @@ module.exports = async function (app) {
         } catch (err) {
             let responseMessage
             let responseCode = 'unexpected_error'
-            if (/user_username_lower_unique/.test(err.parent?.toString())) {
+            if (/user_username_lower_unique|Users_username_key/.test(err.parent?.toString())) {
                 responseMessage = 'username not available'
                 responseCode = 'invalid_username'
-            } else if (/user_email_lower_unique/.test(err.parent?.toString())) {
+            } else if (/user_email_lower_unique|Users_email_key/.test(err.parent?.toString())) {
                 responseMessage = 'email not available'
                 responseCode = 'invalid_email'
             } else if (err.errors) {

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -299,9 +299,9 @@ module.exports = fp(async function (app, opts, done) {
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage
-            if (/user_username_lower_unique/.test(err.parent?.toString())) {
+            if (/user_username_lower_unique|Users_username_key/.test(err.parent?.toString())) {
                 responseMessage = 'username not available'
-            } else if (/user_email_lower_unique/.test(err.parent?.toString())) {
+            } else if (/user_email_lower_unique|Users_email_key/.test(err.parent?.toString())) {
                 responseMessage = 'email not available'
             } else if (err.errors) {
                 responseMessage = err.errors.map(err => err.message).join(',')


### PR DESCRIPTION
Fixes #1029 

When trying to insert a duplicate username or email, sqlite returns an error due to the recently added index constraint that does a case-insensitive check. That is the code we were looking for.

Postgres returns an error due to the constraint on the column - which we didn't catch so it fell through to the generic error response - which the tests weren't expecting to see.

The fix is to check for both errors properly.