### PR TITLE
Load stacks asynchronously 

### DIFF
--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -113,8 +113,8 @@ export default {
         result.types.forEach(pt => {
             this.projectTypes[pt.id] = pt
         })
-        await this.loadInactiveItems()
-        await this.loadActiveItems()
+        this.loadInactiveItems()
+        this.loadActiveItems()
     },
     computed: {
         ...mapState('account', ['settings']),


### PR DESCRIPTION
As far as I can tell, there's no need to wait for the inactive items to load before loading the active items