### PR TITLE
Add palette.modules to Project Settings

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -76,6 +76,7 @@ module.exports = {
         moduleList.forEach(module => {
             modules[module.name] = module.version
         })
+        result.palette = result.palette || {}
         result.palette.modules = modules
         result.env = env
         return result
@@ -188,7 +189,7 @@ module.exports = {
     mergeProjectModules: async function (app, project, moduleList) {
         let changed = false
         let newProjectModuleList
-        const currentProjectSettings = await project.getSetting('settings')
+        const currentProjectSettings = await project.getSetting('settings') || {}
         if (currentProjectSettings?.palette?.modules) {
             // The project has an existing list of modules - need to resolve any
             // changes between the two lists
@@ -228,6 +229,7 @@ module.exports = {
             newProjectModuleList = Object.values(existingModules)
         } else {
             // No existing modules - so updated with the list as provided
+            changed = true
             newProjectModuleList = moduleList.map(m => {
                 if (/^\d/.test(m.version)) {
                     m.version = `~${m.version}`

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto')
+const semver = require('semver')
 
 /**
  * inflightProjectState - when projects are transitioning between states, there
@@ -67,7 +68,15 @@ module.exports = {
                 })
             }
         }
-
+        // If we don't have any modules listed in project settings. We should
+        // look them up from StorageSettings in case this is a pre-existing project
+        // that has nodes installed from before we started tracking them ourselves
+        const moduleList = result.palette?.modules || await app.db.controllers.StorageSettings.getProjectModules(project) || []
+        const modules = {}
+        moduleList.forEach(module => {
+            modules[module.name] = module.version
+        })
+        result.palette.modules = modules
         result.env = env
         return result
     },
@@ -170,6 +179,67 @@ module.exports = {
         const newHash = crypto.createHash('sha256').update(newKey).digest()
         const oldHash = crypto.createHash('sha256').update(oldKey).digest()
         return encryptCreds(newHash, decryptCreds(oldHash, original))
+    },
+
+    /**
+     * Updates the project settings.palette.modules value based on the
+     * module list Node-RED has provided to the StorageSettings api.
+     */
+    mergeProjectModules: async function (app, project, moduleList) {
+        let changed = false
+        let newProjectModuleList
+        const currentProjectSettings = await project.getSetting('settings')
+        if (currentProjectSettings?.palette?.modules) {
+            // The project has an existing list of modules - need to resolve any
+            // changes between the two lists
+
+            // As the moduleList comes from Node-RED's runtimeSettings object,
+            // it will only contain the modules that include Node-RED nodes.
+            // Regular npm modules that do not include nodes (nrlint for eg)
+            // will not be included.
+            // So we don't want to remove anything from the current list just
+            // because it isn't listed in what moduleList provides.
+
+            // This is the list of modules from ProjectSettings
+            const existingModulesList = currentProjectSettings?.palette?.modules
+            const existingModules = {}
+            existingModulesList.forEach(m => { existingModules[m.name] = m })
+
+            const newModules = {}
+            moduleList.forEach(m => {
+                newModules[m.name] = m
+                if (!existingModules[m.name]) {
+                    // Newly installed module - add to the list
+                    changed = true
+                    existingModules[m.name] = m
+                    if (/^\d/.test(m.version)) {
+                        m.version = `~${m.version}`
+                    }
+                } else if (!semver.satisfies(m.version, existingModules[m.name].version)) {
+                    // The installed version does not match what we thought semver wanted.
+                    // Defer to what has been installed - but with '~' prepended
+                    // as is the default Node-RED/npm behaviour
+                    if (/^\d/.test(m.version)) {
+                        m.version = `~${m.version}`
+                    }
+                    existingModules[m.name] = m
+                }
+            })
+            newProjectModuleList = Object.values(existingModules)
+        } else {
+            // No existing modules - so updated with the list as provided
+            newProjectModuleList = moduleList.map(m => {
+                if (/^\d/.test(m.version)) {
+                    m.version = `~${m.version}`
+                }
+                return m
+            })
+        }
+        if (changed) {
+            currentProjectSettings.palette = currentProjectSettings.palette || {}
+            currentProjectSettings.palette.modules = newProjectModuleList
+            await project.updateSetting('settings', currentProjectSettings)
+        }
     }
 }
 

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -21,6 +21,29 @@ const validSettings = [
     // 'env' // Handled separately
 ]
 
+const defaultTemplatePolicy = {
+    disableEditor: false,
+    disableTours: false,
+    httpAdminRoot: false,
+    dashboardUI: false,
+    codeEditor: false,
+    theme: false,
+    page_title: false,
+    page_favicon: false,
+    header_title: false,
+    header_url: false,
+    timeZone: false,
+    palette_allowInstall: false,
+    palette_nodesExcludes: false,
+    palette_denyList: false,
+    palette_modules: true,
+    modules_allowInstall: false,
+    modules_denyList: false,
+    httpNodeAuth_user: false,
+    httpNodeAuth_pass: false
+}
+
+
 function getTemplateValue (template, path) {
     const parts = path.split('_')
     let p = template
@@ -66,7 +89,9 @@ module.exports = {
         validSettings.forEach((name) => {
             const value = getTemplateValue(settings, name)
             if (value !== undefined) {
-                if (!template || getTemplateValue(template.policy, name) !== false) {
+                let policy = !template || getTemplateValue(template.policy, name)
+                if (policy === undefined) { policy = defaultTemplatePolicy[name] }
+                if (!template || policy) {
                     setTemplateValue(result, name, value)
                 }
             }

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -43,7 +43,6 @@ const defaultTemplatePolicy = {
     httpNodeAuth_pass: false
 }
 
-
 function getTemplateValue (template, path) {
     const parts = path.split('_')
     let p = template

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -14,6 +14,7 @@ const validSettings = [
     'palette_allowInstall',
     'palette_nodesExcludes',
     'palette_denyList',
+    'palette_modules',
     'modules_allowInstall',
     'httpNodeAuth_user',
     'httpNodeAuth_pass'
@@ -61,12 +62,11 @@ module.exports = {
    */
     validateSettings: function (app, settings, template) {
         const result = {}
-
         // First pass - copy over only the known and policy-permitted settings
         validSettings.forEach((name) => {
             const value = getTemplateValue(settings, name)
             if (value !== undefined) {
-                if (!template || getTemplateValue(template.policy, name)) {
+                if (!template || getTemplateValue(template.policy, name) !== false) {
                     setTemplateValue(result, name, value)
                 }
             }
@@ -187,7 +187,7 @@ module.exports = {
    * @param {*} settings the new settings to merge in
    */
     mergeSettings: function (app, existingSettings, settings) {
-    // Quick deep clone that is safe as we know settings are JSON-safe
+        // Quick deep clone that is safe as we know settings are JSON-safe
         const result = JSON.parse(JSON.stringify(existingSettings))
         validSettings.forEach((name) => {
             const value = getTemplateValue(settings, name)

--- a/forge/db/controllers/StorageSettings.js
+++ b/forge/db/controllers/StorageSettings.js
@@ -7,6 +7,9 @@ module.exports = {
                 const runtimeSettings = JSON.parse(storageSettings.settings)
                 if (runtimeSettings.nodes) {
                     for (const [key, value] of Object.entries(runtimeSettings.nodes)) {
+                        // Only return the 'local' modules - those are the ones loaded
+                        // from the project's own package.json, rather than elsewhere
+                        // on the node path.
                         if (value.local) {
                             result.push({
                                 name: key,

--- a/forge/db/controllers/StorageSettings.js
+++ b/forge/db/controllers/StorageSettings.js
@@ -1,0 +1,29 @@
+module.exports = {
+    getProjectModules: async function (app, project) {
+        const result = []
+        try {
+            const storageSettings = await app.db.models.StorageSettings.byProject(project.id)
+            if (storageSettings?.settings) {
+                const runtimeSettings = JSON.parse(storageSettings.settings)
+                if (runtimeSettings.nodes) {
+                    for (const [key, value] of Object.entries(runtimeSettings.nodes)) {
+                        if (value.local) {
+                            result.push({
+                                name: key,
+                                version: value.version,
+                                local: value.local
+                            })
+                            result.sort((A, B) => {
+                                if (A.local && !B.local) { return 1 }
+                                if (!A.local && B.local) { return -1 }
+                                return A.name.localeCompare(B.name)
+                            })
+                        }
+                    }
+                }
+            }
+        } catch (err) {
+        }
+        return result
+    }
+}

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -22,7 +22,8 @@ const modelTypes = [
     'ProjectTemplate',
     'ProjectSnapshot',
     'Device',
-    'BrokerClient'
+    'BrokerClient',
+    'StorageSettings'
 ]
 
 async function init (app) {

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -1,5 +1,5 @@
 module.exports = {
-    project: function (app, project) {
+    project: async function (app, project) {
         const proj = project.toJSON()
         const result = {
             id: proj.id,
@@ -17,6 +17,12 @@ module.exports = {
             }
         } else {
             result.settings = {}
+        }
+        if (!result.settings.palette?.modules) {
+            // If there are no modules listed in settings, check the StorageSettings
+            // for the project to see what Node-RED may already think is installed
+            result.settings.palette = result.settings.palette || {}
+            result.settings.palette.modules = await app.db.controllers.StorageSettings.getProjectModules(project)
         }
         if (proj.Team) {
             result.team = {
@@ -58,15 +64,18 @@ module.exports = {
         result.links = proj.links
         return result
     },
-    teamProjectList: function (app, projectList) {
-        return projectList.map((t) => {
-            const r = app.db.views.Project.project(t)
+    teamProjectList: async function (app, projectList) {
+        const result = new Array(projectList.length)
+        for (let i = 0; i < projectList.length; i++) {
+            const p = projectList[i]
+            const r = await app.db.views.Project.project(p)
             // A limitation of how httpAdminRoot is applied to the url property
             // means we can't return the raw url from a projectList that won't
             // include the Template/Settings values with additional db lookups
             delete r.url
-            return r
-        })
+            result[i] = r
+        }
+        return result
     },
     projectSummary: function (app, project) {
         return {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -76,6 +76,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId', async (request, reply) => {
+        // request.project.runtimeSettings = await app.db.models.StorageSettings.byProject(request.project.id)
         const result = await app.db.views.Project.project(request.project)
         const inflightState = app.db.controllers.Project.getInflightState(request.project)
         if (inflightState) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -76,7 +76,6 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId', async (request, reply) => {
-        // request.project.runtimeSettings = await app.db.models.StorageSettings.byProject(request.project.id)
         const result = await app.db.views.Project.project(request.project)
         const inflightState = app.db.controllers.Project.getInflightState(request.project)
         if (inflightState) {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -124,7 +124,7 @@ module.exports = async function (app) {
     app.get('/:teamId/projects', { config: { allowToken: true } }, async (request, reply) => {
         const projects = await app.db.models.Project.byTeam(request.params.teamId)
         if (projects) {
-            let result = app.db.views.Project.teamProjectList(projects)
+            let result = await app.db.views.Project.teamProjectList(projects)
             if (request.session.ownerType === 'project') {
                 // This request is from a project token. Filter the list to return
                 // the minimal information needed

--- a/forge/routes/storage/index.js
+++ b/forge/routes/storage/index.js
@@ -98,6 +98,7 @@ module.exports = async function (app) {
                 })
                 await settings.save()
             }
+            await app.db.controllers.Project.mergeProjectModules(project, await app.db.controllers.StorageSettings.getProjectModules(project))
             response.send(request.body)
         } else {
             response.status(404).send()

--- a/frontend/src/pages/admin/Template/sections/PaletteModules.vue
+++ b/frontend/src/pages/admin/Template/sections/PaletteModules.vue
@@ -216,6 +216,8 @@ export default {
             return /^\*$|x|(?:[\^~]?(0|[1-9]\d*)\.(x$|0|[1-9]\d*)(?:\.(x$|0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)$/.test(version)
         },
         showAddModule () {
+            this.input.name = ''
+            this.input.version = ''
             this.showAddRow = true
         },
         cancelAddModule () {

--- a/frontend/src/pages/admin/Template/sections/PaletteModules.vue
+++ b/frontend/src/pages/admin/Template/sections/PaletteModules.vue
@@ -1,0 +1,265 @@
+<template>
+    <form class="space-y-4" @submit.prevent>
+        <FormHeading>
+            <div class="flex">
+                <div class="mr-4">Installed Modules</div>
+                <div class="flex justify-center"><ChangeIndicator :value="editable.changed.palette_modules"></ChangeIndicator></div>
+            </div>
+        </FormHeading>
+
+        <div class="text-gray-400 space-y-1">
+            <p>This is the list of modules that will be installed into the project.</p>
+            <div v-if="editable.settings.palette_allowInstall" class="space-y-1">
+                <p>Any changes to this list will require restarting the project to apply.</p>
+                <p>You can also install modules using the palette manager in the editor.</p>
+            </div>
+
+        </div>
+
+        <table class="w-full max-w-2xl table-fixed text-sm rounded overflow-hidden">
+            <thead>
+                <tr class="font-medium">
+                    <td class="border bg-gray-100 p-2 w-auto">Module</td>
+                    <td class="border bg-gray-100 p-2 w-48">Version</td>
+                    <td class="border bg-gray-100 p-2 w-24"></td>
+                </tr>
+            </thead>
+            <tbody class="bg-white">
+                <tr v-for="(item, itemIdx) in editable.settings.palette_modules"  :key="item.index">
+                    <td class="px-2 py-2 border align-top">
+                        <FormRow
+                            class="font-mono"
+                            v-model="item.name"
+                            :error="item.error"
+                            type="uneditable">
+                        </FormRow>
+                        <!-- <ff-text-input  v-model="item.name" :disabled="item.encrypted"  /> -->
+                    </td>
+                    <td class="px-2 py-2 border align-top">
+                        <div style="width: calc(100% - 40px);">
+                            <FormRow
+                                class="font-mono"
+                                v-model="item.version"
+                                :type="(!readOnly && item.local && item.editing)?'text':'uneditable'"
+                                :error="item.errorVersion">
+                                <template #append>
+                                    <div v-if="!readOnly && item.local && !item.editing" class="flex items-center">
+                                        <ff-button kind="tertiary" @click="editModule(itemIdx)" size="small">
+                                            <template v-slot:icon>
+                                                <PencilIcon />
+                                            </template>
+                                        </ff-button>
+                                    </div>
+                                    <div v-if="!readOnly && item.local && item.editing" class="flex items-center pt-1">
+                                        <ff-button kind="tertiary" @click="cancelEditModule(itemIdx)" size="small">
+                                            <template v-slot:icon>
+                                                <XIcon />
+                                            </template>
+                                        </ff-button>
+                                    </div>
+                                </template>
+                            </FormRow>
+                        </div>
+                    </td>
+                    <td class="border align-middle px-2">
+                        <div v-if="!readOnly && item.local" class="flex justify-center">
+                            <ff-button kind="tertiary" @click="removeModule(itemIdx)" size="small">
+                                <template v-slot:icon>
+                                    <TrashIcon />
+                                </template>
+                            </ff-button>
+                        </div>
+                        <div v-else-if="!item.local" class="flex justify-center">
+                            <LockClosedIcon class="inline w-4" />
+                        </div>
+                    </td>
+                </tr>
+                <tr v-if="editable.settings.palette_modules?.length === 0">
+                    <td class="px-4 py-4 border w-auto align-top text-center text-gray-400" colspan="3">
+                        No modules installed
+                    </td>
+                </tr>
+                <!-- Empty row to differentiate between the existing env vars, and the iput form row-->
+                <tr v-if="!readOnly">
+                    <td colspan="3" class="p-1 bg-gray-50"></td>
+                </tr>
+                <tr v-if="!readOnly && !showAddRow" class="">
+                    <td colspan="3" class="p-1 bg-gray-50">
+                        <ff-button kind="primary" @click="showAddModule()" size="small">
+                            Add module
+                            <template v-slot:icon>
+                                <PlusSmIcon />
+                            </template>
+                        </ff-button>
+                    </td>
+                </tr>
+                <tr v-if="!readOnly && showAddRow" class="">
+                    <td class="px-4 pt-4 border w-auto align-top">
+                        <FormRow class="font-mono" v-model="input.name" :error="input.error" placeholder="@example/module">
+                            <template #description>npm module name</template>
+                        </FormRow>
+                    </td>
+                    <td class="px-4 pt-4 pb-3 border w-auto align-top space-y-3">
+                        <FormRow class="font-mono" v-model="input.version" :error="input.errorVersion" placeholder="*">
+                            <template #description>*, 1.2.3, ^2.3.2, ...</template>
+                        </FormRow>
+                        <!-- <FormRow id="encrypt-env-var" v-model="input.encrypt" type="checkbox"> <span class="text-gray-500"><LockClosedIcon class="inline w-4" /> encrypt</span></FormRow> -->
+                    </td>
+                    <td class="border w-16">
+                        <div class="flex align-center justify-center space-x-2">
+                            <ff-button kind="primary" @click="addModule()" :disabled="!addEnabled" size="small">
+                                <template v-slot:icon>
+                                    <CheckIcon />
+                                </template>
+                            </ff-button>
+                            <ff-button kind="secondary" @click="cancelAddModule()" size="small">
+                                <template v-slot:icon>
+                                    <XIcon />
+                                </template>
+                            </ff-button>
+                        </div>
+                    </td>
+                    <td class="p-2" v-if="editTemplate"></td>
+                </tr>
+            </tbody>
+        </table>
+    </form>
+
+</template>
+
+<script>
+
+import FormRow from '@/components/FormRow'
+import FormHeading from '@/components/FormHeading'
+import ChangeIndicator from '../components/ChangeIndicator'
+import { TrashIcon, PlusSmIcon, LockClosedIcon, PencilIcon, XIcon, CheckIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'TemplatePaletteModulesEditor',
+    props: ['editTemplate', 'modelValue', 'readOnly'],
+    emits: ['update:modelValue'],
+    data () {
+        return {
+            addedCount: 0,
+            input: {
+                name: '',
+                version: ''
+            },
+            showAddRow: false,
+            modules: {}
+        }
+    },
+    computed: {
+        editable: {
+            get () { return this.modelValue },
+            set (localValue) { this.$emit('update:modelValue', localValue) }
+        },
+        addEnabled () {
+            return this.input.name && this.input.version && !this.input.error && !this.input.errorVersion
+        }
+    },
+    watch: {
+        'input.name' () {
+            if (this.input.name !== '' && !this.validateModuleName(this.input.name)) {
+                this.input.error = 'Invalid name'
+            } else if (this.modules[this.input.name] !== undefined) {
+                this.input.error = 'Duplicate name'
+            } else {
+                this.input.error = ''
+            }
+        },
+        'input.version' () {
+            if (this.input.version !== '' && !this.validateModuleVersion(this.input.version)) {
+                this.input.errorVersion = 'Invalid version'
+            } else {
+                this.input.errorVersion = ''
+            }
+        },
+        'editable' () {
+            if (this.editable) {
+                this.editable.settings.palette_modules?.forEach(field => {
+                    this.modules[field.name] = field
+                })
+            }
+        },
+        'editable.settings.palette_modules': {
+            deep: true,
+            handler (v) {
+                if (v) {
+                    this.modules = {}
+                    v.forEach((field, i) => {
+                        if (this.modules[field.name] === undefined) {
+                            this.modules[field.name] = i
+                        }
+                        if (field.policy === undefined && this.modules[field.name] !== i) {
+                            field.error = 'Field has duplicate name'
+                        } else if (!this.validateModuleName(field.name)) {
+                            field.error = 'Invalid name'
+                        } else {
+                            field.error = ''
+                        }
+                        if (!this.validateModuleVersion(field.version)) {
+                            field.errorVersion = 'Invalid version'
+                        } else {
+                            field.errorVersion = ''
+                        }
+                    })
+                }
+            }
+        }
+    },
+    methods: {
+        validateModuleName (name) {
+            return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+        },
+        validateModuleVersion (version) {
+            return /^\*$|x|(?:[\^~]?(0|[1-9]\d*)\.(x$|0|[1-9]\d*)(?:\.(x$|0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)$/.test(version)
+        },
+        showAddModule () {
+            this.showAddRow = true
+        },
+        cancelAddModule () {
+            this.showAddRow = false
+        },
+        editModule (index) {
+            const module = this.editable.settings.palette_modules[index]
+            module.originalVersion = module.version
+            module.editing = true
+        },
+        cancelEditModule (index) {
+            const module = this.editable.settings.palette_modules[index]
+            module.version = module.originalVersion
+            module.editing = false
+        },
+        removeModule (index) {
+            const field = this.editable.settings.palette_modules[index]
+            delete this.modules[field.name]
+            this.editable.settings.palette_modules.splice(index, 1)
+        },
+        addModule (index) {
+            const field = {
+                index: 'add-' + this.addedCount++,
+                name: this.input.name,
+                version: this.input.version,
+                local: true
+            }
+            this.modules[this.input.name] = this.editable.settings.palette_modules.length
+            this.input.name = ''
+            this.input.version = ''
+            this.editable.settings.palette_modules.push(field)
+            this.showAddRow = false
+        }
+    },
+    components: {
+        FormRow,
+        FormHeading,
+        ChangeIndicator,
+        TrashIcon,
+        PencilIcon,
+        PlusSmIcon,
+        LockClosedIcon,
+        XIcon,
+        CheckIcon
+    }
+}
+</script>

--- a/frontend/src/pages/project/Logs.vue
+++ b/frontend/src/pages/project/Logs.vue
@@ -23,6 +23,7 @@ export default {
     props: ['project'],
     data () {
         return {
+            doneInitialLoad: false,
             loading: true,
             logEntries: [],
             prevCursor: null,
@@ -53,7 +54,6 @@ export default {
         fetchData: async function () {
             if (this.project.id) {
                 if (this.project.meta.state !== 'suspended') {
-                    this.loading = true
                     await this.loadItems(this.project.id)
                     this.loading = false
                 } else {

--- a/frontend/src/pages/project/Settings/Palette.vue
+++ b/frontend/src/pages/project/Settings/Palette.vue
@@ -1,6 +1,7 @@
 <template>
     <form class="space-y-6">
         <TemplateSettingsPalette v-model="editable" :editTemplate="false" />
+        <TemplatePaletteModulesEditor v-model="editable" :editTemplate="false" :readOnly="!paletteEditable"/>
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save settings</ff-button>
         </div>
@@ -12,6 +13,8 @@ import alerts from '@/services/alerts'
 
 import projectApi from '@/api/project'
 import TemplateSettingsPalette from '../../admin/Template/sections/Palette'
+import TemplatePaletteModulesEditor from '../../admin/Template/sections/PaletteModules'
+
 import {
     getTemplateValue,
     setTemplateValue,
@@ -28,6 +31,7 @@ export default {
     data () {
         return {
             unsavedChanges: false,
+            modulesChanged: false,
             editable: {
                 name: '',
                 settings: {},
@@ -48,7 +52,10 @@ export default {
     props: ['project'],
     mixins: [permissionsMixin],
     computed: {
-        ...mapState('account', ['team', 'teamMembership'])
+        ...mapState('account', ['team', 'teamMembership']),
+        paletteEditable () {
+            return this.editable?.settings.palette_allowInstall
+        }
     },
     watch: {
         project: 'getSettings',
@@ -58,11 +65,48 @@ export default {
                 if (this.project.template) {
                     let changed = false
                     templateFields.forEach(field => {
-                        // this.editable.changed.settings[field] = this.editable.settings[field] != this.original.settings[field]
-                        changed = changed || (this.editable.settings[field] !== this.original.settings[field])
+                        if (field !== 'palette_modules') {
+                            // this.editable.changed.settings[field] = this.editable.settings[field] != this.original.settings[field]
+                            changed = changed || (this.editable.settings[field] !== this.original.settings[field])
+                        }
                     })
                     this.unsavedChanges = changed
                 }
+            }
+        },
+        'editable.settings.palette_modules': {
+            deep: true,
+            handler (v) {
+                let changed = false
+                let errors = false
+
+                let originalCount = 0
+                this.editable.settings.palette_modules.forEach(field => {
+                    errors = errors || field.error
+                    if (/^add/.test(field.index)) {
+                        changed = true
+                    } else {
+                        originalCount++
+                        if (this.original.settings.palette_modulesMap[field.name]) {
+                            const original = this.original.settings.palette_modulesMap[field.name]
+                            if (original.index !== field.index) {
+                                changed = true
+                            } else if (original.name !== field.name) {
+                                changed = true
+                            } else if (original.version !== field.version) {
+                                changed = true
+                            }
+                        } else {
+                            changed = true
+                        }
+                    }
+                })
+                if (originalCount !== this.original.settings.palette_modules.length) {
+                    changed = true
+                }
+                this.modulesChanged = changed
+                this.unsavedChanges = this.unsavedChanges || changed
+                this.hasErrors = errors
             }
         }
     },
@@ -71,7 +115,7 @@ export default {
         this.getSettings()
     },
     methods: {
-        checkAccess: async function () {
+        checkAccess: function () {
             if (!this.hasPermission('project:edit')) {
                 useRouter().push({ replace: true, path: 'general' })
             }
@@ -85,12 +129,16 @@ export default {
                 templateFields.forEach(field => {
                     const projectSettingsValue = getTemplateValue(this.project.settings, field)
                     if (projectSettingsValue !== undefined) {
-                        this.editable.settings[field] = projectSettingsValue
+                        this.editable.settings[field] = JSON.parse(JSON.stringify(projectSettingsValue))
                         // Also update original for change detection - although if we want to
                         // have a 'revert to default' option, we'll want the Template-provided
                         // original to use
-                        this.original.settings[field] = projectSettingsValue
+                        this.original.settings[field] = JSON.parse(JSON.stringify(projectSettingsValue))
                     }
+                })
+                this.original.settings.palette_modulesMap = {}
+                this.project.settings.palette?.modules?.forEach(module => {
+                    this.original.settings.palette_modulesMap[module.name] = module
                 })
             }
         },
@@ -107,7 +155,8 @@ export default {
         }
     },
     components: {
-        TemplateSettingsPalette
+        TemplateSettingsPalette,
+        TemplatePaletteModulesEditor
     }
 }
 </script>

--- a/frontend/src/pages/project/Settings/Palette.vue
+++ b/frontend/src/pages/project/Settings/Palette.vue
@@ -3,7 +3,7 @@
         <TemplateSettingsPalette v-model="editable" :editTemplate="false" />
         <TemplatePaletteModulesEditor v-model="editable" :editTemplate="false" :readOnly="!paletteEditable"/>
         <div class="space-x-4 whitespace-nowrap">
-            <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save settings</ff-button>
+            <ff-button size="small" :disabled="!unsavedChanges && !modulesChanged" @click="saveSettings()">Save settings</ff-button>
         </div>
     </form>
 </template>
@@ -105,7 +105,6 @@ export default {
                     changed = true
                 }
                 this.modulesChanged = changed
-                this.unsavedChanges = this.unsavedChanges || changed
                 this.hasErrors = errors
             }
         }

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -57,6 +57,11 @@ describe('Project controller', function () {
                 ]
             })
 
+            await app.db.models.StorageSettings.create({
+                settings: '{"nodes":{"node-red":{"name":"node-red","version":"3.0.0","local":false,"user":false},"@flowforge/nr-project-nodes":{"name":"@flowforge/nr-project-nodes","version":"0.1.0","local":false,"user":false},"node-red-node-random":{"name":"node-red-node-random","version":"1.2.3","local":true}}}',
+                ProjectId: project.id
+            })
+
             const reloadedProject = await app.db.models.Project.byId(project.id)
 
             const result = await app.db.controllers.Project.getRuntimeSettings(reloadedProject)
@@ -68,19 +73,86 @@ describe('Project controller', function () {
             result.should.have.property('palette')
             result.palette.should.have.property('allowInstall', true)
             result.palette.should.have.property('nodesExcludes', 'updated.js')
+            result.palette.should.have.property('modules')
+            result.palette.modules.should.have.property('node-red-node-random', '1.2.3')
             result.should.have.property('modules')
             result.modules.should.have.property('allowInstall', true)
             result.should.have.property('env')
-
             result.env.should.have.property('one', 'project-a')
             result.env.should.have.property('two', 'b')
             result.env.should.have.property('three', 'c')
         })
     })
 
-    describe('exportProject', function () {
-        it('', async function () {
-            //
+    describe('mergeProjectModules', function () {
+        it('updates without project that has no modules currently', async function () {
+            const project = await app.db.models.Project.create({
+                name: 'testProject',
+                type: '',
+                url: ''
+            })
+
+            const reloadedProject = await app.db.models.Project.byId(project.id)
+
+            await app.db.controllers.Project.mergeProjectModules(reloadedProject, [
+                { name: 'new-module', version: '1', local: true },
+                { name: 'upgraded-module', version: '2', local: true }
+            ])
+
+            const updatedSettings = await project.getSetting('settings')
+            updatedSettings.palette.modules.should.have.length(2)
+            updatedSettings.palette.modules.sort((A, B) => A.name.localeCompare(B.name))
+            // 'new-module' added
+            updatedSettings.palette.modules[0].should.have.property('name', 'new-module')
+            updatedSettings.palette.modules[0].should.have.property('version', '~1')
+
+            // 'upgraded-module' added
+            updatedSettings.palette.modules[1].should.have.property('name', 'upgraded-module')
+            updatedSettings.palette.modules[1].should.have.property('version', '~2')
+        })
+
+        it('updates project settings based on Node-RED module list', async function () {
+            const project = await app.db.models.Project.create({
+                name: 'testProject',
+                type: '',
+                url: ''
+            })
+
+            await project.updateSetting('settings', {
+                palette: {
+                    modules: [
+                        { name: 'upgraded-module', version: '1', local: true },
+                        { name: 'another-module', version: '1', local: true }
+                    ]
+                }
+            })
+
+            const reloadedProject = await app.db.models.Project.byId(project.id)
+
+            await app.db.controllers.Project.mergeProjectModules(reloadedProject, [
+                { name: 'new-module', version: '1', local: true },
+                { name: 'upgraded-module', version: '2', local: true }
+            ])
+
+            const updatedSettings = await project.getSetting('settings')
+            updatedSettings.palette.modules.should.have.length(3)
+            updatedSettings.palette.modules.sort((A, B) => A.name.localeCompare(B.name))
+            // 'another-module' left untouched
+            updatedSettings.palette.modules[0].should.have.property('name', 'another-module')
+            updatedSettings.palette.modules[0].should.have.property('version', '1')
+
+            // 'new-module' added
+            updatedSettings.palette.modules[1].should.have.property('name', 'new-module')
+            updatedSettings.palette.modules[1].should.have.property('version', '~1')
+
+            // 'upgraded-module' upgraded
+            updatedSettings.palette.modules[2].should.have.property('name', 'upgraded-module')
+            updatedSettings.palette.modules[2].should.have.property('version', '~2')
         })
     })
+    // describe('exportProject', function () {
+    //     it('', async function () {
+    //         //
+    //     })
+    // })
 })

--- a/test/unit/forge/db/controllers/StorageSettings_spec.js
+++ b/test/unit/forge/db/controllers/StorageSettings_spec.js
@@ -1,0 +1,47 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('Storage Settings controller', function () {
+    // Use standard test data.
+    let app
+    beforeEach(async function () {
+        app = await setup()
+    })
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('getProjectModules', function () {
+        it('returns the modules Node-RED has discovered and stored in settings', async function () {
+            const project = await app.db.models.Project.create({
+                name: 'testProject',
+                type: '',
+                url: ''
+            })
+
+            await app.db.models.StorageSettings.create({
+                settings: '{"nodes":{"node-red":{"name":"node-red","version":"3.0.0","local":false,"user":false},"@flowforge/nr-project-nodes":{"name":"@flowforge/nr-project-nodes","version":"0.1.0","local":false,"user":false},"node-red-node-random":{"name":"node-red-node-random","version":"1.2.3","local":true}}}',
+                ProjectId: project.id
+            })
+
+            const result = await app.db.controllers.StorageSettings.getProjectModules(project)
+
+            result.should.have.length(1)
+            result[0].should.have.property('name', 'node-red-node-random')
+            result[0].should.have.property('version', '1.2.3')
+            result[0].should.have.property('local', true)
+        })
+        it('returns an empty list if Node-RED has not stored anything', async function () {
+            const project = await app.db.models.Project.create({
+                name: 'testProject',
+                type: '',
+                url: ''
+            })
+
+            const result = await app.db.controllers.StorageSettings.getProjectModules(project)
+
+            result.should.have.length(0)
+        })
+    })
+})

--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -172,7 +172,7 @@ describe('Storage API', function () {
         const projectSettings = await app.db.controllers.Project.getRuntimeSettings(localProject)
         projectSettings.should.have.property('palette')
         projectSettings.palette.should.have.property('modules')
-        projectSettings.palette.modules.should.have.property('node-red-node-random', '1.2.3')
+        projectSettings.palette.modules.should.have.property('node-red-node-random', '~1.2.3')
         projectSettings.palette.modules.should.not.have.property('node-red')
         projectSettings.palette.modules.should.not.have.property('@flowforge/nr-project-nodes')
     })

--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -146,8 +146,8 @@ describe('Storage API', function () {
         should(settings).eqls({})
     })
 
-    it('Save Settings', async function () {
-        const newSettings = [{ id: '1', type: 'tab', label: 'tab1', disabled: false, info: '' }]
+    it('Runtime Settings', async function () {
+        const newSettings = JSON.parse('{"nodes":{"node-red":{"name":"node-red","version":"3.0.0","local":false,"user":false},"@flowforge/nr-project-nodes":{"name":"@flowforge/nr-project-nodes","version":"0.1.0","local":false,"user":false},"node-red-node-random":{"name":"node-red-node-random","version":"1.2.3","local":true}}}')
         const settingsURL = `/storage/${project.id}/settings`
         await app.inject({
             method: 'POST',
@@ -167,6 +167,14 @@ describe('Storage API', function () {
         })
         const creds = response.json()
         should(creds).eqls(newSettings)
+        // Reload the project to ensure it is fully populated
+        const localProject = await app.db.models.Project.byId(project.id)
+        const projectSettings = await app.db.controllers.Project.getRuntimeSettings(localProject)
+        projectSettings.should.have.property('palette')
+        projectSettings.palette.should.have.property('modules')
+        projectSettings.palette.modules.should.have.property('node-red-node-random', '1.2.3')
+        projectSettings.palette.modules.should.not.have.property('node-red')
+        projectSettings.palette.modules.should.not.have.property('@flowforge/nr-project-nodes')
     })
 
     it('Get Sessions', async function () {


### PR DESCRIPTION
Closes #405

This adds the ability to list npm modules that should get preinstalled in the project before Node-RED starts.

Note: there will be a companion PR against the launcher to match.

The Project-Settings-Palette view gets a new 'Installed Modules' table. This lists the additional modules that have been installed:

<img width="642" alt="image" src="https://user-images.githubusercontent.com/51083/196235120-2c9df4cf-bede-49a3-871b-51d58465fee5.png">

### Adding a new module

If the user is allowed to modify the installed modules, then the `+ add module` button is shown. Clicking on it reveals another row in the table:

<img width="622" alt="image" src="https://user-images.githubusercontent.com/51083/196235465-283ebacb-3144-404e-9855-b5dab93ee4a1.png">

Both fields use regex validation:

<img width="584" alt="image" src="https://user-images.githubusercontent.com/51083/196235587-29f64ae4-037a-46f6-adb1-c163b0ef586b.png">


Note that we don't care if its a Node-RED node module or not - it just needs to be a valid npm module. This means it can be used to install `nrlint` and other plugins that don't otherwise show up in the palette manager.

### Editing an existing module

The pencil icon can be used to edit the version of a given module. Clicking it turns the version string into an editable input:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/51083/196235817-2b1ea607-ceae-411d-b5b7-466f01f48ff6.png">

### Removing a module

The trashcan icon can be used to remove a module


### Applying the changes

After any changes are made, the user must click 'save settings' to... save the settings. They then must restart Node-RED to apply these changes (as is the case with *all* settings changes... a bit of UX to improve IMHO)


### Editing the palette in Node-RED

The user can still install new modules in the editor. We catch the update when Node-RED updates its runtime settings and make any necessary changes to our own record of what should be installed.


