### PR TITLE
Catch any unhandled  XHR errors that bubble up to the view

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,10 +1,12 @@
 import { createApp } from 'vue'
+import { AxiosError } from 'axios'
 
 import ForgeUIComponents from '@flowforge/forge-ui-components'
 import '@flowforge/forge-ui-components/dist/forge-ui-components.css'
 import LottieAnimation from 'lottie-web-vue'
 
 import router from '@/routes'
+import Alerts from '@/services/alerts'
 import store from '@/store'
 import App from '@/App.vue'
 import '@/index.css'
@@ -19,6 +21,22 @@ const app = createApp(App)
     .use(router)
 
 app.component('ff-loading', Loading)
+
+app.config.errorHandler = function (err, vm, info) {
+    // Uncaught XHR errors bubble to here
+    if (err instanceof AxiosError) {
+        // API has returned error details
+        const errorMessage =
+            err.response?.data?.message ?? // deprecated format
+            err.response?.data?.error // new format
+        if (errorMessage) {
+            return Alerts.emit(`Request Failed: ${errorMessage}`, 'warning')
+        }
+
+        // HTTP error only
+        return Alerts.emit(`${err.message ?? 'Request Failed: Unknown error'}`, 'warning')
+    }
+}
 
 app.config.globalProperties.$filters = {
     pluralize (amount, singular, plural = `${singular}s`) { return amount === 1 ? singular : plural }


### PR DESCRIPTION
Fixes #929. If errors are not handled (with a try/catch or .catch) they bubble up to vue, which displays them in the UI using the Alerts service.

If the API has returned the error in the [standard format](https://github.com/flowforge/flowforge/blob/0dc8b449036ed3310b8d1c3ab9337a057ca174c6/docs/contribute/api-design.md?plain=1#L116-L125) that is displayed: 

<img width="376" alt="Screenshot 2022-10-14 at 13 56 45" src="https://user-images.githubusercontent.com/507155/195844479-20084174-cab0-432d-bd31-437c1903bdfd.png">

Otherwise, it falls back to the error from Axios:

<img width="399" alt="Screenshot 2022-10-14 at 13 56 53" src="https://user-images.githubusercontent.com/507155/195844473-dfa3b867-b708-422a-bea4-87118b467311.png">