### PR TITLE
Add project name to docker-compose up

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -127,7 +127,7 @@ If you are running with the MQTT broker then you should adjust the `public_url` 
 Once the containers have been built you can start FlowForge by running:
 
 ```
-docker-compose up -d
+docker-compose up -p flowforge -d
 ```
 
 This will also create a directory called `db` to hold the database files used to store project instance and user information.

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -126,9 +126,16 @@ If you are running with the MQTT broker then you should adjust the `public_url` 
 
 Once the containers have been built you can start FlowForge by running:
 
+Using the docker compose plugin
 ```
-docker-compose up -p flowforge -d
+docker compose -p flowforge up -d
 ```
+
+Using the docker-compose command
+```
+docker-compose up -p flowforge up -d
+```
+
 
 This will also create a directory called `db` to hold the database files used to store project instance and user information.
 


### PR DESCRIPTION
This allows for easier upgrades later.

By default the project name is set to the directory name the `docker-compose.yml` file is in. In the default case that includes the version number which makes upgrading hard (docker artefacts are prefixed with the project name.)