### PR TITLE
Allow device to subscribe to all-project broadcast

### DIFF
--- a/forge/comms/aclManager.js
+++ b/forge/comms/aclManager.js
@@ -19,6 +19,17 @@ module.exports = function (app) {
             // ids = [ 'project', <teamid>, <projectid> ]
             return requestParts[1] === ids[1]
         },
+        checkDeviceIsAssigned: async function (requestParts, ids) {
+            // requestParts = [ _ , <teamid>, <projectid> ]
+            // ids = [ 'device', <teamid>, <deviceid> ]
+
+            // Do the simple team id check
+            if (requestParts[1] !== ids[1]) {
+                return false
+            }
+            const assignedProject = await app.db.models.Device.getDeviceProjectId(ids[2])
+            return !!assignedProject
+        },
         checkDeviceAssignedToProject: async function (requestParts, ids) {
             // requestParts = [ _ , <teamid>, <projectid> ]
             // ids = [ 'device', <teamid>, <deviceid> ]

--- a/forge/ee/lib/projectComms/index.js
+++ b/forge/ee/lib/projectComms/index.js
@@ -57,7 +57,7 @@ module.exports.init = function (app) {
         app.comms.aclManager.addACL(
             'device',
             'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceCanAccessProject' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/out\/[^/]+($|\/.*$)/, verify: 'checkDeviceIsAssigned' }
         )
         // Receive messages sent to this project
         // - ff/v1/<team>/p/<project>/in/+/#

--- a/test/unit/forge/comms/authRoutes_spec.js
+++ b/test/unit/forge/comms/authRoutes_spec.js
@@ -678,6 +678,12 @@ describe('Broker Auth API', async function () {
                             topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectB.id}/out/foo`
                         })
                     })
+                    it('cannot subscribe to all broadcast if unassigned', async function () {
+                        await denyRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/+/out/foo`
+                        })
+                    })
                     it('cannot publish to project inbox if unassigned', async function () {
                         await denyWrite({
                             username: deviceUsername,
@@ -724,6 +730,12 @@ describe('Broker Auth API', async function () {
                         await allowRead({
                             username: deviceUsername,
                             topic: `ff/v1/${TestObjects.ATeam.hashid}/p/${TestObjects.ProjectB.id}/out/foo`
+                        })
+                    })
+                    it('can subscribe to all broadcast if assigned', async function () {
+                        await allowRead({
+                            username: deviceUsername,
+                            topic: `ff/v1/${TestObjects.ATeam.hashid}/p/+/out/foo`
                         })
                     })
                     it('can publish to project inbox if assigned', async function () {


### PR DESCRIPTION
The existing checks handled devices subscribing to a specific project's broadcast, but not all-projects (`+` in the topic).

This adds a check to ensure the device is in the team and assigned to a project.