### PR TITLE
improve UI/UX around new/edit admin templates

### DIFF
--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -1,14 +1,18 @@
 <template>
     <div class="flex flex-col sm:flex-row mb-8 max-w-4xl">
         <div class="flex-grow">
-            <div v-if="!isNew" class="text-gray-800 text-xl"><span class=" font-bold">Template:</span> {{ template.name }}</div>
-            <div v-else class="text-gray-800 text-xl"><span class=" font-bold">Create a new template</span></div>
-
+            <div class="text-gray-800 text-xl">
+                <router-link class="ff-link font-bold" :to="{path: '/admin/templates'}">Templates</router-link> 
+                <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
+                <ChevronRightIcon class="ff-icon" />
+                <span v-if="!isNew">{{ template.name }}</span>
+                <span v-if="isNew">Create a new template</span>
+            </div>
         </div>
         <div class="text-right space-x-4 flex h-8" >
-            <template v-if="unsavedChanges">
-                <ff-button kind="secondary" class="ml-4" @click="cancelEdit">Cancel</ff-button>
-                <ff-button class="ml-4" :disabled="hasErrors" @click="showSaveTemplateDialog">Save changes</ff-button>
+            <template v-if="!isNew">
+                <ff-button kind="secondary" v-if="unsavedChanges" class="ml-4" @click="cancelEdit">Discard changes</ff-button>
+                <ff-button class="ml-4" :disabled="hasErrors || !unsavedChanges" @click="showSaveTemplateDialog">Save changes</ff-button>
             </template>
             <template v-else-if="isNew">
                 <ff-button :to="{ name: 'Admin Templates' }" kind="secondary">Cancel</ff-button>
@@ -36,6 +40,8 @@ import {
     prepareTemplateForEdit,
     templateValidators
 } from './utils'
+import alerts from '@/services/alerts'
+import { ChevronRightIcon } from '@heroicons/vue/solid'
 
 const sideNavigation = [
     { name: 'Settings', path: './settings' },
@@ -78,7 +84,10 @@ export default {
                 policy: {}
             },
             unsavedChanges: false,
-            hasErrors: false
+            hasErrors: false,
+            icons: {
+                breadcrumbSeparator: ChevronRightIcon
+            }
         }
     },
     watch: {
@@ -245,6 +254,11 @@ export default {
                 await templateApi.updateTemplate(this.template.id, template)
                 await this.loadTemplate()
             } catch (err) {
+                if (err.response?.data) {
+                    alerts.emit(err.response.data.error, 'warning')
+                } else {
+                    alerts.emit('Unknown Error. Check logs.', 'warning')
+                }
                 console.log(err)
             }
         },
@@ -276,12 +290,18 @@ export default {
                     name: 'Admin Templates'
                 })
             } catch (err) {
+                if (err.response?.data) {
+                    alerts.emit(err.response.data.error, 'warning')
+                } else {
+                    alerts.emit('Unknown Error. Check logs.', 'warning')
+                }
                 console.log(err)
             }
         }
     },
     components: {
-        SectionSideMenu
+        SectionSideMenu,
+        ChevronRightIcon
     }
 }
 </script>

--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -2,7 +2,7 @@
     <div class="flex flex-col sm:flex-row mb-8 max-w-4xl">
         <div class="flex-grow">
             <div class="text-gray-800 text-xl">
-                <router-link class="ff-link font-bold" :to="{path: '/admin/templates'}">Templates</router-link> 
+                <router-link class="ff-link font-bold" :to="{path: '/admin/templates'}">Templates</router-link>
                 <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
                 <ChevronRightIcon class="ff-icon" />
                 <span v-if="!isNew">{{ template.name }}</span>

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -14,7 +14,7 @@
         <ff-loading v-if="loading" message="Loading Templates..." />
         <ff-data-table v-if="!loading" :columns="columns" data-el="templates"
                        :rows="templates" :show-search="true" search-placeholder="Search Templates..."
-                       :search-fields="['name',, 'description', 'owner_username', 'owner_id']"
+                       :search-fields="['name', 'description', 'owner_username', 'owner_id']"
                        :rows-selectable="true" @row-selected="editTemplate"
                        >
             <template v-slot:context-menu="{row}">

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -16,10 +16,10 @@
                        :rows="templates" :show-search="true" search-placeholder="Search Templates..."
                        :search-fields="['name', 'description', 'owner_username', 'owner_id']"
                        :rows-selectable="true" @row-selected="editTemplate"
-                       >
+        >
             <template v-slot:context-menu="{row}">
-                <ff-list-item label="Edit Template" @click="editTemplate(row)"/>
-                <ff-list-item label="Delete Template" kind="danger" @click="showDeleteDialog(row)"/>
+                <ff-list-item label="Edit Template" @click.stop="editTemplate(row)"/>
+                <ff-list-item label="Delete Template" kind="danger" @click.stop="showDeleteDialog(row)"/>
             </template>
         </ff-data-table>
         <div v-if="nextCursor">

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -1,6 +1,7 @@
 <template>
     <form class="space-y-6">
-        <FormHeading>Project Templates
+        <FormHeading>
+            <div class="text-xl font-bold flex">Templates</div>
             <template v-slot:tools>
                 <ff-button size="small" :to="{ name: 'Admin Template', params: { id: 'create' } }">
                     <template v-slot:icon-right>
@@ -13,7 +14,9 @@
         <ff-loading v-if="loading" message="Loading Templates..." />
         <ff-data-table v-if="!loading" :columns="columns" data-el="templates"
                        :rows="templates" :show-search="true" search-placeholder="Search Templates..."
-                       :search-fields="['name',, 'description', 'owner_username', 'owner_id']">
+                       :search-fields="['name',, 'description', 'owner_username', 'owner_id']"
+                       :rows-selectable="true" @row-selected="editTemplate"
+                       >
             <template v-slot:context-menu="{row}">
                 <ff-list-item label="Edit Template" @click="editTemplate(row)"/>
                 <ff-list-item label="Delete Template" kind="danger" @click="showDeleteDialog(row)"/>

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -6,6 +6,14 @@
     background-color: $ff-grey-300;
 }
 
+.ff-link {
+    color: $ff-blue-700;
+    &:hover {
+        cursor: pointer;
+        color: $ff-blue-900;
+    }
+}
+
 .ff-avatar {
     width: 24px;
     height: 24px;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@fastify/csrf-protection": "^5.1.0",
         "@fastify/helmet": "9.1.0",
         "@fastify/static": "^6.5.0",
-        "@flowforge/forge-ui-components": "^0.3.3",
+        "@flowforge/forge-ui-components": "^0.4.0",
         "@flowforge/localfs": "^0.10.0",
         "@headlessui/vue": "1.6.3",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
fixes #963

@hardillb  I discussed this with @joepavitt earlier today & we agreed several improvements 

1. Change button name of "Edit Template" to "Discard Changes"
2. Always show the "Save Changes" button, but conditionally enabled/disabled if fields have changed
3. Hid the "Discard Changes" button, and only show it if fields have changed
4. Add a kinda mini breadcrumb that takes you back to templates list
5. Make items in templates list clickable to default operation (edit)  (saves 1 click & moving mouse to far side)

In action...

![Image](https://user-images.githubusercontent.com/44235289/195680572-4fddd662-56d5-4a52-99d4-5a3c5106f37c.gif)

NOTE: Needs https://github.com/flowforge/forge-ui-components/issues/58 to be fixed before merging