### PR TITLE
Consistent Menu Item pointers

### DIFF
--- a/frontend/src/components/DropdownMenu.vue
+++ b/frontend/src/components/DropdownMenu.vue
@@ -17,7 +17,7 @@
         >
             <MenuItems :class="[edge === 'left' ? 'left-0 origin-top-left' : 'right-0 origin-top-right','z-50 absolute w-56 mt-1 bg-white divide-y divide-gray-100 rounded overflow-hidden shadow-lg ring-1 ring-black ring-opacity-10 focus:outline-none']">
                 <div class="apx-1 apy-1">
-                    <MenuItem v-for="(item, $index) in options" v-slot="{ active }" :key="$index">
+                    <MenuItem v-for="(item, $index) in options" v-slot="{ active }" :key="$index" :disabled="!item || item.disabled == true ? true : false">
                         <template v-if="item == null">
                             <hr/>
                         </template>

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -54,3 +54,8 @@ label {
     color: $ff-grey-400 !important;
     opacity: 1; /* Firefox */
 }
+
+/* Ensure headlessui MenuItem pointer for active `menuitem` anchors */
+[role="menu"] a[role="menuitem"] {
+    cursor: pointer
+}


### PR DESCRIPTION
fixes #1113 

1. Ensure headlessui MenuItem pointer for active `menuitem` anchors are set to `pointer`
2. Ensure disabled menu items do NOT get a `pointer` 

NOTE: This also lead to finding a bug where the menu could be navigated and operated by keyboard due to lack of `disabled` attribute on the `MenuItem` - also fixed.

BEFORE: items have faint hover, are keyboard navigable, and menu is dismissed when operated

![chrome_QO7eEGio1E](https://user-images.githubusercontent.com/44235289/197213248-448ea156-11f2-4c82-bc49-88b44afda4b0.gif)


AFTER: disabled items and separators are no longer clickable nor dismiss the menu & no longer keyboard navigable. 

![chrome_szSbHJUfVU](https://user-images.githubusercontent.com/44235289/197213327-54f14ccb-2bdd-45c7-8385-b088b1856a61.gif)
