### PR TITLE
Refactor stacks logic to only hold one list client side

### DIFF
--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -70,13 +70,26 @@ const StackName = {
     props: ['id', 'name', 'label', 'description', 'projectTypeName'],
     components: { DesktopComputerIcon }
 }
+
+function comparator (A, B) {
+    if (A.projectType === B.projectType) {
+        return A.createdAt.localeCompare(B.createdAt)
+    } else {
+        if (!A.projectType) {
+            return -1
+        }
+        if (!B.projectType) {
+            return 1
+        }
+        return this.projectTypes[A.projectType].order - this.projectTypes[B.projectType].order
+    }
+}
+
 export default {
     name: 'AdminStacks',
     data () {
         return {
-            allStacks: {},
-            activeStacks: [],
-            inactiveStacks: [],
+            allStacks: new Map(),
             projectTypes: [],
             loadingActive: false,
             loadingInactive: false,
@@ -104,11 +117,20 @@ export default {
         await this.loadActiveItems()
     },
     computed: {
-        ...mapState('account', ['settings'])
+        ...mapState('account', ['settings']),
+        stacksArray () {
+            return Array.from(this.allStacks.values())
+        },
+        activeStacks () {
+            return this.stacksArray.filter((stack) => stack.active).sort(comparator)
+        },
+        inactiveStacks () {
+            return this.stacksArray.filter((stack) => !stack.active).sort(comparator)
+        }
     },
     methods: {
         stackAction (action, stackId) {
-            const stack = this.allStacks[stackId]
+            const stack = this.allStacks.get(stackId)
             if (stack) {
                 switch (action) {
                 case 'editProperties':
@@ -126,14 +148,7 @@ export default {
                         // on confirm - delete the stack
                         stacksApi.deleteStack(stack.id)
                             .then(() => {
-                                if (stack.active) {
-                                    const index = this.activeStacks.indexOf(stack)
-                                    this.activeStacks.splice(index, 1)
-                                } else {
-                                    const index = this.inactiveStacks.indexOf(stack)
-                                    this.inactiveStacks.splice(index, 1)
-                                }
-                                delete this.allStacks[stack.id]
+                                this.allStacks.delete(stack.id)
                             })
                             .catch((err) => {
                                 if (err.response && err.response.data && err.response.data.error) {
@@ -156,97 +171,45 @@ export default {
         async stackCreated (stack, replaced) {
             // stack.onedit = (data) => { this.showEditStackDialog(stack) }
             // stack.ondelete = (data) => { this.showConfirmStackDeleteDialog(stack) }
-            if (stack.active) {
-                this.activeStacks.push(stack)
-            } else {
-                this.inactiveStacks.push(stack)
-            }
+            this.allStacks.set(stack.id, stack)
+
             if (stack.projectType) {
                 stack.projectTypeName = this.projectTypes[stack.projectType]?.name
             }
-            this.allStacks[stack.id] = stack
             if (replaced) {
                 this.stackUpdated(replaced)
             }
-            this.sortStacks(this.activeStacks)
-            this.sortStacks(this.inactiveStacks)
         },
         async stackUpdated (stack) {
-            this.allStacks[stack.id] = stack
+            this.allStacks.set(stack.id, stack)
 
-            // This stack might have moved between the active/inactive lists.
-            const activeIndex = this.activeStacks.findIndex(s => s.id === stack.id)
-            if (activeIndex > -1) {
-                // Found in the active list
-                if (stack.active) {
-                    // update in place
-                    this.activeStacks[activeIndex] = stack
-                } else {
-                    this.activeStacks.splice(activeIndex, 1)
-                    this.inactiveStacks.push(stack)
-                }
-            } else {
-                const inactiveIndex = this.inactiveStacks.findIndex(s => s.id === stack.id)
-                if (inactiveIndex > -1) {
-                    // Found in the active list
-                    if (stack.inactive) {
-                        // update in place
-                        this.inactiveStacks[inactiveIndex] = stack
-                    } else {
-                        this.inactiveStacks.splice(inactiveIndex, 1)
-                        this.activeStacks.push(stack)
-                    }
-                } // else - not found anywhere..!
-            }
             if (stack.projectType) {
                 stack.projectTypeName = this.projectTypes[stack.projectType]?.name
             }
-
-            this.sortStacks(this.activeStacks)
-            this.sortStacks(this.inactiveStacks)
         },
         loadActiveItems: async function () {
             this.loadingActive = true
             const result = await stacksApi.getStacks(this.nextActiveCursor, 30, 'active')
             this.nextActiveCursor = result.meta.next_cursor
-            result.stacks.forEach(v => {
-                if (v.projectType) {
-                    v.projectTypeName = this.projectTypes[v.projectType]?.name
+            result.stacks.forEach(stack => {
+                if (stack.projectType) {
+                    stack.projectTypeName = this.projectTypes[stack.projectType]?.name
                 }
-                this.activeStacks.push(v)
-                this.allStacks[v.id] = v
+                this.allStacks.set(stack.id, stack)
             })
-            this.sortStacks(this.activeStacks)
             this.loadingActive = false
         },
         loadInactiveItems: async function () {
             this.loadingInactive = true
             const result = await stacksApi.getStacks(this.nextInactiveCursor, 30, 'inactive')
             this.nextInactiveCursor = result.meta.next_cursor
-            result.stacks.forEach(v => {
-                if (v.projectType) {
-                    v.projectTypeName = this.projectTypes[v.projectType]?.name
+            result.stacks.forEach(stack => {
+                if (stack.projectType) {
+                    stack.projectTypeName = this.projectTypes[stack.projectType]?.name
                 }
-                this.inactiveStacks.push(v)
-                this.allStacks[v.id] = v
+                this.allStacks.set(stack.id, stack)
             })
-            this.sortStacks(this.inactiveStacks)
             this.loadingInactive = false
-        },
-        sortStacks: function (stacks) {
-            stacks.sort((A, B) => {
-                if (A.projectType === B.projectType) {
-                    return A.createdAt.localeCompare(B.createdAt)
-                } else {
-                    if (!A.projectType) {
-                        return -1
-                    }
-                    if (!B.projectType) {
-                        return 1
-                    }
-                    return this.projectTypes[A.projectType].order - this.projectTypes[B.projectType].order
-                }
-            })
         }
     },
     components: {


### PR DESCRIPTION
**Warning:** Merge target is https://github.com/flowforge/flowforge/pull/1167 do not merge until after that PR.

This has negligible impact on the time complexity for calculating inactiveStacks/activeStacks (from `O(n)` to `O(n2)` but still linear), with the following advantages:

- Easier to maintain by removing all the checks for `active`
- Maintaining one rather than three lists that can end up out of sync (see #1164).
- `O(1)` lookup of any stack using [`Map.get()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) - previously required searching over array with `indexOf`

I've tested with 1000 stacks locally and the page is equally performant