### PR TITLE
docs: How to secure Node-RED pages (backport)

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -20,6 +20,7 @@ For more details on these and other core concepts, you can learn about them [her
  - [Change Project Stack](changestack.md) - How to change a projects stack, for example to upgrade Node-RED
  - [Logs](logs.md) - The Logs available in the FlowForge application.
  - [Project Link Nodes](projectnodes.md) - Custom nodes for sending messages between projects and devices.
+ - [Project Settings](project-settings.md) - Settings available for projects
 
 ## Working with Teams
 

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -1,0 +1,9 @@
+# Project Settings
+
+## HTTP Nodes
+
+The HTTP Endpoints served by the Node-RED runtime, except the editor, are by
+default accessable anywhere in the world. When building a dashboard for example
+this might not be intended. Pages like these can be secured using HTTP Basic
+Auth. A username and password combination can be added in a projects settings
+in the `Editor` tab.


### PR DESCRIPTION
Backport of https://github.com/flowforge/flowforge/pull/1266

---

FlowForge allows pages to be secured with HTTP Basic Auth, but this wasn't documented. This change adds documentation.
