### PR TITLE
Change editor auth to use AccessToken rather than Session

### DIFF
--- a/forge/db/controllers/Session.js
+++ b/forge/db/controllers/Session.js
@@ -9,8 +9,6 @@ const DEFAULT_WEB_SESSION_IDLE_TIMEOUT = HOUR * 32 // 32 hours
 // to idle timeout. That avoids the need to update idle timeout on every single request
 const DEFAULT_WEB_SESSION_IDLE_GRACE = HOUR * 31 // 31 hours
 
-const DEFAULT_TOKEN_SESSION_EXPIRY = 1000 * 60 * 30 // 30 mins session - with refresh token support
-
 module.exports = {
     /**
      * Create a new session for the given username
@@ -24,39 +22,6 @@ module.exports = {
                 idleAt: Date.now() + DEFAULT_WEB_SESSION_IDLE_TIMEOUT,
                 UserId: user.id
             })
-        }
-        return null
-    },
-
-    /**
-     * Create a new oauth session for the given username
-     */
-    createTokenSession: async function (app, username) {
-        const user = await app.db.models.User.byUsernameOrEmail(username)
-        if (user) {
-            const session = {
-                sid: generateToken(32, 'ffp'),
-                refreshToken: generateToken(32, 'ffp'),
-                expiresAt: Date.now() + DEFAULT_TOKEN_SESSION_EXPIRY,
-                UserId: user.id
-            }
-            // Do this in two stages as `refreshToken` is hashed in the db
-            await app.db.models.Session.create(session)
-            return session
-        }
-        return null
-    },
-
-    refreshTokenSession: async function (app, refreshToken) {
-        const existingSession = await app.db.models.Session.byRefreshToken(refreshToken)
-        if (existingSession) {
-            const newSession = {
-                sid: generateToken(32, 'ffp'),
-                refreshToken: generateToken(32, 'ffp'),
-                expiresAt: Date.now() + DEFAULT_TOKEN_SESSION_EXPIRY
-            }
-            await app.db.models.Session.update(newSession, { where: { refreshToken: existingSession.refreshToken } })
-            return newSession
         }
         return null
     },

--- a/forge/db/migrations/20221102-01-add-accesstoken-refresh.js
+++ b/forge/db/migrations/20221102-01-add-accesstoken-refresh.js
@@ -1,0 +1,15 @@
+/**
+ * Add refreshToken to AccessToken
+ */
+
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    up: async (context) => {
+        await context.addColumn('AccessTokens', 'refreshToken', {
+            type: DataTypes.STRING
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Session.js
+++ b/forge/db/models/Session.js
@@ -21,15 +21,5 @@ module.exports = {
     },
     associations: function (M) {
         this.belongsTo(M.User)
-    },
-    finders: function (M) {
-        return {
-            static: {
-                byRefreshToken: async (refreshToken) => {
-                    const hashedToken = sha256(refreshToken)
-                    return await this.findOne({ where: { refreshToken: hashedToken } })
-                }
-            }
-        }
     }
 }

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -160,7 +160,7 @@ module.exports = async function (app) {
                     reply.code(400).send('Please ask the team owner to update this project to the latest stack to support viewer access')
                     return
                 }
-                requestObject.username = request.session.User.username
+                requestObject.userId = request.session.User.id
                 requestObject.code = base64URLEncode(crypto.randomBytes(32))
                 requestCache.set(requestObject.code, requestObject)
                 const responseUrl = new URL(requestObject.redirect_uri)
@@ -169,11 +169,21 @@ module.exports = async function (app) {
                     code: requestObject.code,
                     state: requestObject.state
                 })
+                console.log('/account/complete redirect', responseUrl.toString())
                 reply.redirect(responseUrl.toString())
                 return
             }
         }
         return badRequest(reply, 'access_denied', 'Access Denied')
+    })
+    app.get('/account/reject/:code', async function (request, reply) {
+        const requestId = request.params.code
+        const requestObject = requestCache.get(requestId)
+        requestCache.delete(requestId)
+        if (!requestObject) {
+            return badRequest(reply, 'invalid_request', 'Invalid request')
+        }
+        return redirectInvalidRequest(reply, requestObject.redirect_uri, 'access_denied', 'Access Denied', requestObject.state)
     })
 
     app.post('/account/token', {
@@ -228,7 +238,7 @@ module.exports = async function (app) {
                 badRequest(reply, 'invalid_request', 'Invalid code')
                 return
             }
-            if (!requestObject.username) {
+            if (!requestObject.userId) {
                 badRequest(reply, 'access_denied', 'Access Denied - missing user', requestObject.state)
                 return
             }
@@ -245,15 +255,15 @@ module.exports = async function (app) {
                 return
             }
 
-            const sessionTokens = await app.db.controllers.Session.createTokenSession(requestObject.username)
+            const accessToken = await app.db.controllers.AccessToken.createTokenForUser(requestObject.userId, null, ['project:flows:view', 'project:flows:edit'], true)
 
             const project = await app.db.models.Project.byId(authClient.ownerId)
-            const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: sessionTokens.UserId } })
+            const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: requestObject.userId } })
             const canReadFlows = app.hasPermission(teamMembership, 'project:flows:view')
             const canWriteFlows = app.hasPermission(teamMembership, 'project:flows:edit')
 
             if (!canReadFlows && !canWriteFlows) {
-                await sessionTokens.destroy()
+                app.db.controllers.AccessToken.destroyToken(accessToken.token)
                 return badRequest(reply, 'access_denied', 'Access Denied')
             }
 
