### PR TITLE
Fix flow import

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -218,40 +218,38 @@ module.exports = {
      * @param {*} components
      */
     importProject: async function (app, project, components) {
-        const t = await app.db.sequelize.transaction()
+        const transaction = await app.db.sequelize.transaction()
         try {
             if (components.flows) {
                 let currentProjectFlows = await app.db.models.StorageFlow.byProject(project.id)
                 if (currentProjectFlows) {
-                    currentProjectFlows.flows = components.flows
-                    await currentProjectFlows.save({ transaction: t })
+                    // Note StorageFlow.flow not .flows
+                    currentProjectFlows.flow = components.flows
+                    await currentProjectFlows.save({ transaction })
                 } else {
                     currentProjectFlows = await app.db.models.StorageFlow.create({
                         ProjectId: project.id,
                         flow: components.flows
-                    }, { transaction: t })
+                    }, { transaction })
                 }
             }
             if (components.credentials) {
                 const projectSecret = await project.getCredentialSecret()
-                const credSecretsHash = crypto.createHash('sha256').update(components.credsSecret).digest()
-                const projectSecretHash = crypto.createHash('sha256').update(projectSecret).digest()
-                const decryptedCreds = decryptCreds(credSecretsHash, JSON.parse(components.credentials))
-                const encryptedCreds = encryptCreds(projectSecretHash, decryptedCreds)
+                const encryptedCreds = app.db.controllers.Project.exportCredentials(JSON.parse(components.credentials), components.credsSecret, projectSecret)
                 let origCredentials = await app.db.models.StorageCredentials.byProject(project.id)
                 if (origCredentials) {
                     origCredentials.credentials = JSON.stringify(encryptedCreds)
-                    await origCredentials.save({ transaction: t })
+                    await origCredentials.save({ transaction })
                 } else {
                     origCredentials = await app.db.models.StorageCredentials.create({
                         ProjectId: project.id,
                         credentials: JSON.stringify(encryptedCreds)
-                    }, { transaction: t })
+                    }, { transaction })
                 }
             }
-            await t.commit()
+            await transaction.commit()
         } catch (error) {
-            t.rollback()
+            transaction.rollback()
             throw error
         }
         if (project.state === 'running') {

--- a/frontend/src/pages/project/Settings/Danger.vue
+++ b/frontend/src/pages/project/Settings/Danger.vue
@@ -4,6 +4,7 @@
     <ff-loading v-if="loading.changingStack" message="Changing Stack..." />
     <ff-loading v-if="loading.settingType" message="Setting Type..." />
     <ff-loading v-if="loading.suspend" message="Suspending Project..." />
+    <ff-loading v-if="loading.importing" message="Importing Project..." />
     <form v-if="!isLoading" class="space-y-6">
         <template v-if="!project.projectType">
             <FormHeading>Set Project Type</FormHeading>
@@ -157,7 +158,8 @@ export default {
                 deleting: false,
                 changingStack: false,
                 duplicating: false,
-                suspend: false
+                suspend: false,
+                importing: false
             }
         }
     },
@@ -240,7 +242,16 @@ export default {
             projectApi.updateProject(parts.target, options)
         },
         importProject (parts) {
-            projectApi.importProject(this.project.id, parts)
+            this.loading.importing = true
+            projectApi.importProject(this.project.id, parts).then(result => {
+                this.$router.push({ name: 'Project', params: { id: this.project.id } })
+                alerts.emit('Project flows imported.', 'confirmation')
+            }).catch(err => {
+                console.log(err)
+                alerts.emit('Failed to import flows.', 'warning')
+            }).finally(() => {
+                this.loading.importing = false
+            })
         },
         deleteProject () {
             this.loading.deleting = true


### PR DESCRIPTION
Fixes importing flows into an existing project.

There is still an issue when doing this with *old* projects that were created pre 0.6 (possibly... not nailed it down). The fix for that involves changes to our credentialSecret handling which is risky and not suitable for trying to do at this stage.

This also provides better feedback in the UI that something is happening.