### PR TITLE
Fix intermittently failing async project creation test

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -13,6 +13,7 @@ const list = {}
 const forgeUtils = require('../../db/utils')
 
 module.exports = {
+    START_DELAY: 500,
     /**
      * Initialises this driver
      *
@@ -109,7 +110,7 @@ module.exports = {
                     }, 500)
                 })
             } else {
-                const startTime = project.name === 'stub-slow-start' ? 6000 : 500
+                const startTime = project.name === 'stub-slow-start' ? 6000 : module.exports.START_DELAY
                 return new Promise((resolve, reject) => {
                     setTimeout(() => {
                         list[project.id].state = 'running'

--- a/test/system/100-project-lifecycle_spec.js
+++ b/test/system/100-project-lifecycle_spec.js
@@ -2,6 +2,7 @@ const should = require('should') // eslint-disable-line
 const FF_UTIL = require('flowforge-test-utils')
 const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localTransport.js')
 const { Roles } = FF_UTIL.require('forge/lib/roles')
+const { START_DELAY } = FF_UTIL.require('forge/containers/stub/index.js')
 
 async function waitFor (delay) {
     return new Promise((resolve) => { setTimeout(() => resolve(), delay) })
@@ -124,7 +125,7 @@ describe('Project Lifecycle', function () {
     })
 
     it('Project starts asynchronously to the create', async function () {
-        await waitFor(500)
+        await waitFor(START_DELAY + 100)
         const response = await getProjectState(TestObjects.Project1.id)
         response.meta.should.have.property('state', 'running')
     })


### PR DESCRIPTION
This test seems to fail _sometimes_ on CI. e.g: https://github.com/flowforge/flowforge/actions/runs/3234499930/attempts/1

Prevents a race condition where both the test and stub were waiting 500ms.
Using a variable in case we change the stub delay later.