### PR TITLE
Fix template create and edit

### DIFF
--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -108,6 +108,11 @@ export default {
                     changed = changed || this.editable.changed.description
 
                     templateFields.forEach(field => {
+                        if (field === 'palette_modules') {
+                            // Don't check `palette_modules` for changes.
+                            // They are part of the template but are not edited here in admin/settings
+                            return
+                        }
                         this.editable.changed.settings[field] = this.editable.settings[field] !== this.original.settings[field]
                         this.editable.changed.policy[field] = this.editable.policy[field] !== this.original.policy[field]
                         changed = changed || this.editable.changed.settings[field] || this.editable.changed.policy[field]

--- a/frontend/src/pages/admin/Template/index.vue
+++ b/frontend/src/pages/admin/Template/index.vue
@@ -270,6 +270,8 @@ export default {
         async createTemplate () {
             const template = {
                 name: this.editable.name,
+                active: this.editable.active,
+                description: this.editable.description,
                 settings: {},
                 policy: {}
             }

--- a/frontend/src/pages/admin/Template/utils.js
+++ b/frontend/src/pages/admin/Template/utils.js
@@ -133,7 +133,7 @@ const templateValidators = {
         for (let i = 0; i < parts.length; i++) {
             const fn = parts[i]
             if (!/^((@[a-z0-9-~][a-z0-9-._~]*\/)?([a-z0-9-~][a-z0-9-._~]*|\*))(@([~^><]|<=|>=)?((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?))?$/i.test(fn)) {
-                return 'Must be a comma-seperated list of nodes[@version]'
+                return 'Must be a comma-separated list of nodes[@version]'
             }
         }
     }

--- a/frontend/src/pages/project/Settings/Palette.vue
+++ b/frontend/src/pages/project/Settings/Palette.vue
@@ -27,7 +27,7 @@ import { mapState } from 'vuex'
 import permissionsMixin from '@/mixins/Permissions'
 
 export default {
-    name: 'ProjectSettingsEditor',
+    name: 'ProjectSettingsPalette',
     data () {
         return {
             unsavedChanges: false,


### PR DESCRIPTION
fixes #1148 

* adds missing fields `description` and `active`
  * fixes newly created template has no description
  * fixes newly created template (without every setting the `active` checkbox) being considered active and selectable for use
* ignores `module_templates` in the `admin/settings/x` routes
  * fixes template edit "Discard Changes" when there are no changes
* spelling fix
* component name fix

