### PR TITLE
Hide the projects stats if empty or undefined

### DIFF
--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -20,7 +20,7 @@
         <div class="border rounded p-4 text-center">
             <div class="text-xl">{{stats.projectCount}}</div>
             <div>{{ $filters.pluralize(stats.projectCount,'Project')}}</div>
-            <div class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
+            <div v-if="stats.projectsByState && Object.keys(stats.projectsByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
                 <div v-for="(count, state) in stats.projectsByState" :key="state">
                     {{ count }} {{ state }}
                 </div>


### PR DESCRIPTION
Fixes a tiny UI bug introduced by me in #949

### Before

<img width="1062" alt="Screenshot 2022-10-14 at 15 17 46" src="https://user-images.githubusercontent.com/507155/195856876-42c16cb9-eec5-44eb-a3e1-430e8e0bfaa1.png">

### After

<img width="1065" alt="Screenshot 2022-10-14 at 15 09 58" src="https://user-images.githubusercontent.com/507155/195856879-6f5e2c92-e9ce-4d7e-a77a-78bf6aa1abe6.png">

This isn't needed for the users section as there will always be at least one admin to be able to visit this page.
