### PR TITLE
E2E Coverage of Platform Admins viewing teams/projects/devices

### DIFF
--- a/frontend/src/components/SideNavigationTeamOptions.vue
+++ b/frontend/src/components/SideNavigationTeamOptions.vue
@@ -133,6 +133,7 @@ export default {
                 this.routes.admin.splice(1, 0, {
                     label: 'Billing',
                     to: '/billing',
+                    tag: 'team-billing',
                     icon: CurrencyDollarIcon
                 })
             }
@@ -140,6 +141,7 @@ export default {
                 this.routes.general.splice(2, 0, {
                     label: 'Devices',
                     to: '/devices',
+                    tag: 'team-devices',
                     icon: ChipIcon
                 })
             }

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -5,7 +5,7 @@
         <ff-data-table v-if="!loading" :columns="columns" :rows="teams"
                        :rows-selectable="true" @row-selected="viewTeam"
                        :show-search="true" search-placeholder="Search Teams..."
-                       :search-fields="['name', 'id']"/>
+                       :search-fields="['name', 'id']" data-el="teams-table" />
         <div v-if="nextCursor">
             <a v-if="!loading" @click.stop="loadItems" class="forge-button-inline">Load more...</a>
         </div>

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -23,7 +23,7 @@
         </SectionTopMenu>
         <div class="text-sm sm:px-6 mt-4 sm:mt-8">
             <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
-                <div class="ff-banner">You are viewing this device as an Administrator</div>
+                <div class="ff-banner" data-el="banner-device-as-admin">You are viewing this device as an Administrator</div>
             </Teleport>
             <router-view :device="device" @device-updated="loadDevice()"></router-view>
         </div>

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -12,7 +12,7 @@
                                 <div v-if="isVisitingAdmin" class="my-2">
                                     {{project.url}}
                                 </div>
-                                <a v-else :href="project.url" target="_blank" class="forge-button-secondary py-1 mb-1">
+                                <a v-else :href="project.url" target="_blank" class="forge-button-secondary py-1 mb-1" data-el="editor-link">
                                     <span class="ml-r">{{project.url}}</span>
                                     <ExternalLinkIcon class="w-4 ml-3" />
                                 </a>

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -34,7 +34,7 @@
         </SectionTopMenu>
         <div class="text-sm mt-4 sm:mt-8">
             <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
-                <div class="ff-banner">You are viewing this project as an Administrator</div>
+                <div class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
             </Teleport>
             <router-view :project="project" :isVisitingAdmin="isVisitingAdmin" @projectUpdated="updateProject"></router-view>
         </div>

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -8,7 +8,7 @@
         </template>
         <div v-else-if="team">
             <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
-                <div class="ff-banner">You are viewing this team as an Administrator</div>
+                <div class="ff-banner" data-el="banner-team-as-admin">You are viewing this team as an Administrator</div>
             </Teleport>
             <router-view :team="team" :teamMembership="teamMembership"></router-view>
         </div>

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -29,6 +29,26 @@ describe('FlowForge platform admin users', () => {
         cy.visit('/admin/overview')
         cy.url().should('include', '/admin/overview')
     })
