### PR TITLE
Add warning on Palette Modules settings if launcher detected as old

### DIFF
--- a/frontend/src/pages/admin/Template/sections/PaletteModules.vue
+++ b/frontend/src/pages/admin/Template/sections/PaletteModules.vue
@@ -7,13 +7,18 @@
             </div>
         </FormHeading>
 
+        <div class="text-red-400 space-y-1" v-if="!projectLauncherCompatible">
+            <p>You will need to update your Project Stack to use this feature.</p>
+            <div v-if="project.stack.replacedBy">
+                <ff-button size="small" to="./settings/danger">Update</ff-button>
+            </div>
+        </div>
         <div class="text-gray-400 space-y-1">
             <p>This is the list of modules that will be installed into the project.</p>
             <div v-if="editable.settings.palette_allowInstall" class="space-y-1">
                 <p>Any changes to this list will require restarting the project to apply.</p>
                 <p>You can also install modules using the palette manager in the editor.</p>
             </div>
-
         </div>
 
         <table class="w-full max-w-2xl table-fixed text-sm rounded overflow-hidden">
@@ -136,7 +141,7 @@ import { TrashIcon, PlusSmIcon, LockClosedIcon, PencilIcon, XIcon, CheckIcon } f
 
 export default {
     name: 'TemplatePaletteModulesEditor',
-    props: ['editTemplate', 'modelValue', 'readOnly'],
+    props: ['editTemplate', 'modelValue', 'readOnly', 'project'],
     emits: ['update:modelValue'],
     data () {
         return {
@@ -153,6 +158,15 @@ export default {
         editable: {
             get () { return this.modelValue },
             set (localValue) { this.$emit('update:modelValue', localValue) }
+        },
+        projectLauncherCompatible () {
+            const launcherVersion = this.project?.meta?.versions?.launcher
+            if (!launcherVersion) {
+                // We won't have this for a suspended project - so err on the side
+                // of permissive
+                return true
+            }
+            return !/^0\./.test(launcherVersion)
         },
         addEnabled () {
             return this.input.name && this.input.version && !this.input.error && !this.input.errorVersion

--- a/frontend/src/pages/project/Settings/Palette.vue
+++ b/frontend/src/pages/project/Settings/Palette.vue
@@ -1,7 +1,7 @@
 <template>
     <form class="space-y-6">
         <TemplateSettingsPalette v-model="editable" :editTemplate="false" />
-        <TemplatePaletteModulesEditor v-model="editable" :editTemplate="false" :readOnly="!paletteEditable"/>
+        <TemplatePaletteModulesEditor v-model="editable" :editTemplate="false" :readOnly="!paletteEditable" :project="project"/>
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges && !modulesChanged" @click="saveSettings()">Save settings</ff-button>
         </div>


### PR DESCRIPTION
Fixes #1127

Displays a warning in the Palette Modules section that the project stack needs to be updated if it is detected to be running <1.0.

<img width="437" alt="image" src="https://user-images.githubusercontent.com/51083/197760248-d3397dc5-962f-4e84-a23d-dda8d4f745bf.png">

If there is a newer stack available, also includes a button to take you to the Danger settings page.