### PR TITLE
Allow install-stack.js to use 'latest'

### DIFF
--- a/scripts/install-stack.js
+++ b/scripts/install-stack.js
@@ -35,6 +35,7 @@ exec(npmCmd, (err, stdout, stderr) => {
             const packagePath = path.join(p, 'node_modules/node-red/package.json')
             const packageJSON = JSON.parse(fs.readFileSync(packagePath))
             log(`node-red@latest is currently node-red@${packageJSON.version}`)
+            log(`installed stack node-red@${packageJSON.version}`)
             const newPath = path.join(path.dirname(p), packageJSON.version)
             if (!fs.existsSync(newPath)) {
                 fs.renameSync(p, newPath)

--- a/scripts/install-stack.js
+++ b/scripts/install-stack.js
@@ -14,7 +14,7 @@ if (!vers) {
     }
 }
 
-if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/.test(vers)) {
+if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/.test(vers) && vers !== 'latest') {
     throw new Error('version not valid semantic version')
 }
 
@@ -31,6 +31,19 @@ exec(npmCmd, (err, stdout, stderr) => {
     if (err) {
         error(err)
     } else {
-        log(`installed stack node-red@${vers}`)
+        if (vers === 'latest') {
+            const packagePath = path.join(p, 'node_modules/node-red/package.json')
+            const packageJSON = JSON.parse(fs.readFileSync(packagePath))
+            log(`node-red@latest is currently node-red@${packageJSON.version}`)
+            const newPath = path.join(path.dirname(p), packageJSON.version)
+            if (!fs.existsSync(newPath)) {
+                fs.renameSync(p, newPath)
+            } else {
+                log(`node-red@${packageJSON.version} already installed`)
+                fs.rmSync(p, { recursive: true, force: true })
+            }
+        } else {
+            log(`installed stack node-red@${vers}`)
+        }
     }
 })


### PR DESCRIPTION
part of #1194

Will now take `latest` as well as a full semver.

Once installed it checks the version and renames the directory to match