### PR TITLE
Allow user to enter tax info when setting up stripe billing

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -59,6 +59,9 @@ module.exports.init = async function (app) {
                         team: team.hashid
                     }
                 },
+                tax_id_collection: {
+                    enabled: true
+                },
                 client_reference_id: team.hashid,
                 payment_method_types: ['card'],
                 success_url: `${app.config.base_url}/team/${team.slug}/overview?billing_session={CHECKOUT_SESSION_ID}`,


### PR DESCRIPTION
Closes #1230

When setting up stripe billing, this allows the user to enter tax details:

![](https://user-images.githubusercontent.com/51083/202183248-6966f94f-d533-4c3b-af5e-1cb463324212.png)

When accessing the stripe dashboard for their account, the tax information is available:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/51083/203036499-2f5af84f-68a7-473c-b822-0682f61872b2.png">
