### PR TITLE
Plumb in fileStore for file-server & nr-file-nodes

### DIFF
--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -66,6 +66,15 @@ driver:
   ## External url used by devices to connect to the broker, if different
   # public_url: ws://localhost:4881
 
+
+#################################################
+# File Server config                            #
+#################################################
+
+fileStore:
+  url: http://localhost:3001
+
+
 #################################################
 # Email Configuration                           #
 #################################################

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -699,6 +699,7 @@ module.exports = async function (app) {
         settings.env = settings.env || {}
         settings.baseURL = request.project.url
         settings.forgeURL = app.config.base_url
+        settings.fileStore = app.config.fileStore ? { ...app.config.fileStore } : null
         settings.teamID = request.project.Team.hashid
         settings.storageURL = request.project.storageURL
         settings.auditURL = request.project.auditURL


### PR DESCRIPTION
part of #998

Introduces a section in the yml file `fileStore` for the URL (and future settings) - consumed by 
@flowforge/nr-file-nodes and @flowforge/file-storage