### PR TITLE
Standardize 404 response format

### DIFF
--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -16,17 +16,17 @@ module.exports = async function (app) {
                 try {
                     request.device = await app.db.models.Device.byId(request.params.deviceId)
                     if (!request.device) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                     if (request.session.User) {
                         request.teamMembership = await request.session.User.getTeamMembership(request.device.Team.id)
                     }
                 } catch (err) {
-                    reply.code(404).type('text/html').send('Not Found')
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
             } else {
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         }
     })

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -45,6 +45,6 @@ module.exports = async function (app) {
     app.register(Device, { prefix: '/devices' })
     app.register(ProjectType, { prefix: '/project-types' })
     app.get('*', function (request, reply) {
-        reply.code(404).type('text/html').send('Not Found')
+        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
     })
 }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -41,24 +41,24 @@ module.exports = async function (app) {
                 try {
                     request.project = await app.db.models.Project.byId(request.params.projectId)
                     if (!request.project) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                     if (request.session.User) {
                         request.teamMembership = await request.session.User.getTeamMembership(request.project.Team.id)
                         if (!request.teamMembership && !request.session.User.admin) {
-                            reply.code(404).type('text/html').send('Not Found')
+                            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                             return
                         }
                     } else if (request.session.ownerId !== request.params.projectId) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                 } catch (err) {
-                    reply.code(404).type('text/html').send('Not Found')
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
             } else {
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         }
     })

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -15,14 +15,14 @@ module.exports = async function (app) {
                 try {
                     request.snapshot = await app.db.models.ProjectSnapshot.byId(request.params.snapshotId)
                     if (!request.snapshot) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                 } catch (err) {
-                    reply.code(404).type('text/html').send('Not Found')
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
             } else {
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         }
     })

--- a/forge/routes/api/projectType.js
+++ b/forge/routes/api/projectType.js
@@ -40,7 +40,7 @@ module.exports = async function (app) {
         if (projectType) {
             reply.send(app.db.views.ProjectType.projectType(projectType, request.session.User.admin))
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -49,7 +49,7 @@ module.exports = async function (app) {
         if (stack) {
             reply.send(app.db.views.ProjectStack.stack(stack, request.session.User.admin))
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -42,23 +42,23 @@ module.exports = async function (app) {
                                 return
                             }
                         }
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                     request.teamMembership = await request.session.User.getTeamMembership(request.params.teamId)
                     if (!request.teamMembership && !request.session.User.admin) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                     request.team = await app.db.models.Team.byId(request.params.teamId)
                     if (!request.team) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                     }
                 } catch (err) {
-                    reply.code(404).type('text/html').send('Not Found')
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
             } else {
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         }
     })
@@ -101,12 +101,12 @@ module.exports = async function (app) {
             if (team) {
                 const teamMembership = await request.session.User.getTeamMembership(team.id)
                 if (!teamMembership && !request.session.User.admin) {
-                    reply.code(404).type('text/html').send('Not Found')
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                     return
                 }
                 await getTeamDetails(request, reply, team)
             } else {
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         } else if (!request.session.User.admin) {
             reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
@@ -135,7 +135,7 @@ module.exports = async function (app) {
                 projects: result
             })
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -306,7 +306,7 @@ module.exports = async function (app) {
             })
             return
         }
