### PR TITLE
Ensure that changes to stack are immediately recorded

### DIFF
--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -172,6 +172,8 @@ export default {
             this.sortStacks(this.inactiveStacks)
         },
         async stackUpdated (stack) {
+            this.allStacks[stack.id] = stack
+
             // This stack might have moved between the active/inactive lists.
             const activeIndex = this.activeStacks.findIndex(s => s.id === stack.id)
             if (activeIndex > -1) {


### PR DESCRIPTION
This page maintains three lists of stacks `allStacks`, `activeStacks` and `inactiveStacks`. The bug in #1149 is that the allStacks list isn't necessarily updated when a stack changes. 

The quick fix is to also update `allStacks` as per this PR. However, given that it's not used on the page apart from lookup a longer term fix for a follow up is to refactor to reduce to only one in memory list, or remove allStacks.

Fixes https://github.com/flowforge/flowforge/issues/1149.