### PR TITLE
Project > Deployments Page

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -29,7 +29,7 @@ module.exports = {
         this._app = app
 
         const projects = await this._app.db.models.Project.findAll()
-        projects.forEach(async (project) => {
+        projects.forEach(project => {
             if (project.state !== 'suspended') {
                 const p = {
                     id: project.id,

--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -102,13 +102,6 @@ module.exports = {
                 const stubProjectToken = forgeUtils.generateToken(8)
                 await project.updateSetting('stubProjectToken', stubProjectToken)
             }
-            const existingFlow = await this._app.db.models.StorageFlow.byProject(project.id)
-            if (!existingFlow) {
-                await this._app.db.models.StorageFlow.create({
-                    flow: JSON.stringify([]),
-                    ProjectId: project.id
-                })
-            }
             if (project.name === 'stub-fail-start') {
                 return new Promise((resolve, reject) => {
                     setTimeout(() => {

--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -29,7 +29,7 @@ module.exports = {
         this._app = app
 
         const projects = await this._app.db.models.Project.findAll()
-        projects.forEach(project => {
+        projects.forEach(async (project) => {
             if (project.state !== 'suspended') {
                 const p = {
                     id: project.id,
@@ -101,6 +101,13 @@ module.exports = {
             if (await project.getSetting('stubProjectToken') === undefined) {
                 const stubProjectToken = forgeUtils.generateToken(8)
                 await project.updateSetting('stubProjectToken', stubProjectToken)
+            }
+            const existingFlow = await this._app.db.models.StorageFlow.byProject(project.id)
+            if (!existingFlow) {
+                await this._app.db.models.StorageFlow.create({
+                    flow: JSON.stringify([]),
+                    ProjectId: project.id
+                })
             }
             if (project.name === 'stub-fail-start') {
                 return new Promise((resolve, reject) => {

--- a/forge/db/models/StorageFlow.js
+++ b/forge/db/models/StorageFlow.js
@@ -22,7 +22,7 @@ module.exports = {
                 byProject: async (project) => {
                     return this.findOne({
                         where: { ProjectId: project },
-                        attributes: ['id', 'flow']
+                        attributes: ['id', 'flow', 'updatedAt']
                     })
                 }
             }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -74,8 +74,14 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId', async (request, reply) => {
-        const result = await app.db.views.Project.project(request.project)
+        const [result, projectFlow] = await Promise.all([
+            await app.db.views.Project.project(request.project),
+            await app.db.models.StorageFlow.byProject(request.project.id)
+        ])
         const inflightState = app.db.controllers.Project.getInflightState(request.project)
+
+        result.flowLastUpdatedAt = projectFlow?.updatedAt
+
         if (inflightState) {
             result.meta = {
                 state: inflightState

--- a/frontend/src/api/project.js
+++ b/frontend/src/api/project.js
@@ -12,6 +12,7 @@ const getProject = (projectId) => {
     return client.get(`/api/v1/projects/${projectId}`).then(res => {
         res.data.createdSince = daysSince(res.data.createdAt)
         res.data.updatedSince = daysSince(res.data.updatedAt)
+        res.data.flowLastUpdatedSince = daysSince(res.data.flowLastUpdatedAt)
         return res.data
     })
 }

--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -229,7 +229,7 @@ export default {
             ]
         },
         cloudRows () {
-            return [this.project]
+            return this.project.id ? [this.project] : []
         },
         projectRunning () {
             return this.project.meta?.state === 'running'

--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -1,94 +1,104 @@
 <template>
-    <div class="space-y-6">
-        <ff-loading
-            v-if="loading"
-            message="Loading Devices..."
-        />
-        <ff-loading
-            v-else-if="creatingDevice"
-            message="Creating Device..."
-        />
-        <ff-loading
-            v-else-if="deletingDevice"
-            message="Deleting Device..."
-        />
-        <template v-else>
-            <template v-if="devices.length > 0">
-                <div
-                    v-if="project?.id"
-                    class="flex space-x-8"
-                >
-                    <ff-button
-                        v-if="hasPermission('device:create')"
-                        data-action="register-device"
-                        kind="primary"
-                        size="small"
-                        @click="showCreateDeviceDialog"
-                    >
-                        <template #icon-left>
-                            <PlusSmIcon />
-                        </template>Register Device
-                    </ff-button>
-                    <ff-button
-                        kind="tertiary"
-                        size="small"
-                        to="./snapshots"
-                    >
-                        <template #icon-left>
-                            <ClockIcon />
-                        </template>
-                        Target Snapshot: {{ project.deviceSettings.targetSnapshot || 'none' }}
-                    </ff-button>
+    <div>
+        <div class="border-b border-gray-200 mb-3">
+            <div class="w-full md:w-auto mb-2 mr-8">
+                <div class="text-gray-800 text-lg font-bold">
+                    Devices
                 </div>
-
-                <ff-data-table
-                    data-el="devices"
-                    :columns="columns"
-                    :rows="devices"
-                    :show-search="true"
-                    search-placeholder="Search Devices..."
-                >
-                    <template
-                        v-if="hasPermission('device:edit')"
-                        #context-menu="{row}"
-                    >
-                        <ff-list-item
-                            label="Edit Details"
-                            @click="deviceAction('edit', row.id)"
-                        />
-                        <ff-list-item
-                            label="Remove from Project"
-                            @click="deviceAction('removeFromProject', row.id)"
-                        />
-                        <ff-list-item
-                            kind="danger"
-                            label="Regenerate Credentials"
-                            @click="deviceAction('updateCredentials', row.id)"
-                        />
-                        <ff-list-item
-                            v-if="hasPermission('device:delete')"
-                            kind="danger"
-                            label="Delete Device"
-                            @click="deviceAction('delete', row.id)"
-                        />
-                    </template>
-                </ff-data-table>
-            </template>
+            </div>
+        </div>
+        <div class="space-y-6">
+            <ff-loading
+                v-if="loading"
+                message="Loading Devices..."
+            />
+            <ff-loading
+                v-else-if="creatingDevice"
+                message="Creating Device..."
+            />
+            <ff-loading
+                v-else-if="deletingDevice"
+                message="Deleting Device..."
+            />
             <template v-else>
-                <div class="flex text-gray-500 justify-center italic mb-4 p-8">
-                    <div class="text-center">
-                        <p>You have not added any devices to this team yet.</p>
-                        <p>
-                            To add a device, go to the
-                            <router-link :to="{name: 'TeamDevices', params: {team_slug:team.slug}}">
-                                Team Device
-                            </router-link>
-                            page
-                        </p>
+                <template v-if="devices.length > 0">
+                    <ff-data-table
+                        data-el="devices"
+                        :columns="columns"
+                        :rows="devices"
+                        :show-search="true"
+                        search-placeholder="Search Device Deployments..."
+                    >
+                        <template
+                            v-if="hasPermission('project:snapshot:create')"
+                            #actions
+                        >
+                            <ff-button
+                                kind="secondary"
+                                to="./snapshots"
+                            >
+                                <template #icon-left>
+                                    <ClockIcon />
+                                </template>
+                                <span class="font-normal">
+                                    Target Snapshot: <b>{{ project.deviceSettings.targetSnapshot || 'none' }}</b>
+                                </span>
+                            </ff-button>
+                            <ff-button
+                                v-if="hasPermission('device:create')"
+                                class="font-normal"
+                                data-action="register-device"
+                                kind="primary"
+                                @click="showCreateDeviceDialog"
+                            >
+                                <template #icon-right>
+                                    <PlusSmIcon />
+                                </template>
+                                <span class="font-normal">Add Device</span>
+                            </ff-button>
+                        </template>
+                        <template
+                            v-if="hasPermission('device:edit')"
+                            #context-menu="{row}"
+                        >
+                            <ff-list-item
+                                label="Edit Details"
+                                @click="deviceAction('edit', row.id)"
+                            />
+                            <ff-list-item
+                                label="Remove from Project"
+                                @click="deviceAction('removeFromProject', row.id)"
+                            />
+                            <ff-list-item
+                                kind="danger"
+                                label="Regenerate Credentials"
+                                @click="deviceAction('updateCredentials', row.id)"
+                            />
+                            <ff-list-item
+                                v-if="hasPermission('device:delete')"
+                                kind="danger"
+                                label="Delete Device"
+                                @click="deviceAction('delete', row.id)"
+                            />
+                        </template>
+                    </ff-data-table>
+                </template>
+                <template v-else>
+                    <div class="flex text-gray-500 justify-center italic mb-4 p-8">
+                        <div class="text-center">
+                            <p>You have not added any devices to this team yet.</p>
+                            <p>
+                                To add a device, go to the
+                                <router-link :to="{name: 'TeamDevices', params: {team_slug:team.slug}}">
+                                    Team Device
+                                </router-link>
+                                page
+                            </p>
+                        </div>
                     </div>
-                </div>
+                </template>
             </template>
-        </template>
+        </div>
 
         <TeamDeviceCreateDialog
             ref="teamDeviceCreateDialog"
@@ -103,7 +113,8 @@
 
 <script>
 
-import { ChipIcon, CheckCircleIcon, ExclamationIcon, PlusSmIcon, ClockIcon } from '@heroicons/vue/solid'
+import { ClockIcon } from '@heroicons/vue/outline'
+import { ChipIcon, CheckCircleIcon, ExclamationIcon, PlusSmIcon } from '@heroicons/vue/solid'
 
 import { markRaw } from 'vue'
 import { mapState } from 'vuex'

--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -194,9 +194,9 @@ export default {
 
             return [
                 { label: 'Device', class: ['w-64'], key: 'name', sortable: true, component: { is: markRaw(DeviceLink) } },
-                { label: 'Status', class: ['w-20'], key: 'status', sortable: true, component: { is: markRaw(ProjectStatusBadge) } },
-                { label: 'Last Seen', class: ['w-64'], key: 'last seen', sortable: true, component: { is: markRaw(LastSeen) } },
-                { label: 'Deployed Snapshot', class: ['w-64'], component: { is: markRaw(SnapshotComponent) } }
+                { label: 'Last Seen', class: ['w-48'], key: 'last seen', sortable: true, component: { is: markRaw(LastSeen) } },
+                { label: 'Deployed Snapshot', class: ['w-32'], component: { is: markRaw(SnapshotComponent) } },
+                { label: '', class: ['w-20'], key: 'status', sortable: false, component: { is: markRaw(ProjectStatusBadge) } }
             ]
         }
     },

--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -354,7 +354,6 @@ export default {
             try {
                 if (this.project.id) {
                     await this.fetchData()
-                    this.loading = false
                 }
             } finally {
                 this.checkInterval = setTimeout(this.pollForData, 10000)
@@ -363,6 +362,7 @@ export default {
         fetchData: async function () {
             const data = await projectApi.getProjectDevices(this.project.id)
             this.devices = data.devices
+            this.loading = false
         },
         deviceAction (action, deviceId) {
             const device = this.devices.find(d => d.id === deviceId)

--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -216,7 +216,7 @@ export default {
             return [
                 { label: 'Device', class: ['w-64'], sortable: true, component: { is: markRaw(DeviceLink) } },
                 { label: 'Last Seen', class: ['w-48'], sortable: true, component: { is: markRaw(LastSeen) } },
-                { label: 'Deployed Snapshot', class: ['w-32'], component: { is: markRaw(Snapshot), extraProps: { targetSnapshot: this.project.deviceSettings.targetSnapshot } } },
+                { label: 'Deployed Snapshot', class: ['w-32'], component: { is: markRaw(Snapshot) } },
                 { label: '', class: ['w-20'], component: { is: markRaw(ProjectStatusBadge) } }
             ]
         },

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -28,7 +28,7 @@
                         <td class="font-medium">Type</td>
                         <td class="flex items-center">
                             <div class="py-2 flex-grow">{{project.projectType?.name || 'none'}} / {{project.stack?.label || project.stack?.name || 'none'}}</div>
-                            <div v-if="project.stack.replacedBy">
+                            <div v-if="project.stack?.replacedBy">
                                 <ff-button size="small" to="./settings/danger">Update</ff-button>
                             </div>
                         </td>

--- a/frontend/src/pages/project/components/cells/DeploymentLink.vue
+++ b/frontend/src/pages/project/components/cells/DeploymentLink.vue
@@ -26,7 +26,7 @@
 import { CloudIcon } from '@heroicons/vue/outline'
 
 export default {
-    name: 'CloudLink',
+    name: 'DeploymentLink',
     components: { CloudIcon },
     props: {
         url: {

--- a/frontend/src/pages/project/components/cells/DeploymentLink.vue
+++ b/frontend/src/pages/project/components/cells/DeploymentLink.vue
@@ -1,0 +1,42 @@
+<template>
+    <a
+        v-if="!disabled"
+        :href="url"
+        target="_blank"
+        class="flex"
+        data-action="open-editor"
+    >
+        <CloudIcon class="w-6 mr-2 text-gray-500" />
+        <div class="flex flex-col space-y-1">
+            {{ url }}
+        </div>
+    </a>
+    <span
+        v-else
+        class="flex"
+    >
+        <CloudIcon class="w-6 mr-2 text-gray-500" />
+        <div class="flex flex-col space-y-1">
+            {{ url }}
+        </div>
+    </span>
+</template>
+
+<script>
+import { CloudIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'CloudLink',
+    components: { CloudIcon },
+    props: {
+        url: {
+            required: true,
+            type: String
+        },
+        disabled: {
+            type: Boolean,
+            default: false
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/project/components/cells/DeviceLink.vue
+++ b/frontend/src/pages/project/components/cells/DeviceLink.vue
@@ -1,0 +1,32 @@
+<template>
+    <router-link
+        :to="{ name: 'Device', params: { id: id } }"
+        class="flex"
+    >
+        <ChipIcon class="w-6 mr-2 text-gray-500" />
+        <div class="flex flex-col space-y-1">
+            <span class="text-lg">{{ name }}</span>
+            <span class="text-xs text-gray-500">id: {{ id }}</span>
+        </div>
+    </router-link>
+</template>
+
+<script>
+import { ChipIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'DeviceLink',
+    components: { ChipIcon },
+    props: {
+        id: {
+            required: true,
+            type: String
+        },
+        name: {
+            type: String,
+            required: true
+        }
+
+    }
+}
+</script>

--- a/frontend/src/pages/project/components/cells/LastSeen.vue
+++ b/frontend/src/pages/project/components/cells/LastSeen.vue
@@ -1,0 +1,23 @@
+<template>
+    <span>
+        <span v-if="lastSeenSince">{{ lastSeenSince }}</span>
+        <span
+            v-else
+            class="italic text-gray-500"
+        >
+            never
+        </span>
+    </span>
+</template>
+
+<script>
+export default {
+    name: 'LastSeen',
+    props: {
+        lastSeenSince: {
+            required: true,
+            type: String
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/project/components/cells/ProjectEditorLink.vue
+++ b/frontend/src/pages/project/components/cells/ProjectEditorLink.vue
@@ -1,16 +1,18 @@
 <template>
-    <a
-        v-if="!disabled"
-        :href="url"
-        target="_blank"
-        class="ff-btn ff-btn--secondary"
-        data-action="open-editor"
-    >
-        Open Editor
-        <span class="ff-btn--icon ff-btn--icon-right">
-            <ExternalLinkIcon />
-        </span>
-    </a>
+    <div class="flex justify-end">
+        <a
+            v-if="!disabled"
+            :href="url"
+            target="_blank"
+            class="ff-btn ff-btn--secondary"
+            data-action="open-editor"
+        >
+            Open Editor
+            <span class="ff-btn--icon ff-btn--icon-right">
+                <ExternalLinkIcon />
+            </span>
+        </a>
+    </div>
 </template>
 
 <script>

--- a/frontend/src/pages/project/components/cells/ProjectEditorLink.vue
+++ b/frontend/src/pages/project/components/cells/ProjectEditorLink.vue
@@ -1,0 +1,29 @@
+<template>
+    <a
+        v-if="!disabled"
+        :href="url"
+        target="_blank"
+        class="ff-btn ff-btn--secondary"
+        data-action="open-editor"
+    >
+        Open Editor
+        <span class="ff-btn--icon ff-btn--icon-right">
+            <ExternalLinkIcon />
+        </span>
+    </a>
+</template>
+
+<script>
+import { ExternalLinkIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'ProjectEditorLink',
+    components: { ExternalLinkIcon },
+    props: {
+        disabled: {
+            type: Boolean,
+            default: false
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/project/components/cells/ProjectEditorLink.vue
+++ b/frontend/src/pages/project/components/cells/ProjectEditorLink.vue
@@ -21,8 +21,12 @@ export default {
     components: { ExternalLinkIcon },
     props: {
         disabled: {
-            type: Boolean,
-            default: false
+            default: false,
+            type: Boolean
+        },
+        url: {
+            required: true,
+            type: String
         }
     }
 }

--- a/frontend/src/pages/project/components/cells/Snapshot.vue
+++ b/frontend/src/pages/project/components/cells/Snapshot.vue
@@ -29,17 +29,17 @@ export default {
     },
     props: {
         activeSnapshot: {
-            default: {},
+            default: null,
             type: Object
         },
         targetSnapshot: {
-            type: String,
-            required: true
+            default: null,
+            type: Object
         }
     },
     computed: {
         updateNeeded: function () {
-            return !this.activeSnapshot || (this.activeSnapshot?.id !== this.targetSnapshot)
+            return !this.activeSnapshot || (this.activeSnapshot?.id !== this.targetSnapshot?.id)
         }
     }
 }

--- a/frontend/src/pages/project/components/cells/Snapshot.vue
+++ b/frontend/src/pages/project/components/cells/Snapshot.vue
@@ -1,0 +1,46 @@
+<template>
+    <span class="flex space-x-4">
+        <span
+            v-if="activeSnapshot?.id || updateNeeded"
+            class="flex items-center space-x-2 text-gray-500 italic"
+        >
+            <ExclamationIcon
+                v-if="updateNeeded"
+                class="text-yellow-600 w-4"
+            />
+            <CheckCircleIcon
+                v-else-if="activeSnapshot?.id"
+                class="text-green-700 w-4"
+            />
+        </span>
+        <template v-if="activeSnapshot"><div class="flex flex-col"><span>{{ activeSnapshot?.name }}</span><span class="text-xs text-gray-500">{{ activeSnapshot.id }}</span></div></template>
+        <template v-else><span class="italic text-gray-500">none</span></template>
+    </span>
+</template>
+
+<script>
+import { CheckCircleIcon, ExclamationIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'CloudLink',
+    components: {
+        ExclamationIcon,
+        CheckCircleIcon
+    },
+    props: {
+        activeSnapshot: {
+            default: {},
+            type: Object
+        },
+        targetSnapshot: {
+            type: String,
+            required: true
+        }
+    },
+    computed: {
+        updateNeeded: function () {
+            return !this.activeSnapshot || (this.activeSnapshot?.id !== this.targetSnapshot)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -17,8 +17,13 @@
         <SectionTopMenu>
             <template #hero>
                 <div class="flex-grow space-x-6 items-center inline-flex">
-                    <router-link :to="navigation[0]?navigation[0].path:''" class="inline-flex items-center">
-                        <div class="text-gray-800 text-xl font-bold">{{project.name}}</div>
+                    <router-link
+                        :to="navigation[0]?.path ?? ''"
+                        class="inline-flex items-center"
+                    >
+                        <div class="text-gray-800 text-xl font-bold">
+                            {{ project.name }}
+                        </div>
                     </router-link>
                     <ProjectStatusBadge :status="project.meta.state" :pendingStateChange="project.pendingStateChange" v-if="project.meta" />
                 </div>
@@ -39,7 +44,15 @@
             <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
                 <div class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
             </Teleport>
-            <router-view :project="project" :isVisitingAdmin="isVisitingAdmin" @projectUpdated="updateProject"></router-view>
+            <router-view
+                :project="project"
+                :is-visiting-admin="isVisitingAdmin"
+                @projectUpdated="updateProject"
+                @project-start="startProject"
+                @project-restart="restartProject"
+                @project-suspend="showConfirmSuspendDialog"
+                @project-delete="showConfirmDeleteDialog"
+            />
         </div>
     </main>
 </template>
@@ -109,13 +122,10 @@ export default {
             const result = [
                 {
                     name: 'Start',
-                    action: async () => {
-                        this.project.pendingStateChange = true
-                        await projectApi.startProject(this.project.id)
-                    },
+                    action: this.startProject,
                     disabled: this.project.pendingStateChange || this.projectRunning
                 },
-                { name: 'Restart', action: async () => { this.project.pendingRestart = true; this.project.pendingStateChange = true; await projectApi.restartProject(this.project.id) }, disabled: flowActionsDisabled },
+                { name: 'Restart', action: this.restartProject, disabled: flowActionsDisabled },
                 { name: 'Suspend', class: ['text-red-700'], action: () => { this.showConfirmSuspendDialog() }, disabled: flowActionsDisabled }
             ]
             if (this.hasPermission('project:delete')) {
@@ -187,6 +197,15 @@ export default {
                 this.project.pendingStateChange = true
                 this.refreshProject()
             }
+        },
+        async startProject () {
+            this.project.pendingStateChange = true
+            await projectApi.startProject(this.project.id)
+        },
+        async restartProject () {
+            this.project.pendingRestart = true
+            this.project.pendingStateChange = true
+            await projectApi.restartProject(this.project.id)
         },
         showConfirmDeleteDialog () {
             this.$refs.confirmProjectDeleteDialog.show(this.project)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@fastify/csrf-protection": "^6.0.0",
         "@fastify/helmet": "^10.0.2",
         "@fastify/static": "^6.5.0",
-        "@flowforge/forge-ui-components": "^0.4.2",
+        "@flowforge/forge-ui-components": "^0.4.3",
         "@flowforge/localfs": "^1.0.0",
         "@headlessui/vue": "1.7.3",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
Continued work on #1174, fixes https://github.com/flowforge/flowforge/issues/1176, this PR:

- Reorders the devices table columns
- Adds a cloud deployments table (title not settled on yet) to the top of the page
- Adds information regarding the last flow deployment to the projects API
- Refactors all the inline vue components into separate files

<img width="1187" alt="Screenshot 2022-11-10 at 17 33 30" src="https://user-images.githubusercontent.com/507155/201153123-4660e337-b903-4423-ab41-e20f24a8cf7b.png">