@@ -263,9 +273,9 @@ module.exports = async function (app) {
             }
 
             const response = {
-                access_token: sessionTokens.sid,
-                expires_in: Math.floor((sessionTokens.expiresAt - Date.now()) / 1000),
-                refresh_token: sessionTokens.refreshToken,
+                access_token: accessToken.token,
+                expires_in: Math.floor((accessToken.expiresAt - Date.now()) / 1000),
+                refresh_token: accessToken.refreshToken,
                 state: requestObject.state,
                 scope
             }
@@ -273,28 +283,31 @@ module.exports = async function (app) {
         } else if (grant_type === 'refresh_token') {
             // We have validated client_id and client_secret by this point.
 
-            const existingSession = await app.db.models.Session.byRefreshToken(refresh_token)
-
+            const existingToken = await app.db.models.AccessToken.byRefreshToken(refresh_token)
+            if (!existingToken) {
+                badRequest(reply, 'invalid_request', 'Invalid refresh_token')
+                return
+            }
             // Check the owner of the existing session still has access to the project
             // this client is owned by
             const project = await app.db.models.Project.byId(authClient.ownerId)
-            const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: existingSession.UserId } })
+            const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: parseInt(existingToken.ownerId) } })
             const canReadFlows = app.hasPermission(teamMembership, 'project:flows:view')
             const canWriteFlows = app.hasPermission(teamMembership, 'project:flows:edit')
 
             if (!canReadFlows && !canWriteFlows) {
                 return badRequest(reply, 'access_denied', 'Access Denied')
             }
