### PR TITLE
Allow snapshots to be created with api provided flows/credentials

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -185,12 +185,17 @@ module.exports = {
     },
 
     /**
-     * Takes a credentials object and re-encrypts it with a new key
+     * Takes a credentials object and re-encrypts it with a new key.
+     * If oldKey is blank or undefined, it assumes the credentials object is
+     * unencrypted at this point and only needs to be re-encrypted
      */
     exportCredentials: function (app, original, oldKey, newKey) {
+        if (oldKey) {
+            const oldHash = crypto.createHash('sha256').update(oldKey).digest()
+            original = decryptCreds(oldHash, original)
+        }
         const newHash = crypto.createHash('sha256').update(newKey).digest()
-        const oldHash = crypto.createHash('sha256').update(oldKey).digest()
-        return encryptCreds(newHash, decryptCreds(oldHash, original))
+        return encryptCreds(newHash, original)
     },
 
     /**

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -89,14 +89,10 @@ module.exports = async function (app) {
     app.post('/', {
         preHandler: app.needsPermission('project:snapshot:create')
     }, async (request, reply) => {
-        // TODO: permission check
         const snapShot = await app.db.controllers.ProjectSnapshot.createSnapshot(
             request.project,
             request.session.User,
-            {
-                name: request.body.name || '',
-                description: request.body.description || ''
-            }
+            request.body
         )
         snapShot.User = request.session.User
         await app.db.controllers.AuditLog.projectLog(

--- a/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
+++ b/test/unit/forge/db/controllers/ProjectSnapshot_spec.js
@@ -1,0 +1,113 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+const crypto = require('crypto')
+// const FF_UTIL = require('flowforge-test-utils')
+// const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+function decryptCreds (key, cipher) {
+    let flows = cipher.$
+    const initVector = Buffer.from(flows.substring(0, 32), 'hex')
+    flows = flows.substring(32)
+    const decipher = crypto.createDecipheriv('aes-256-ctr', key, initVector)
+    const decrypted = decipher.update(flows, 'base64', 'utf8') + decipher.final('utf8')
+    return JSON.parse(decrypted)
+}
+
+describe('ProjectSnapshot controller', function () {
+    // Use standard test data.
+    let app
+    beforeEach(async function () {
+        app = await setup()
+    })
+
+    afterEach(async function () {
+        await app.close()
+    })
+
+    describe('createSnapshot', function () {
+        async function createProject () {
+            let project = await app.db.models.Project.create({ name: 'project1', type: '', url: '' })
+            await project.updateSetting('credentialSecret', crypto.randomBytes(32).toString('hex'))
+            // Reload to ensure all models are attached
+            project = await app.db.models.Project.byId(project.id)
+            await app.db.models.StorageFlow.create({
+                flow: JSON.stringify([{ id: '123', type: 'node' }]),
+                ProjectId: project.id
+            })
+            await app.db.models.StorageCredentials.create({
+                credentials: JSON.stringify({}),
+                ProjectId: project.id
+            })
+            await app.db.models.StorageSettings.create({
+                settings: JSON.stringify({}),
+                ProjectId: project.id
+            })
+            await app.db.models.StorageSession.create({
+                sessions: JSON.stringify({}),
+                ProjectId: project.id
+            })
+            return project
+        }
+        it('creates a snapshot of the current project state', async function () {
+            const project = await createProject()
+            const user = await app.db.models.User.byUsername('alice')
+            const options = {
+                name: 'snapshot1',
+                description: 'a snapshot'
+            }
+            const snapshot = await app.db.controllers.ProjectSnapshot.createSnapshot(project, user, options)
+            snapshot.should.have.property('id', 1)
+            snapshot.should.have.property('name', 'snapshot1')
+            snapshot.should.have.property('description', 'a snapshot')
+            snapshot.should.have.property('description', 'a snapshot')
+            snapshot.should.have.property('settings')
+            // Ensure modules is empty as none has been provided
+            snapshot.settings.should.have.only.keys('settings', 'env', 'modules')
+            snapshot.settings.modules.should.have.only.keys()
+            snapshot.should.have.property('flows')
+            snapshot.flows.should.have.only.keys('flows', 'credentials')
+            snapshot.flows.flows.should.have.length(1)
+            snapshot.flows.flows[0].should.have.property('id', '123')
+        })
+
+        it('creates a snapshot using the provided flows/creds/modules', async function () {
+            const project = await createProject()
+            const credSecret = await project.getCredentialSecret()
+            const user = await app.db.models.User.byUsername('alice')
+            const options = {
+                name: 'snapshot1',
+                description: 'a snapshot',
+                flows: [{ id: '456', type: 'newNode' }],
+                credentials: { 456: { a: 'b' } },
+                settings: {
+                    modules: {
+                        foo: '1.2.3'
+                    }
+                }
+            }
+            const snapshot = await app.db.controllers.ProjectSnapshot.createSnapshot(project, user, options)
+            snapshot.should.have.property('id', 1)
+            snapshot.should.have.property('name', 'snapshot1')
+            snapshot.should.have.property('description', 'a snapshot')
+            snapshot.should.have.property('description', 'a snapshot')
+            snapshot.should.have.property('settings')
+            // Ensure modules includes those provided
+            snapshot.settings.should.have.only.keys('settings', 'env', 'modules')
+            snapshot.settings.modules.should.have.only.keys('foo')
+
+            snapshot.should.have.property('flows')
+            snapshot.flows.should.have.only.keys('flows', 'credentials')
+            snapshot.flows.flows.should.have.length(1)
+            snapshot.flows.flows[0].should.have.property('id', '456')
+            snapshot.flows.credentials.should.have.only.keys('$')
+            const keyHash = crypto.createHash('sha256').update(credSecret).digest()
+            const creds = decryptCreds(keyHash, snapshot.flows.credentials)
+            creds.should.have.only.keys('456')
+        })
+    })
+    // describe('exportProject', function () {
+    //     it('', async function () {
+    //         //
+    //     })
+    // })
+})

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -1,5 +1,6 @@
 const should = require('should') // eslint-disable-line
 const setup = require('../setup')
+const crypto = require('crypto')
 // const FF_UTIL = require('flowforge-test-utils')
 // const { Roles } = FF_UTIL.require('forge/lib/roles')
 
@@ -201,6 +202,54 @@ describe('Project controller', function () {
             // 'upgraded-module' upgraded
             updatedSettings.palette.modules[2].should.have.property('name', 'upgraded-module')
             updatedSettings.palette.modules[2].should.have.property('version', '~2')
+        })
+    })
+
+    describe('exportCredentials', function () {
+        function decryptCreds (key, cipher) {
+            let flows = cipher.$
+            const initVector = Buffer.from(flows.substring(0, 32), 'hex')
+            flows = flows.substring(32)
+            const decipher = crypto.createDecipheriv('aes-256-ctr', key, initVector)
+            const decrypted = decipher.update(flows, 'base64', 'utf8') + decipher.final('utf8')
+            return JSON.parse(decrypted)
+        }
+
+        function encryptCreds (key, plain) {
+            const initVector = crypto.randomBytes(16)
+            const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
+            return { $: initVector.toString('hex') + cipher.update(JSON.stringify(plain), 'utf8', 'base64') + cipher.final('base64') }
+        }
+
+        it('re-encrypts credentials from old to new key', function () {
+            const oldKey = 'oldkey'
+            const oldHash = crypto.createHash('sha256').update(oldKey).digest()
+            const newKey = 'newkey'
+            const newHash = crypto.createHash('sha256').update(newKey).digest()
+
+            const credentials = { foo: { a: 'b' } }
+            const encrypted = encryptCreds(oldHash, credentials)
+
+            const result = app.db.controllers.Project.exportCredentials(encrypted, oldKey, newKey)
+
+            result.should.only.have.keys('$')
+            ;(typeof result.$).should.equal('string')
+
+            const decrypted = decryptCreds(newHash, result)
+            decrypted.should.only.have.keys('foo')
+        })
+        it('encrypts credentials when no old key provided', function () {
+            const newKey = 'newkey'
+            const newHash = crypto.createHash('sha256').update(newKey).digest()
+
+            const credentials = { foo: { a: 'b' } }
+            const result = app.db.controllers.Project.exportCredentials(credentials, null, newKey)
+
+            result.should.only.have.keys('$')
+            ;(typeof result.$).should.equal('string')
+
+            const decrypted = decryptCreds(newHash, result)
+            decrypted.should.only.have.keys('foo')
         })
     })
     // describe('exportProject', function () {


### PR DESCRIPTION
This updates the `POST /api/v1/projects/:id/snapshots` endpoint to allow the request to include flows, credentials and list of modules - rather than pulling the current values from active project.

This allows a snapshot to be created outside of the platform and pushed in.

Notes:

 - if `credentials` are encrypted, the payload must include `credentialSecret` so they can be decrypted and reencrypted with the projects own key. Otherwise they must be posted unencrypted.
 - The snapshot will still include the current project settings, include env values. In other words, it isn't possible, with the work in this PR, to customise the env vars included in the snapshot. That may come in a future iteration.
