### PR TITLE
Only create personal team on first verify

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -338,7 +338,10 @@ module.exports = fp(async function (app, opts, done) {
                 return
             }
 
-            if (app.settings.get('user:team:auto-create')) {
+            // only create a personal team if no other teams exist
+            console.log(app.settings.get('user:team:auto-create'))
+            console.log(await app.db.models.Team.forUser(verifiedUser).length)
+            if (app.settings.get('user:team:auto-create') && !((await app.db.models.Team.forUser(verifiedUser)).length)) {
                 await app.db.controllers.Team.createTeamForUser({
                     name: `Team ${verifiedUser.name}`,
                     slug: verifiedUser.username,


### PR DESCRIPTION
Given a user can not be a member of a team until they sign in and verify their email address and accept the invite this should work.

Since they  will end up with their own team after the first verify.

fixes #1055