-            const sessionTokens = await app.db.controllers.Session.refreshTokenSession(refresh_token)
-            if (!sessionTokens) {
+            const accessToken = await app.db.controllers.AccessToken.refreshToken(refresh_token)
+            if (!accessToken) {
                 badRequest(reply, 'invalid_request', 'Invalid refresh_token')
                 return
             }
 
             const response = {
-                access_token: sessionTokens.sid,
-                expires_in: Math.floor((sessionTokens.expiresAt - Date.now()) / 1000),
-                refresh_token: sessionTokens.refreshToken
+                access_token: accessToken.token,
+                expires_in: Math.floor((accessToken.expiresAt - Date.now()) / 1000),
+                refresh_token: accessToken.refreshToken
             }
             reply.send(response)
         } else {

--- a/test/unit/forge/db/controllers/AccessToken_spec.js
+++ b/test/unit/forge/db/controllers/AccessToken_spec.js
@@ -1,0 +1,148 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('AccessToken controller', function () {
+    // Use standard test data.
+    let app
+    const TestObjects = {}
+
+    beforeEach(async function () {
+        app = await setup()
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+    })
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('Project Tokens', function () {
+        it('creates a token for a project', async function () {
+            const team = await app.db.models.Team.byName('ATeam')
+            const project = await app.db.models.Project.create({ name: 'project', type: '', url: '' })
+            await team.addProject(project)
+
+            ;(await app.db.models.AccessToken.count()).should.equal(0)
+            const result = await app.db.controllers.AccessToken.createTokenForProject(project, Date.now() + 5000, 'test:scope')
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+            result.should.have.property('token')
+
+            const token = await app.db.controllers.AccessToken.getOrExpire(result.token)
+            should.exist(token)
+            token.should.have.property('scope', ['test:scope'])
+            token.should.have.property('ownerId', project.id)
+            token.should.have.property('ownerType', 'project')
+        })
+
+        it('replaces a token for a project', async function () {
+            const team = await app.db.models.Team.byName('ATeam')
+            const project = await app.db.models.Project.create({ name: 'project', type: '', url: '' })
+            await team.addProject(project)
+
+            // Setup the inital token
+            ;(await app.db.models.AccessToken.count()).should.equal(0)
+            const result = await app.db.controllers.AccessToken.createTokenForProject(project, Date.now() + 5000, 'test:scope')
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+            result.should.have.property('token')
+
+            // Renew the token
+            const renewResult = await app.db.controllers.AccessToken.createTokenForProject(project, Date.now() + 5000, 'test:scope')
+            // Check we don't have two tokens in the database
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+            renewResult.should.have.property('token')
+
+            result.token.should.not.equal(renewResult.token)
+            should.not.exist(await app.db.controllers.AccessToken.getOrExpire(result.token))
+
+            const token = await app.db.controllers.AccessToken.getOrExpire(renewResult.token)
+            should.exist(token)
+            token.should.have.property('scope', ['test:scope'])
+            token.should.have.property('ownerId', project.id)
+            token.should.have.property('ownerType', 'project')
+        })
+    })
+
+    describe('User Tokens', function () {
+        it('creates a token for a user - id only', async function () {
+            const result = await app.db.controllers.AccessToken.createTokenForUser(
+                TestObjects.alice.id,
+                null,
+                ['test:scope']
+            )
+            result.should.have.property('token')
+            should.not.exist(result.expiresAt)
+            should.not.exist(result.refreshToken)
+        })
+        it('creates a token for a user - full object', async function () {
+            const result = await app.db.controllers.AccessToken.createTokenForUser(
+                TestObjects.alice,
+                null,
+                ['test:scope']
+            )
+            result.should.have.property('token')
+            should.not.exist(result.expiresAt)
+            should.not.exist(result.refreshToken)
+        })
+        it('creates a token for a user with refresh token', async function () {
+            const result = await app.db.controllers.AccessToken.createTokenForUser(
+                TestObjects.alice,
+                null,
+                ['test:scope'],
+                true
+            )
+            result.should.have.property('token')
+            should.exist(result.expiresAt)
+            should.exist(result.refreshToken)
+        })
+
+        it('refreshes a valid token', async function () {
+            // Create token
+            ;(await app.db.models.AccessToken.count()).should.equal(0)
+            const original = await app.db.controllers.AccessToken.createTokenForUser(
+                TestObjects.alice,
+                null,
+                ['test:scope'],
+                true
+            )
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+
+            const refreshResult = await app.db.controllers.AccessToken.refreshToken(original.refreshToken)
+            should.exist(refreshResult.token)
+            refreshResult.token.should.not.equal(original.token)
+            should.exist(refreshResult.refreshToken)
+            refreshResult.refreshToken.should.not.equal(original.refreshToken)
+            should.exist(refreshResult.expiresAt)
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+            should.not.exist(await app.db.controllers.AccessToken.getOrExpire(original.token))
+        })
+    })
+
+    describe('getOrExpire', function () {
+        it('does not return expired tokens', async function () {
+            const team = await app.db.models.Team.byName('ATeam')
+            const project = await app.db.models.Project.create({ name: 'project', type: '', url: '' })
+            await team.addProject(project)
+
+            ;(await app.db.models.AccessToken.count()).should.equal(0)
+            // Create the token with an already-expired time
+            const result = await app.db.controllers.AccessToken.createTokenForProject(project, Date.now() - 5000, 'test:scope')
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+            should.not.exist(await app.db.controllers.AccessToken.getOrExpire(result.token))
+        })
+    })
+
+    describe('destroyToken', function () {
+        it('removes token', async function () {
+            const team = await app.db.models.Team.byName('ATeam')
+            const project = await app.db.models.Project.create({ name: 'project', type: '', url: '' })
+            await team.addProject(project)
+
+            ;(await app.db.models.AccessToken.count()).should.equal(0)
+            const result = await app.db.controllers.AccessToken.createTokenForProject(project, Date.now() + 5000, 'test:scope')
+            ;(await app.db.models.AccessToken.count()).should.equal(1)
+
+            // Now destroy the token
+            await app.db.controllers.AccessToken.destroyToken(result.token)
+            ;(await app.db.models.AccessToken.count()).should.equal(0)
+        })
+    })
+})


### PR DESCRIPTION
This PR changes how the editor authentication is managed in the platform.

We have two tables in the database related to access control - `AccessToken` and `Session`.

 - `Session` - represents a login session in the UI by a real user. For each request, it uses the `sid` cookie to look up the appropriate Session object to get the User. If valid, it gives the request the full range of access that User has.
 - `AccessToken` - this represents a token that can be passed in via the `authorisation` header to authenticate a request.

When logging into the Node-RED editor, the oauth flow between the `nr-auth` plugin and the platform would store its state as a `Session`. However the storage/logging apis expect the token to be provided in the auth header. This mean we had a special case in the code where, if the token 'looked' like an nr-auth token, it would divert to the Session table.

This PR changes the oauth flow to store things in the AccessToken table instead of Session. This removes the need to have a special case for the editor token and is more logically consistent.

It also steps closer to allowing the `AccessToken` to have an associated `scope` (already in the table... just not used widely) - meaning a token could be generated for a user that has only a specific set of permissions, rather than full access.