### PR TITLE
Redirect user to full URL they were accessing before being asked to login

### DIFF
--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -20,7 +20,7 @@ import NoTeamsUser from './account/NoTeamsUser'
 export default {
     name: 'HomePage',
     computed: {
-        ...mapState('account', ['pending', 'user', 'team', 'teams'])
+        ...mapState('account', ['pending', 'user', 'team', 'teams', 'redirectUrlAfterLogin'])
     },
     data () {
         return {
@@ -36,7 +36,8 @@ export default {
     },
     methods: {
         redirectOnLoad () {
-            if (this.user.email_verified) {
+            // Only bounce to team view if there's no redirectUrlAfterLogin set
+            if (!this.redirectUrlAfterLogin && this.user.email_verified) {
                 if (this.team) {
                     this.$router.push({
                         name: 'Team',

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -2,6 +2,7 @@ import settingsApi from '@/api/settings'
 import userApi from '@/api/user'
 import teamApi from '@/api/team'
 import router from '@/routes'
+import { nextTick } from 'vue'
 
 // initial state
 const state = () => ({
@@ -89,7 +90,6 @@ const mutations = {
     },
     login (state, user) {
         state.loginInflight = false
-        state.redirectUrlAfterLogin = null
         state.user = user
     },
     logout (state) {
@@ -202,6 +202,8 @@ const actions = {
                 if (redirectUrlAfterLogin) {
                     // If this is a user-driven login, take them to the profile page
                     router.push(redirectUrlAfterLogin)
+                    // Clear the redirectUrl on nextTick
+                    nextTick(() => { state.commit('setRedirectUrl', null) })
                 }
             } catch (teamLoadErr) {
                 state.commit('clearPending')
@@ -218,7 +220,10 @@ const actions = {
             // Not logged in
             state.commit('clearPending')
             if (router.currentRoute.value.meta.requiresLogin !== false) {
-                state.commit('setRedirectUrl', router.currentRoute.value.fullPath)
+                if (router.currentRoute.value.path !== '/') {
+                    // Only remember the url if it isn't the default / path
+                    state.commit('setRedirectUrl', router.currentRoute.value.fullPath)
+                }
                 router.push({ name: 'Home' })
             }
         }


### PR DESCRIPTION
Fixes #974 

This fixes the `redirectUrlAfterLogin` handling to ensure we redirect the user back to where they were headed before being prompted to login.

I have tested this by trying to access the following paths, logging in, then verifying I reach the path:

 - `/` - an important case because this hits `Home.vue` which then redirects to the default team view... but should only do so *if* there's no redirect url to deal with
 - `/team/dev/overview` - not as interesting as that is the default view that `Home.vue` bounces you to... but it still works
 - `/project/1e7bb9d0-36e5-40dd-888f-6927a635bc5b/overview`
 - `/account/settings` - user settings

This does not work for `/admin` routes. Something is causing unauthorised access to those routes to get redirected to `/` *before* all of the logic I can find which might be doing it. Until I can track that down, we can't capture the url to ensure it gets redirected back to. Having spent an hour on it, I'm cutting my loses and moving forward with the PR that fixes it for all user-facing routes.
