### PR TITLE
Projects: Move the header to only the Overview Page

### DIFF
--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -183,8 +183,6 @@ import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
 import Alerts from '@/services/alerts'
 import Dialog from '@/services/dialog'
 
-// <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" alt="Open actions menu" :options="options" data-action="open-actions">Actions</DropdownMenu
-
 export default {
     name: 'ProjectDeployments',
     components: {

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -10,8 +10,7 @@
             </template>
             <template #tools>
                 <div class="space-x-2 flex">
-                    <!--  && !isVisitingAdmin -->
-                    <a v-if="editorAvailable" :href="project.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
+                    <a v-if="editorAvailable && !isVisitingAdmin" :href="project.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
                         Open Editor
                         <span class="ff-btn--icon ff-btn--icon-right">
                             <ExternalLinkIcon />

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -14,70 +14,40 @@
     </Teleport>
     <main>
         <ConfirmProjectDeleteDialog @confirm="deleteProject" ref="confirmProjectDeleteDialog"/>
-        <SectionTopMenu>
-            <template #hero>
-                <div class="flex-grow space-x-6 items-center inline-flex">
-                    <router-link
-                        :to="navigation[0]?.path ?? ''"
-                        class="inline-flex items-center"
-                    >
-                        <div class="text-gray-800 text-xl font-bold">
-                            {{ project.name }}
-                        </div>
-                    </router-link>
-                    <ProjectStatusBadge :status="project.meta.state" :pendingStateChange="project.pendingStateChange" v-if="project.meta" />
-                </div>
-            </template>
-            <template v-slot:tools>
-                <div class="space-x-2 flex">
-                    <a v-if="projectRunning && !isVisitingAdmin" :href="project.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
-                        Open Editor
-                        <span class="ff-btn--icon ff-btn--icon-right">
-                            <ExternalLinkIcon />
-                        </span>
-                    </a>
-                    <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" alt="Open actions menu" :options="options" data-action="open-actions">Actions</DropdownMenu>
-                </div>
-            </template>
-        </SectionTopMenu>
-        <div class="text-sm mt-4 sm:mt-8">
-            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
-                <div class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
-            </Teleport>
-            <router-view
-                :project="project"
-                :is-visiting-admin="isVisitingAdmin"
-                @projectUpdated="updateProject"
-                @project-start="startProject"
-                @project-restart="restartProject"
-                @project-suspend="showConfirmSuspendDialog"
-                @project-delete="showConfirmDeleteDialog"
-            />
-        </div>
+        <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
+            <div class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
+        </Teleport>
+        <router-view
+            :project="project"
+            :is-visiting-admin="isVisitingAdmin"
+            @projectUpdated="updateProject"
+            @project-start="startProject"
+            @project-restart="restartProject"
+            @project-suspend="showConfirmSuspendDialog"
+            @project-delete="showConfirmDeleteDialog"
+        />
     </main>
 </template>
 
 <script>
+import { Roles } from '@core/lib/roles'
+import { ChevronLeftIcon, ClockIcon, CloudIcon, CogIcon, TerminalIcon, ViewListIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
+
+import ConfirmProjectDeleteDialog from './Settings/dialogs/ConfirmProjectDeleteDialog'
+
 import projectApi from '@/api/project'
 
 import NavItem from '@/components/NavItem'
 // import SideNavigation from '@/components/SideNavigation'
 // import SideTeamSelection from '@/components/SideTeamSelection'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
-import DropdownMenu from '@/components/DropdownMenu'
-import ProjectStatusBadge from './components/ProjectStatusBadge'
-import SectionTopMenu from '@/components/SectionTopMenu'
 
-import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
+import ProjectsIcon from '@/components/icons/Projects'
 import permissionsMixin from '@/mixins/Permissions'
 
-import { ExternalLinkIcon } from '@heroicons/vue/outline'
-import ProjectsIcon from '@/components/icons/Projects'
-import { ChevronLeftIcon, CogIcon, ClockIcon, CloudIcon, TerminalIcon, ViewListIcon } from '@heroicons/vue/solid'
-import ConfirmProjectDeleteDialog from './Settings/dialogs/ConfirmProjectDeleteDialog'
-import Dialog from '@/services/dialog'
 import alerts from '@/services/alerts'
+import Dialog from '@/services/dialog'
 
 const projectTransitionStates = [
     'installing',
@@ -115,27 +85,6 @@ export default {
         },
         isLoading: function () {
             return this.loading.deleting || this.loading.suspend
-        },
-        options: function () {
-            const flowActionsDisabled = !(this.project.meta && this.project.meta.state !== 'suspended')
-
-            const result = [
-                {
-                    name: 'Start',
-                    action: this.startProject,
-                    disabled: this.project.pendingStateChange || this.projectRunning
-                },
-                { name: 'Restart', action: this.restartProject, disabled: flowActionsDisabled },
-                { name: 'Suspend', class: ['text-red-700'], action: () => { this.showConfirmSuspendDialog() }, disabled: flowActionsDisabled }
-            ]
-            if (this.hasPermission('project:delete')) {
-                result.push(null)
-                result.push({ name: 'Delete', class: ['text-red-700'], action: () => { this.showConfirmDeleteDialog() } })
-            }
-            return result
-        },
-        projectRunning () {
-            return this.project.meta?.state === 'running'
         }
     },
     watch: {
@@ -244,11 +193,7 @@ export default {
     },
     components: {
         NavItem,
-        ExternalLinkIcon,
-        DropdownMenu,
-        ProjectStatusBadge,
         SideNavigationTeamOptions,
-        SectionTopMenu,
         ConfirmProjectDeleteDialog
     }
 }

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -4,8 +4,7 @@
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigationTeamOptions>
             <template v-slot:nested-menu>
-                <div class="ff-nested-title">Project</div>
-                <!-- <div class="ff-nested-title">{{ project.name }}</div> -->
+                <div class="ff-nested-title">{{ project.name }}</div>
                 <router-link v-for="route in navigation" :key="route.label" :to="route.path">
                     <nav-item :icon="route.icon" :label="route.label" :data-nav="route.tag"></nav-item>
                 </router-link>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@fastify/csrf-protection": "^6.0.0",
         "@fastify/helmet": "^10.0.2",
         "@fastify/static": "^6.5.0",
-        "@flowforge/forge-ui-components": "^0.4.3",
+        "@flowforge/forge-ui-components": "^0.4.5",
         "@flowforge/localfs": "^1.0.0",
         "@headlessui/vue": "1.7.3",
         "@heroicons/vue": "1.0.6",

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -11,7 +11,7 @@ describe('FlowForge platform admin users', () => {
     })
 
     it('can view (and click) the "Admin Settings" in user options', () => {
-        cy.get('[data-cy="user-options"]').get('.ff-dropdown-options').should('not.exist')
+        cy.get('[data-cy="user-options"]').get('.ff-dropdown-options').should('not.be.visible')
         cy.get('[data-cy="user-options"]').click()
         cy.get('[data-cy="user-options"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-cy="user-options"] .ff-dropdown-options > .ff-dropdown-option').eq(1).contains('Admin Settings').should('be.visible')
@@ -111,7 +111,7 @@ describe('FlowForge platform non-admin users', () => {
     })
 
     it('cannot view the "Admin Settings" in user options', () => {
-        cy.get('[data-cy="user-options"]').get('.ff-dropdown-options').should('not.exist')
+        cy.get('[data-cy="user-options"]').get('.ff-dropdown-options').should('not.be.visible')
         cy.get('[data-cy="user-options"]').click()
         cy.get('[data-cy="user-options"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-cy="user-options"] .ff-dropdown-options > .ff-dropdown-option').eq(1).contains('Admin Settings').should('not.exist')


### PR DESCRIPTION
Fixes https://github.com/flowforge/flowforge/issues/1235

### Simplified version on overview page
<img width="1540" alt="Screenshot 2022-11-17 at 14 46 56" src="https://user-images.githubusercontent.com/507155/202450427-993407b1-dbde-44ac-9c4e-bcd3fbd5f585.png">

### All other pages have no header
<img width="1549" alt="Screenshot 2022-11-17 at 14 47 03" src="https://user-images.githubusercontent.com/507155/202450447-b1444d05-380f-4295-a9dc-9b5b1afa9610.png">
<img width="1536" alt="Screenshot 2022-11-17 at 14 47 11" src="https://user-images.githubusercontent.com/507155/202450453-b443c530-57b5-4944-883f-dde3519c1f0c.png">
