### PR TITLE
docs: Remove header paragraph

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,5 @@
 # FlowForge Docs
 
-Welcome to the FlowForge documentation.
-
-This documentation covers everything you need to get started with the FlowForge
-platform, as an administrator, end-user, contributor, or all three.
-
-## About FlowForge
-
 FlowForge is an open-source low-code platform based on the OpenJS Foundation Node-RED
 project. It provides the tools you need to run and manage multiple Node-RED instances
 in your own environment.


### PR DESCRIPTION
While it's polite to welcome users to the docs, it pushes down the links I want to get to for further reading. By removing this section the page renders these links on initial rendering without scrolling on more (all?) screens.