### PR TITLE
Add backend search to Admin Users/Teams tables

### DIFF
--- a/frontend/src/api/teams.js
+++ b/frontend/src/api/teams.js
@@ -1,8 +1,8 @@
 import client from './client'
 import paginateUrl from '@/utils/paginateUrl'
 
-const getTeams = async (cursor, limit) => {
-    const url = paginateUrl('/api/v1/teams', cursor, limit)
+const getTeams = async (cursor, limit, query) => {
+    const url = paginateUrl('/api/v1/teams', cursor, limit, query)
     return client.get(url).then(res => {
         res.data.teams = res.data.teams.map(r => {
             r.link = { name: 'Team', params: { team_slug: r.slug } }

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -13,8 +13,8 @@ const deleteUser = async (userId) => {
     })
 }
 
-const getUsers = (cursor, limit) => {
-    const url = paginateUrl('/api/v1/users', cursor, limit)
+const getUsers = (cursor, limit, query) => {
+    const url = paginateUrl('/api/v1/users', cursor, limit, query)
     return client.get(url).then(res => res.data)
 }
 

--- a/frontend/src/utils/paginateUrl.js
+++ b/frontend/src/utils/paginateUrl.js
@@ -1,10 +1,13 @@
-export default function (url, cursor, limit) {
+export default function (url, cursor, limit, query) {
     const queryString = new URLSearchParams()
     if (cursor) {
         queryString.append('cursor', cursor)
     }
     if (limit) {
         queryString.append('limit', limit)
+    }
+    if (query) {
+        queryString.append('query', query)
     }
     const qs = queryString.toString()
     if (qs === '') {


### PR DESCRIPTION
Part of #1065

This updates the Admin Users and Teams tables to use the search ability introduced by #1104 

Notes:

 - we debounce the user's typing to avoid sending an api request on every keystroke. We wait 300ms after the last change before sending the request (unless they have cleared it, in which case we don't wait).
 - there's a common pattern emerging between these two tables around this debouncing behaviour. I avoiding refactoring it into a single utility for now, but that should be considered when we expand api-based search to other views.
 - I updated both tables to use `ff-data-tables` own 'load more' UX.
