### PR TITLE
Coalesce token/session auth

### DIFF
--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -9,7 +9,7 @@ module.exports = {
      * The token is hashed in the database. The only time the
      * true value is available is when it is returned from this function.
      */
-    createTokenForProject: async function (app, project, expiresAt, scope) {
+    createTokenForProject: async function (app, project, expiresAt, scope = []) {
         const existingProjectToken = await project.getAccessToken()
         if (existingProjectToken) {
             await existingProjectToken.destroy()
@@ -63,7 +63,7 @@ module.exports = {
     /**
      * Create an AccessToken for the editor.
      */
-    createTokenForUser: async function (app, user, expiresAt, scope, includeRefresh) {
+    createTokenForUser: async function (app, user, expiresAt, scope = [], includeRefresh) {
         const userId = typeof user === 'number' ? user : user.id
         const token = generateToken(32, 'ffu')
         const refreshToken = includeRefresh ? generateToken(32, 'ffu') : null

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -159,7 +159,7 @@ module.exports = {
             instance: {
                 async refreshAuthTokens () {
                     const authClient = await Controllers.AuthClient.createClientForProject(this)
-                    const projectToken = await Controllers.AccessToken.createTokenForProject(this, null, ['project:flows:view', 'project:flows:edit'])
+                    const projectToken = await Controllers.AccessToken.createTokenForProject(this, null)
                     const projectBrokerCredentials = await Controllers.BrokerClient.createClientForProject(this)
                     return {
                         token: projectToken.token,

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -2,19 +2,26 @@ const { Roles } = require('./roles.js')
 
 module.exports = {
     Permissions: {
+        // User Actions
+        'user:read': { description: 'View user Information', self: true },
+        'user:edit': { description: 'Edit User Information', self: true },
         // Team Scoped Actions
-        'team:create': { description: 'Create Team', admin: false },
+        'team:create': { description: 'Create Team' },
+        'team:read': { description: 'View a Team', role: Roles.Viewer },
         'team:edit': { description: 'Edit Team', role: Roles.Owner },
         'team:delete': { description: 'Delete Team', role: Roles.Owner },
         'team:audit-log': { description: 'Access Team Audit Log', role: Roles.Owner },
         // Team Members
         'team:user:add': { description: 'Add Members', role: Roles.Admin },
+        'team:user:list': { description: 'List Team Members', role: Roles.Viewer },
         'team:user:invite': { description: 'Invite Members', role: Roles.Owner },
         'team:user:remove': { description: 'Remove Member', role: Roles.Owner, self: true },
         'team:user:change-role': { description: 'Modify Member role', role: Roles.Owner },
         // Projects
+        'team:projects:list': { description: 'List Team Projects', role: Roles.Viewer },
         'project:create': { description: 'Create Project', role: Roles.Owner },
         'project:delete': { description: 'Delete Project', role: Roles.Owner },
+        'project:read': { description: 'View a Project', role: Roles.Viewer },
         'project:transfer': { description: 'Transfer Project', role: Roles.Owner },
         'project:change-status': { description: 'Start/Stop Project', role: Roles.Owner },
         'project:edit': { description: 'Edit Project Settings', role: Roles.Owner },
@@ -24,26 +31,37 @@ module.exports = {
         // Project Editor
         'project:flows:view': { description: 'View Project Flows', role: Roles.Viewer },
         'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member },
+        // Snapshots
         'project:snapshot:create': { description: 'Create Project Snapshot', role: Roles.Member },
+        'project:snapshot:list': { description: 'List Project Snapshots', role: Roles.Viewer },
+        'project:snapshot:read': { description: 'View a Project Snapshot', role: Roles.Viewer },
         'project:snapshot:delete': { description: 'Delete Project Snapshot', role: Roles.Owner },
         'project:snapshot:rollback': { description: 'Rollback Project Snapshot', role: Roles.Member },
         'project:snapshot:set-target': { description: 'Set Device Target Snapshot', role: Roles.Member },
         // Templates
         'template:create': { description: 'Create a Template', role: Roles.Admin },
+        'template:list': { description: 'List all Templates' },
+        'template:read': { description: 'View a Template' },
         'template:delete': { description: 'Delete a Template', role: Roles.Admin },
         'template:edit': { description: 'Edit a Template', role: Roles.Admin },
         // Stacks
         'stack:create': { description: 'Create a Stack', role: Roles.Admin },
+        'stack:list': { description: 'List all Stacks' },
+        'stack:read': { description: 'View a Stack' },
         'stack:delete': { description: 'Delete a Stack', role: Roles.Admin },
         'stack:edit': { description: 'Edit a Stack', role: Roles.Admin },
         // Devices
+        'team:device:list': { description: 'List Team Devices', role: Roles.Viewer },
         'device:list': { description: 'List Devices', role: Roles.Admin },
         'device:create': { description: 'Create a Device', role: Roles.Owner },
+        'device:read': { description: 'View a Device', role: Roles.Viewer },
         'device:delete': { description: 'Delete a Device', role: Roles.Owner },
         'device:edit': { description: 'Edit a Device', role: Roles.Owner },
         'device:edit-env': { description: 'Edit Device Environment Variables', role: Roles.Member },
         // Project Types
         'project-type:create': { description: 'Create a ProjectType', role: Roles.Admin },
+        'project-type:list': { description: 'List all ProjectTypes' },
+        'project-type:read': { description: 'View a ProjectType' },
         'project-type:delete': { description: 'Delete a ProjectType', role: Roles.Admin },
         'project-type:edit': { description: 'Edit a ProjectType', role: Roles.Admin }
     }

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -55,7 +55,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.devices
      */
-    app.get('/:deviceId', async (request, reply) => {
+    app.get('/:deviceId', {
+        preHandler: app.needsPermission('device:read')
+    }, async (request, reply) => {
         reply.send(app.db.views.Device.device(request.device))
     })
 
@@ -313,7 +315,9 @@ module.exports = async function (app) {
         reply.send({ status: 'okay' })
     })
 
-    app.get('/:deviceId/settings', async (request, reply) => {
+    app.get('/:deviceId/settings', {
+        preHandler: app.needsPermission('device:read')
+    }, async (request, reply) => {
         const settings = await request.device.getAllSettings()
         if (request.teamMembership?.role === Roles.Owner) {
             reply.send(settings)

--- a/forge/routes/api/deviceLive.js
+++ b/forge/routes/api/deviceLive.js
@@ -12,6 +12,7 @@
  */
 module.exports = async function (app) {
     app.addHook('preHandler', (request, reply, done) => {
+        // This check ensures the request is being made by a device token
         if (request.session.ownerType !== 'device' || request.session.ownerId !== ('' + request.device.id)) {
             reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
         } else {
@@ -29,7 +30,7 @@ module.exports = async function (app) {
      * The response will be a 200 if all is well.
      * If the snapshot doesn't match the target, it will get a 409 (conflict)
      */
-    app.post('/state', { config: { allowToken: true } }, async (request, reply) => {
+    app.post('/state', async (request, reply) => {
         await app.db.controllers.Device.updateState(request.device, request.body)
         if (Object.hasOwn(request.body, 'project') && request.body.project !== (request.device.Project?.id || null)) {
             reply.code(409).send({
@@ -61,7 +62,7 @@ module.exports = async function (app) {
         reply.code(200).send({})
     })
 
-    app.get('/state', { config: { allowToken: true } }, async (request, reply) => {
+    app.get('/state', async (request, reply) => {
         reply.send({
             project: request.device.Project?.id || null,
             snapshot: request.device.targetSnapshot?.hashid || null,
@@ -69,7 +70,7 @@ module.exports = async function (app) {
         })
     })
 
-    app.get('/snapshot', { config: { allowToken: true } }, async (request, reply) => {
+    app.get('/snapshot', async (request, reply) => {
         if (!request.device.targetSnapshot) {
             reply.send({})
         } else {
@@ -94,7 +95,7 @@ module.exports = async function (app) {
         }
     })
 
-    app.get('/settings', { config: { allowToken: true } }, async (request, reply) => {
+    app.get('/settings', async (request, reply) => {
         const response = {
             hash: request.device.settingsHash,
             env: {}

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -51,6 +51,7 @@ module.exports = async function (app) {
                             return
                         }
                     } else if (request.session.ownerId !== request.params.projectId) {
+                        // AccesToken being used - but not owned by this project
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
@@ -73,7 +74,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.project
      */
-    app.get('/:projectId', async (request, reply) => {
+    app.get('/:projectId', {
+        preHandler: app.needsPermission('project:read')
+    }, async (request, reply) => {
         const result = await app.db.views.Project.project(request.project)
         const inflightState = app.db.controllers.Project.getInflightState(request.project)
         if (inflightState) {
@@ -367,27 +370,24 @@ module.exports = async function (app) {
      * @name /api/v1/project/:id
      * @memberof forge.routes.api.project
      */
-    app.put('/:projectId', async (request, reply) => {
-        let changed = false
-        let allSettingsEdit = false
-
-        // First, check what is being set & check permissions accordingly.
-        // * If the only value sent is `request.body.settings.env`, then we only need 'project:edit-env' permission
-        // * Otherwise, everything else requires 'project:edit' permission
-        const bodyKeys = Object.keys(request.body || {})
-        const settingsKeys = Object.keys(request.body?.settings || {})
-        try {
+    app.put('/:projectId', {
+        preHandler: async (request, reply) => {
+            // First, check what is being set & check permissions accordingly.
+            // * If the only value sent is `request.body.settings.env`, then we only need 'project:edit-env' permission
+            // * Otherwise, everything else requires 'project:edit' permission
+            const bodyKeys = Object.keys(request.body || {})
+            const settingsKeys = Object.keys(request.body?.settings || {})
             if (bodyKeys.length === 1 && bodyKeys[0] === 'settings' && settingsKeys.length === 1 && settingsKeys[0] === 'env') {
-                await app.needsPermission('project:edit-env')(request, reply)
+                return app.needsPermission('project:edit-env')(request, reply)
             } else {
-                await app.needsPermission('project:edit')(request, reply)
-                allSettingsEdit = true
+                return app.needsPermission('project:edit')(request, reply).then(res => {
+                    request.allSettingsEdit = true
+                    return res
+                })
             }
-        } catch (err) {
-            // Auth failure. needsPermission will have responded already
-            return
         }
-
+    }, async (request, reply) => {
+        let changed = false
         if (request.body.stack) {
             if (request.body.stack !== request.project.ProjectStack?.id) {
                 const stack = await app.db.models.ProjectStack.byId(request.body.stack)
@@ -623,7 +623,7 @@ module.exports = async function (app) {
             }
             if (request.body.settings) {
                 let bodySettings
-                if (allSettingsEdit) {
+                if (request.allSettingsEdit) {
                     // store all body settings if user is owner
                     bodySettings = request.body.settings
                 } else {
@@ -681,9 +681,9 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId/settings', {
-        config: { allowToken: true },
         preHandler: (request, reply, done) => {
             // check accessToken is project scope
+            // (ownerId already checked at top-level preHandler)
             if (request.session.ownerType !== 'project') {
                 reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
             } else {
@@ -720,7 +720,9 @@ module.exports = async function (app) {
      * @name /api/v1/project/:id/log
      * @memberof forge.routes.api.project
      */
-    app.get('/:projectId/logs', async (request, reply) => {
+    app.get('/:projectId/logs', {
+        preHandler: app.needsPermission('project:log')
+    }, async (request, reply) => {
         if (request.project.state === 'suspended') {
             reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
             return
@@ -798,6 +800,7 @@ module.exports = async function (app) {
      * @memberof forge.routs.api.project
      */
     app.post('/:projectId/import', {
+        preHandler: app.needsPermission('project:edit'),
         schema: {
             body: {
                 type: 'object',

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -201,15 +201,6 @@ module.exports = async function (app) {
             return
         }
 
-        // const authClient = await app.db.controllers.AuthClient.createClientForProject(project);
-        // const projectToken = await app.db.controllers.AccessToken.createTokenForProject(project, null, ["project:flows:view","project:flows:edit"])
-        // const containerOptions = {
-        //     name: request.body.name,
-        //     projectToken: projectToken.token,
-        //     ...request.body.options,
-        //     ...authClient
-        // }
-
         await team.addProject(project)
         await project.setProjectStack(stack)
         await project.setProjectTemplate(template)

--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -16,7 +16,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.project
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', { preHandler: app.needsPermission('project:read') }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const where = {
             ProjectId: request.project.id
@@ -26,7 +26,7 @@ module.exports = async function (app) {
         reply.send(devices)
     })
 
-    app.get('/settings', async (request, reply) => {
+    app.get('/settings', { preHandler: app.needsPermission('project:read') }, async (request, reply) => {
         const deviceSettings = await request.project.getSetting('deviceSettings') || {
             targetSnapshot: null
         }

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -31,7 +31,9 @@ module.exports = async function (app) {
     /**
      * Get list of all project snapshots
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', {
+        preHandler: app.needsPermission('project:snapshot:list')
+    }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const snapshots = await app.db.models.ProjectSnapshot.forProject(request.project.id, paginationOptions)
         snapshots.snapshots = snapshots.snapshots.map(s => app.db.views.ProjectSnapshot.snapshot(s))
@@ -41,7 +43,9 @@ module.exports = async function (app) {
     /**
      * Get details of a snapshot - metadata only
      */
-    app.get('/:snapshotId', async (request, reply) => {
+    app.get('/:snapshotId', {
+        preHandler: app.needsPermission('project:snapshot:read')
+    }, async (request, reply) => {
         reply.send(app.db.views.ProjectSnapshot.snapshot(request.snapshot))
     })
 

--- a/forge/routes/api/projectType.js
+++ b/forge/routes/api/projectType.js
@@ -13,7 +13,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.projectTypes
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', {
+        preHandler: app.needsPermission('project-type:list')
+    }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         let filter = { active: true }
         if (request.query.filter === 'all') {
@@ -35,7 +37,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.projectTypes
      */
-    app.get('/:projectTypeId', async (request, reply) => {
+    app.get('/:projectTypeId', {
+        preHandler: app.needsPermission('project-type:read')
+    }, async (request, reply) => {
         const projectType = await app.db.models.ProjectType.byId(request.params.projectTypeId)
         if (projectType) {
             reply.send(app.db.views.ProjectType.projectType(projectType, request.session.User.admin))

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -115,12 +115,12 @@ module.exports = {
             // re-send verification email if a user was previously verifed and is now not verified
             if (wasVerified && user.email_verified === false && request.session.User.id !== user.id) {
                 try {
-                    const verifyToken = await app.db.controllers.User.generateEmailVerificationToken(user)
+                    const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(user)
                     await app.postoffice.send(
                         user,
                         'VerifyEmail',
                         {
-                            confirmEmailLink: `${app.config.base_url}/account/verify/${verifyToken}`
+                            confirmEmailLink: `${app.config.base_url}/account/verify/${verificationToken}`
                         }
                     )
                 } catch (error) {

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -13,7 +13,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.stacks
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', { preHandler: app.needsPermission('stack:list') }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         let filter = { active: true }
         if (request.query.filter === 'all') {
@@ -44,7 +44,7 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.stacks
      */
-    app.get('/:stackId', async (request, reply) => {
+    app.get('/:stackId', { preHandler: app.needsPermission('stack:read') }, async (request, reply) => {
         const stack = await app.db.models.ProjectStack.byId(request.params.stackId)
         if (stack) {
             reply.send(app.db.views.ProjectStack.stack(stack, request.session.User.admin))

--- a/forge/routes/api/teamDevices.js
+++ b/forge/routes/api/teamDevices.js
@@ -40,7 +40,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.team
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', {
+        preHandler: app.needsPermission('team:device:list')
+    }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const where = {
             TeamId: request.team.id

--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -34,7 +34,7 @@ module.exports = async function (app) {
         }
     })
 
-    app.get('/', async (request, reply) => {
+    app.get('/', { preHandler: app.needsPermission('team:user:list') }, async (request, reply) => {
         const members = await app.db.models.User.inTeam(request.params.teamId)
         const result = app.db.views.User.teamMemberList(members)
         reply.send({

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -13,7 +13,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.templates
      */
-    app.get('/', async (request, reply) => {
+    app.get('/', {
+        preHandler: app.needsPermission('template:list')
+    }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const templates = await app.db.models.ProjectTemplate.getAll(paginationOptions)
         templates.templates = templates.templates.map(s => app.db.views.ProjectTemplate.templateSummary(s))
@@ -26,7 +28,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.templates
      */
-    app.get('/:templateId', async (request, reply) => {
+    app.get('/:templateId', {
+        preHandler: app.needsPermission('template:read')
+    }, async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
         if (template) {
             reply.send(app.db.views.ProjectTemplate.template(template))

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -21,7 +21,10 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.get('/', { config: { allowUnverifiedEmail: true, allowToken: true, allowExpiredPassword: true } }, async (request, reply) => {
+    app.get('/', {
+        preHandler: app.needsPermission('user:read'),
+        config: { allowUnverifiedEmail: true, allowExpiredPassword: true }
+    }, async (request, reply) => {
         const users = await app.db.views.User.userProfile(request.session.User)
         reply.send(users)
     })
@@ -33,6 +36,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.user
      */
     app.put('/change_password', {
+        preHandler: app.needsPermission('user:edit'),
         config: { allowExpiredPassword: true },
         schema: {
             body: {
@@ -62,7 +66,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.get('/teams', async (request, reply) => {
+    app.get('/teams', {
+        preHandler: app.needsPermission('user:read')
+    }, async (request, reply) => {
         const teams = await app.db.models.Team.forUser(request.session.User)
         const result = await app.db.views.Team.userTeamList(teams)
         reply.send({
@@ -78,7 +84,9 @@ module.exports = async function (app) {
      * @static
      * @memberof forge.routes.api.user
      */
-    app.put('/', async (request, reply) => {
+    app.put('/', {
+        preHandler: app.needsPermission('user:edit')
+    }, async (request, reply) => {
         sharedUser.updateUser(app, request.session.User, request, reply, userLog)
         return reply // fix errors in tests "Promise may not be fulfilled with 'undefined' when statusCode is not 204" https://github.com/fastify/help/issues/627
     })

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -9,6 +9,8 @@
  * @memberof forge.routes.api
  */
 module.exports = async function (app) {
+    app.addHook('preHandler', app.needsPermission('user:edit'))
+
     app.get('/', async (request, reply) => {
         const invitations = await app.db.models.Invitation.forUser(request.session.User)
         const result = app.db.views.Invitation.invitationList(invitations)

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -34,45 +34,10 @@ module.exports = fp(async function (app, opts, done) {
     await app.register(require('./oauth'), { logLevel: app.config.logging.http })
     await app.register(require('./permissions'))
 
-    // WIP:
-    async function verifyToken (request, reply) {
-        if (request.headers && request.headers.authorization) {
-            const parts = request.headers.authorization.split(' ')
-            if (parts.length === 2) {
-                const scheme = parts[0]
-                const token = parts[1]
-                if (scheme !== 'Bearer') {
-                    reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
-                }
-                const accessToken = await app.db.controllers.AccessToken.getOrExpire(token)
-                if (accessToken) {
-                    request.session = {
-                        ownerId: accessToken.ownerId,
-                        ownerType: accessToken.ownerType,
-                        scope: accessToken.scope
-                    }
-                    if (accessToken.ownerType === 'user') {
-                        request.session.User = await app.db.models.User.findOne({ where: { id: parseInt(accessToken.ownerId) } })
-                    }
-                    return
-                }
-                reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
-            } else {
-                reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
-            }
-        } else {
-            reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
-        }
-    }
-
-    app.decorate('verifyToken', verifyToken)
-
     /**
      * preHandler function that ensures the current request comes from an active
-     * session.
+     * session or token
      *
-     * Currently this is based only on session cookie. This needs expanding
-     * to include authorisation tokens.
      *
      * It sets `request.session` to the active session object.
      * @name verifySession
@@ -90,16 +55,45 @@ module.exports = fp(async function (app, opts, done) {
                     return
                 }
             }
+        } else if (request.headers && request.headers.authorization) {
+            const parts = request.headers.authorization.split(' ')
+            if (parts.length === 2) {
+                const scheme = parts[0]
+                const token = parts[1]
+                if (scheme !== 'Bearer') {
+                    reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                    return
+                }
+                const accessToken = await app.db.controllers.AccessToken.getOrExpire(token)
+                if (accessToken) {
+                    request.session = {
+                        ownerId: accessToken.ownerId,
+                        ownerType: accessToken.ownerType,
+                        scope: accessToken.scope
+                    }
+                    if (accessToken.ownerType === 'user') {
+                        request.session.User = await app.db.models.User.findOne({ where: { id: parseInt(accessToken.ownerId) } })
+                        // Unlike a cookie based session, we'll allow user tokens to continue
+                        // working if password has expired or email isn't verified
+                        // TODO: validate this choice
+                        if (request.session.User.suspended) {
+                            reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                            return
+                        }
+                    }
+                    return
+                }
+                reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                return
+            } else {
+                reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                return
+            }
         }
         if (request.routeConfig.allowAnonymous) {
             return
         }
-        if (request.routeConfig.allowToken) {
-            await verifyToken(request, reply)
-            return
-        }
         reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
-        throw new Error()
     }
     app.decorate('verifySession', verifySession)
 
@@ -112,7 +106,7 @@ module.exports = fp(async function (app, opts, done) {
      * @memberof forge
      */
     app.decorate('verifyAdmin', async (request, reply) => {
-        if (request.session && request.session.User.admin) {
+        if (request.session?.User?.admin) {
             return
         }
         reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
@@ -300,12 +294,12 @@ module.exports = fp(async function (app, opts, done) {
                 tcs_accepted: new Date()
             })
             userInfo.id = newUser.id
-            const verifyToken = await app.db.controllers.User.generateEmailVerificationToken(newUser)
+            const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(newUser)
             await app.postoffice.send(
                 newUser,
                 'VerifyEmail',
                 {
-                    confirmEmailLink: `${app.config.base_url}/account/verify/${verifyToken}`
+                    confirmEmailLink: `${app.config.base_url}/account/verify/${verificationToken}`
                 }
             )
             if (request.body.code) {
@@ -425,12 +419,12 @@ module.exports = fp(async function (app, opts, done) {
             return
         }
         if (!request.session.User.email_verified) {
-            const verifyToken = await app.db.controllers.User.generateEmailVerificationToken(request.session.User)
+            const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(request.session.User)
             await app.postoffice.send(
                 request.session.User,
                 'VerifyEmail',
                 {
-                    confirmEmailLink: `${app.config.base_url}/account/verify/${verifyToken}`
+                    confirmEmailLink: `${app.config.base_url}/account/verify/${verificationToken}`
                 }
             )
             await userLog(request.session.User.id, 'verify.request-token', { info: 'Verify email password sent' })

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -255,7 +255,11 @@ module.exports = async function (app) {
                 return
             }
 
-            const accessToken = await app.db.controllers.AccessToken.createTokenForUser(requestObject.userId, null, ['project:flows:view', 'project:flows:edit'], true)
+            const accessToken = await app.db.controllers.AccessToken.createTokenForUser(requestObject.userId,
+                null,
+                ['user:read', 'project:flows:view', 'project:flows:edit'],
+                true
+            )
 
             const project = await app.db.models.Project.byId(authClient.ownerId)
             const teamMembership = await app.db.models.TeamMember.findOne({ where: { TeamId: project.TeamId, UserId: requestObject.userId } })

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -18,7 +18,6 @@ module.exports = fp(async function (app, opts, done) {
                 // Admins get to have all the fun
                 return
             }
-
             // A user has permission based on:
             // - the resource they are accessing
             // - the action they want to perform
@@ -42,11 +41,18 @@ module.exports = fp(async function (app, opts, done) {
                     reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                     throw new Error()
                 }
-                if (permission.self && request.user.id === request.session.User.id) {
+                if (permission.self && (request.user && (request.user.id === request.session.User?.id))) {
                     // This permission is permitted if the user is operating on themselves
                     return
                 }
                 if (request.teamMembership.role < permission.role) {
+                    reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
+                    throw new Error()
+                }
+            } else if (permission.self) {
+                // A request outside the context of a team. Currently this covers
+                // /api/v1/user/* routes
+                if (!request.session.User) {
                     reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                     throw new Error()
                 }

--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -1,6 +1,19 @@
 const fp = require('fastify-plugin')
 const { Permissions } = require('../../lib/permissions')
 
+// For device/project tokens, list the scopes they implicitly have.
+// This will allow us to add scopes to existing tokens without having to update
+// them (as that requires reprovisioning of devices and restaging of projects)
+const IMPLICIT_TOKEN_SCOPES = {
+    device: [],
+    project: [
+        'user:read',
+        'project:flows:view',
+        'project:flows:edit',
+        'team:projects:list'
+    ]
+}
+
 module.exports = fp(async function (app, opts, done) {
     function hasPermission (teamMembership, scope) {
         if (!teamMembership) {
@@ -14,8 +27,9 @@ module.exports = fp(async function (app, opts, done) {
             throw new Error(`Unrecognised scope requested: '${scope}'`)
         }
         return async (request, reply) => {
-            if (request.session.User && request.session.User.admin) {
-                // Admins get to have all the fun
+            if (!request.session.scope && request.session.User && request.session.User.admin) {
+                // Admins get to have all the fun - as long as they are logged in and not
+                // using an access-token
                 return
             }
             // A user has permission based on:
@@ -34,7 +48,7 @@ module.exports = fp(async function (app, opts, done) {
                 // Permission disabled via admin settings
                 reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                 throw new Error()
-            } else if (permission.role) {
+            } else if (permission.role && (!request.session.scope || request.session.ownerType === 'user')) {
                 // The user is required to have a role in the team associated with
                 // this request
                 if (!request.teamMembership) {
@@ -53,6 +67,17 @@ module.exports = fp(async function (app, opts, done) {
                 // A request outside the context of a team. Currently this covers
                 // /api/v1/user/* routes
                 if (!request.session.User) {
+                    reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
+                    throw new Error()
+                }
+            }
+            if (request.session.scope) {
+                // All things being equal, the user does have this permission
+                // But they are using an access_token that could be scoped down
+                // We also need to check against the list of implicit scopes for
+                // a given token type (ie device/project)
+                if (!request.session.scope.includes(scope) &&
+                    (!IMPLICIT_TOKEN_SCOPES[request.session.ownerType] || !IMPLICIT_TOKEN_SCOPES[request.session.ownerType].includes(scope))) {
                     reply.code(403).send({ code: 'unauthorized', error: 'unauthorized' })
                     throw new Error()
                 }

--- a/forge/routes/logging/index.js
+++ b/forge/routes/logging/index.js
@@ -7,7 +7,7 @@
  */
 
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifyToken)
+    app.addHook('preHandler', app.verifySession)
     app.addHook('preHandler', async (request, response) => {
         // The request has a valid token, but need to check the token is allowed
         // to access the project

--- a/forge/routes/storage/index.js
+++ b/forge/routes/storage/index.js
@@ -7,7 +7,7 @@
  * @memberof forge.storage
  */
 module.exports = async function (app) {
-    app.addHook('preHandler', app.verifyToken)
+    app.addHook('preHandler', app.verifySession)
     app.addHook('preHandler', async (request, response) => {
         // The request has a valid token, but need to check the token is allowed
         // to access the project

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -1460,6 +1460,23 @@ describe('Project API', function () {
             should(response).have.property('statusCode')
             should(response.statusCode).eqls(401)
         })
+
+        it('Project token cannot get another project settings', async function () {
+            const settingsURL = `/api/v1/projects/${app.project.id}/settings`
+
+            const project2 = await app.db.models.Project.create({ name: 'project2', type: '', url: '' })
+            await app.team.addProject(project2)
+            const tokens2 = await project2.refreshAuthTokens()
+            const response = await app.inject({
+                method: 'GET',
+                url: settingsURL,
+                headers: {
+                    authorization: `Bearer ${tokens2.token}`
+                }
+            })
+            should(response).have.property('statusCode')
+            should(response.statusCode).eqls(404)
+        })
     })
     describe('Project import flows & credentials', function () {
         const flows = [


### PR DESCRIPTION
Prior to this PR we had two distinct ways of authenticating a request.

It either had a session cookie or it provided an Authorisation header with a bearer token.

We had separate handlers for those two methods. By default, routes would use `verifySession` as they were expected to only be called by a logged-in user.

A small number of routes set flags to indicate they could be called with a bearer token instead - triggering `verifyToken` to be used.

To enable the Node-RED Plugin, we need to have an access token that has more access to the api, but not the same as a fully logged in user (for example, modifying the user's account details etc).

Rather than keep carving out exceptions and adding more flags for different use cases, this PR addresses a long standing todo in the code. It removes `verifyToken` and does all the work in `verifySession`.

`verifySession` now includes the logic to check the bearer token if a session cookie isn't present.

There were a few routes that assumed they were protected by verifySession as-was, meaning we'd be guaranteed to have `request.session.User` present. That is no longer the case as a request could be a device/project token that isn't tied to a user.

For this PR I have been through every single route and verified its behaviour - verifying that it cannot be accessed with a device/project token and no unexpected errors occur when that is attempted.

I have verified that logging into the editor still works, the project nodes can still get a list of team projects and the device agent can do its thing.

We have unit tests for a reasonable proportion of this - but it isn't exhaustive and it is hard to prove a negative.

When a token is being used, I have updated `needsPermission(...)` to check against the `scope` of the token against the permission. This will allows us to generate tokens with more restricted access.
In doing that, I realised that existing Device and Project tokens do not necessarily have the scopes already set. If we were to add new features that required new scopes, that would mean users would have to regenerated device credentials, or restage their projects - not acceptable. Instead, I've defined a list of implicit scopes those tokens get. That will allow us to grant additional scopes without disruption.

There's a lot going on here - it's the type of change that has to be done in one go. The sooner we get it in, the more time we'll have soaking it.
