### PR TITLE
First pass at Starting copies in stopped state

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -264,6 +264,9 @@ module.exports = async function (app) {
                     }
                 }
             }
+
+            newSettings.runtimeFlowState = 'stop'
+
             await project.updateSetting('credentialSecret', newCredentialSecret)
             const settings = await app.db.models.StorageSettings.create({
                 settings: JSON.stringify(newSettings),

--- a/frontend/src/pages/project/Settings/Danger.vue
+++ b/frontend/src/pages/project/Settings/Danger.vue
@@ -59,7 +59,7 @@
         <div class="flex flex-col lg:flex-row max-w-2xl space-y-4">
             <div class="flex-grow">
                 <div class="max-w-sm pt-2">
-                    Create a copy of this project.
+                    Create a copy of this project. The new project will be created with the flow in the stopped state to allow you to make any changes required before starting.
                 </div>
             </div>
             <div class="min-w-fit flex-shrink-0">


### PR DESCRIPTION
Start of #876

For Stacks based on NR 3.0.2 or later this start the project with the flows in a stopped state requiring somebody to log into the editor and start the flows.

Not sure if it needs more.