### PR TITLE
Run CI checks against all PR's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ on:
       - 'test/system/**'
       - 'package.json'
   pull_request:
-    branches: [ main ]
     paths:
       - 'forge/**'
       - 'test/unit/**'

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -9,7 +9,6 @@ on:
       - 'test/system/**'
       - 'package.json'
   pull_request:
-    branches: [ main ]
     paths:
       - 'forge/**'
       - 'test/unit/**'

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -7,7 +7,6 @@ on:
       - 'frontend/**'
       - 'test/e2e/frontend/**'
   pull_request:
-    branches: [ main ]
     paths:
       - 'frontend/**'
       - 'test/e2e/frontend/**'


### PR DESCRIPTION
I often have PR's that depend on each other so set the bases accordingly. However, that means the tests might not run (see #1173).

GH Workflows will now run for all PR's in this repo, regardless of target. 

I imagine this will have a relatively negligible impact on our GH actions runtime, but I don't have access to the stats, so will ask @knolleary or @ZJvandeWeg to check in a week.