+
+    it('can view projects from teams they\'re not a member of', () => {
+        cy.intercept('GET', '/api/*/projects/*').as('getProject')
+
+        cy.visit('/admin/overview')
+
+        cy.get('[data-nav="admin-teams"]').click()
+        cy.wait('@getTeams')
+
+        // Not a member of BTeam
+        cy.get('[data-el="teams-table"]').contains('BTeam').click()
+        cy.wait('@getTeamProjects')
+
+        cy.get('[data-action="view-project"]').contains('project2').click()
+
+        cy.wait('@getProject')
+
+        cy.get('[data-action="open-editor"]').should('not.exist')
+        cy.get('[data-el="editor-link"]').should('not.exist')
+    })
 })
 
 describe('FlowForge platform non-admin users', () => {

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -42,9 +42,13 @@ describe('FlowForge platform admin users', () => {
         cy.get('[data-el="teams-table"]').contains('BTeam').click()
         cy.wait('@getTeamProjects')
 
+        cy.get('[data-el="banner-team-as-admin"]').should('exist')
+
         cy.get('[data-action="view-project"]').contains('project2').click()
 
         cy.wait('@getProject')
+
+        cy.get('[data-el="banner-project-as-admin"]').should('exist')
 
         cy.get('[data-action="open-editor"]').should('not.exist')
         cy.get('[data-el="editor-link"]').should('not.exist')

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -53,6 +53,29 @@ describe('FlowForge platform admin users', () => {
         cy.get('[data-action="open-editor"]').should('not.exist')
         cy.get('[data-el="editor-link"]').should('not.exist')
     })
+
+    it('can view devices from teams they\'re not a member of', () => {
+        cy.intercept('GET', '/api/*/projects/*').as('getProject')
+        cy.intercept('GET', '/api/*/teams/*/devices').as('getDevices')
+        cy.intercept('GET', '/api/*/devices/*').as('getDevice')
+
+        cy.visit('/admin/overview')
+
+        cy.get('[data-nav="admin-teams"]').click()
+        cy.wait('@getTeams')
+
+        // Not a member of BTeam
+        cy.get('[data-el="teams-table"]').contains('BTeam').click()
+        cy.wait('@getTeamProjects')
+
+        cy.get('[data-nav="team-devices"]').click()
+        cy.wait('@getDevices')
+
+        cy.get('[data-el="devices"]').contains('team2-device').click()
+        cy.wait('@getDevice')
+
+        cy.get('[data-el="banner-device-as-admin"]').should('exist')
+    })
 })
 
 describe('FlowForge platform non-admin users', () => {

--- a/test/e2e/frontend/cypress/tests/project.spec.js
+++ b/test/e2e/frontend/cypress/tests/project.spec.js
@@ -21,6 +21,8 @@ describe('FlowForge - Projects', () => {
 
         cy.wait('@getProject')
 
+        cy.get('[data-el="banner-project-as-admin"]').should('not.exist')
+
         cy.get('[data-action="open-editor"]').should('exist')
         cy.get('[data-el="editor-link"]').should('exist')
     })

--- a/test/e2e/frontend/cypress/tests/project.spec.js
+++ b/test/e2e/frontend/cypress/tests/project.spec.js
@@ -8,6 +8,23 @@ describe('FlowForge - Projects', () => {
         cy.wait('@getProjectTypes')
     })
 
+    it('can be viewed', () => {
+        cy.intercept('GET', '/api/*/projects/*').as('getProject')
+
+        cy.visit('/')
+
+        cy.get('[data-nav="team-projects"]')
+
+        cy.wait('@getTeamProjects')
+
+        cy.contains('project1').click()
+
+        cy.wait('@getProject')
+
+        cy.get('[data-action="open-editor"]').should('exist')
+        cy.get('[data-el="editor-link"]').should('exist')
+    })
+
     it('can be deleted', () => {
         const PROJECT_NAME = 'my-project'
 

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -26,9 +26,9 @@ module.exports = async function (settings = {}, config = {}) {
     const forge = await Forge({ config })
 
     await forge.settings.set('setup:initialised', true)
-    // full platform & team admin
+    // full platform & team1 admin
     const userAlice = await forge.db.models.User.create({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })
-    // team admin, not platform admin
+    // team1 & team2 admin, not platform admin
     const userBob = await forge.db.models.User.create({ admin: false, username: 'bob', name: 'Bob Solo', email: 'bob@example.com', email_verified: true, password: 'bbPassword' })
     // no admin rights
     // eslint-disable-next-line no-unused-vars
@@ -43,6 +43,9 @@ module.exports = async function (settings = {}, config = {}) {
     await team1.addUser(userAlice, { through: { role: Roles.Owner } })
     await team1.addUser(userBob, { through: { role: Roles.Owner } })
     // await team1.addUser(userCharlie, { through: { role: Roles.Member } })
+
+    const team2 = await forge.db.models.Team.create({ name: 'BTeam', TeamTypeId: defaultTeamType.id })
+    await team2.addUser(userBob, { through: { role: Roles.Owner } })
 
     const templateProperties = {
         name: 'template1',
@@ -73,10 +76,36 @@ module.exports = async function (settings = {}, config = {}) {
     }
     const stack = await forge.db.models.ProjectStack.create(stackProperties)
     await stack.setProjectType(projectType)
+
     const project1 = await forge.db.models.Project.create({ name: 'project1', type: '', url: '' })
     await team1.addProject(project1)
     await project1.setProjectStack(stack)
     await project1.setProjectTemplate(template)
+    await project1.setProjectType(projectType)
+    await project1.reload({
+        include: [
+            { model: forge.db.models.Team },
+            { model: forge.db.models.ProjectType },
+            { model: forge.db.models.ProjectStack },
+            { model: forge.db.models.ProjectTemplate }
+        ]
+    })
+    await forge.containers.start(project1) // ensure project is initialized
+
+    const project2 = await forge.db.models.Project.create({ name: 'project2', type: '', url: '' })
+    await team2.addProject(project2)
+    await project2.setProjectStack(stack)
+    await project2.setProjectTemplate(template)
+    await project2.setProjectType(projectType)
+    await project2.reload({
+        include: [
+            { model: forge.db.models.Team },
+            { model: forge.db.models.ProjectType },
+            { model: forge.db.models.ProjectStack },
+            { model: forge.db.models.ProjectTemplate }
+        ]
+    })
+    await forge.containers.start(project2) // ensure project is initialized
 
     forge.project = project1
     forge.template = template

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -107,6 +107,13 @@ module.exports = async function (settings = {}, config = {}) {
     })
     await forge.containers.start(project2) // ensure project is initialized
 
+    const device2 = await forge.db.models.Device.create({
+        name: 'team2-device',
+        type: 'type2',
+        credentialSecret: ''
+    })
+    await team2.addDevice(device2)
+
     forge.project = project1
     forge.template = template
     forge.stack = stack


### PR DESCRIPTION
Adds E2E coverage of #1054 and #987, partially as an exercise in getting the hang of cypress and partially as there was no coverage of admins viewing other pages yet.