### PR TITLE
Add note about where to run `helm upgrade` command

### DIFF
--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -131,6 +131,7 @@ TODO: *Detailed walk through for AWS in internal Cloud Project docs. Will add ex
 
 A full list of all the configable values can be found in the [Helm Chart README](https://github.com/flowforge/helm/blob/main/helm/flowforge/README.md).
 
+The install can then be started with the following command, should be run from the `helm` dirctory:
 
 ```
 helm upgrade --install flowforge flowforge -f values.yml


### PR DESCRIPTION
Until we publish the helm chart to a repository we will need to be clear about where to run the command

See this conversation for reason: https://node-red.slack.com/archives/C02V3BN77GU/p1667924834697679