### PR TITLE
Ensure built-in modules are not listed in project modules

### DIFF
--- a/forge/db/controllers/StorageSettings.js
+++ b/forge/db/controllers/StorageSettings.js
@@ -1,3 +1,12 @@
+// These are the modules we preinstall that Node-RED will report back in its
+// runtime settings.
+// Pre 1.0, for docker/k8s, they might have been included in the main package.json
+// which means they are flagged as local - but they shouldn't be. We need to explicitly
+// filter them out.
+const BUILT_IN_MODULES = [
+    '@flowforge/nr-project-nodes'
+]
+
 module.exports = {
     getProjectModules: async function (app, project) {
         const result = []
@@ -10,7 +19,7 @@ module.exports = {
                         // Only return the 'local' modules - those are the ones loaded
                         // from the project's own package.json, rather than elsewhere
                         // on the node path.
-                        if (value.local) {
+                        if (value.local && !BUILT_IN_MODULES.includes(key)) {
                             result.push({
                                 name: key,
                                 version: value.version,

--- a/frontend/src/pages/admin/Template/sections/PaletteModules.vue
+++ b/frontend/src/pages/admin/Template/sections/PaletteModules.vue
@@ -210,7 +210,10 @@ export default {
     },
     methods: {
         validateModuleName (name) {
-            return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+            const BUILT_IN_MODULES = [
+                '@flowforge/nr-project-nodes'
+            ] 
+            return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name) && !BUILT_IN_MODULES.includes(name)
         },
         validateModuleVersion (version) {
             return /^\*$|x|(?:[\^~]?(0|[1-9]\d*)\.(x$|0|[1-9]\d*)(?:\.(x$|0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)$/.test(version)


### PR DESCRIPTION
This ensures `@flowforge/nr-project-nodes` doesn't get included in the project's main package.json as it isn't a module the user should be managing for themselves.