-        reply.code(404).type('text/html').send('Not Found')
+        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
     })
 
     /**

--- a/forge/routes/api/teamDevices.js
+++ b/forge/routes/api/teamDevices.js
@@ -22,14 +22,14 @@ module.exports = async function (app) {
     //             } else {
     //                 request.user = await app.db.models.User.byId(request.params.userId)
     //                 if (!request.user) {
-    //                     reply.code(404).type('text/html').send('Not Found')
+    //                     reply.code(404).send({ code: 'not_found', error: 'Not Found' })
     //                     return
     //                 }
     //                 request.userRole = await request.user.getTeamMembership(request.params.teamId)
     //             }
     //         } catch (err) {
     //             console.log(err)
-    //             reply.code(404).type('text/html').send('Not Found')
+    //             reply.code(404).send({ code: 'not_found', error: 'Not Found' })
     //         }
     //     }
     // })

--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -122,7 +122,7 @@ module.exports = async function (app) {
             )
             reply.send({ status: 'okay' })
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 }

--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -22,14 +22,14 @@ module.exports = async function (app) {
                 } else {
                     request.user = await app.db.models.User.byId(request.params.userId)
                     if (!request.user) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                     request.userRole = await request.user.getTeamMembership(request.params.teamId)
                 }
             } catch (err) {
                 console.log(err)
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         }
     })

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -31,7 +31,7 @@ module.exports = async function (app) {
         if (template) {
             reply.send(app.db.views.ProjectTemplate.template(template))
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -29,7 +29,7 @@ module.exports = async function (app) {
             await app.db.controllers.Invitation.acceptInvitation(invitation, request.session.User)
             reply.send({ status: 'okay' })
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -43,7 +43,7 @@ module.exports = async function (app) {
             await app.db.controllers.Invitation.rejectInvitation(invitation, request.session.User)
             reply.send({ status: 'okay' })
         } else {
-            reply.code(404).type('text/html').send('Not Found')
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 }

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -17,14 +17,14 @@ module.exports = async function (app) {
                 try {
                     request.user = await app.db.models.User.byId(request.params.userId)
                     if (!request.user) {
-                        reply.code(404).type('text/html').send('Not Found')
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
                 } catch (err) {
-                    reply.code(404).type('text/html').send('Not Found')
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                 }
             } else {
-                reply.code(404).type('text/html').send('Not Found')
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
             }
         }
     })

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -10,6 +10,7 @@ const requestCache = new LRU({
 })
 
 function badRequest (reply, error, description) {
+    // This format is defined by the OAuth standard - do not change
     reply.code(400).send({
         error,
         description
@@ -155,6 +156,7 @@ module.exports = async function (app) {
                     // Older versions of nr-auth do not know how to apply read-only
                     // access. We know it is an older version because it set scope to `editor`.
                     // Versions that support viewer will have a scope of `editor-<version>`.
+                    // This should be sent as plain text as the user will see it in the browser window.
                     reply.code(400).send('Please ask the team owner to update this project to the latest stack to support viewer access')
                     return
                 }

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -29,17 +29,17 @@ module.exports = fp(async function (app, opts, done) {
             if (permission.admin) {
                 // Requires admin user - which would have already been approved
                 // if they were an admin
-                reply.code(403).send({ error: 'unauthorized' })
+                reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                 throw new Error()
             } else if (app.settings.get(scope) === false) {
                 // Permission disabled via admin settings
-                reply.code(403).send({ error: 'unauthorized' })
+                reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                 throw new Error()
             } else if (permission.role) {
                 // The user is required to have a role in the team associated with
                 // this request
                 if (!request.teamMembership) {
-                    reply.code(403).send({ error: 'unauthorized' })
+                    reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                     throw new Error()
                 }
                 if (permission.self && request.user.id === request.session.User.id) {
@@ -47,7 +47,7 @@ module.exports = fp(async function (app, opts, done) {
                     return
                 }
                 if (request.teamMembership.role < permission.role) {
-                    reply.code(403).send({ error: 'unauthorized' })
+                    reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                     throw new Error()
                 }
             }

--- a/forge/routes/storage/index.js
+++ b/forge/routes/storage/index.js
@@ -28,7 +28,7 @@ module.exports = async function (app) {
             }
             response.send(request.body)
         } else {
-            response.status(404).send()
+            response.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -43,7 +43,7 @@ module.exports = async function (app) {
                 response.send([])
             }
         } else {
-            response.status(404).send()
+            response.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -65,7 +65,7 @@ module.exports = async function (app) {
             }
             response.send(request.body)
         } else {
-            response.status(404).send()
+            response.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -101,7 +101,7 @@ module.exports = async function (app) {
             await app.db.controllers.Project.mergeProjectModules(project, await app.db.controllers.StorageSettings.getProjectModules(project))
             response.send(request.body)
         } else {
-            response.status(404).send()
+            response.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -136,7 +136,7 @@ module.exports = async function (app) {
             }
             response.send(request.body)
         } else {
-            response.status(404).send()
+            response.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 
@@ -151,7 +151,7 @@ module.exports = async function (app) {
                 response.send({})
             }
         } else {
-            response.status(404).send()
+            response.status(404).send({ code: 'not_found', error: 'Not Found' })
         }
     })
 

--- a/test/unit/frontend/api/users.spec.js
+++ b/test/unit/frontend/api/users.spec.js
@@ -40,7 +40,7 @@ describe('Users API', async () => {
         const limit = 10
         UsersAPI.default.getUsers(cursor, limit)
         expect(mockPaginateUrl).toHaveBeenCalledOnce()
-        expect(mockPaginateUrl).toHaveBeenCalledWith('/api/v1/users', cursor, limit)
+        expect(mockPaginateUrl).toHaveBeenCalledWith('/api/v1/users', cursor, limit, undefined)
     })
 
     test('getUsers calls the correct API endpoint', () => {


### PR DESCRIPTION
Fixes #1076 

This updates our response format of 404 errors to adhere to our standard response format.

It also tidies up some other responses to ensure they have both `code` and `error` properties.