### PR TITLE
Set project.url in the stub driver

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -95,6 +95,8 @@ module.exports = {
                 meta: { foo: 'bar' },
                 stack: project.ProjectStack.hashid
             }
+            project.url = list[project.id].url
+            await project.save()
             if (await project.getSetting('stubProjectToken') === undefined) {
                 const stubProjectToken = forgeUtils.generateToken(8)
                 await project.updateSetting('stubProjectToken', stubProjectToken)

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -339,6 +339,8 @@ describe('Project API', function () {
             result.should.have.property('safeName', 'test-project')
             result.should.have.property('team')
             result.should.have.property('projectType')
+            result.should.have.property('url')
+            result.url.should.not.be.empty()
             result.projectType.should.have.property('id', TestObjects.projectType1.hashid)
             result.should.have.property('template')
             result.template.should.have.property('id', TestObjects.template1.hashid)


### PR DESCRIPTION
To be consistent with the other drivers and conform to the driver API requirements:

https://github.com/flowforge/flowforge/blob/bb126da55e7b4d3ffb8967a1e12d1e5166644101/forge/containers/stub/index.js#L79-L82

The UI will now shows the mock URL we were already generating in the stub driver:

![Screenshot 2022-10-12 at 13 31 52](https://user-images.githubusercontent.com/507155/195331984-7ed3c672-56f0-4075-b40b-145f1efca2f4.png)
