### PR TITLE
Add gh action to backport any pr labeled backport

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+
+function usage() {
+   echo "Backport a PR to the `maintenance` branch, via a new PR"
+   echo
+   echo "USAGE"
+   echo "  backport <#PR>"
+   echo
+   echo "ARGS"
+   echo "  #PR: The PR number to backport"
+   echo
+   exit 1
+}
+
+if [ -z $1 ]
+then
+    usage
+fi
+
+CURRENT_BRANCH=`git branch --show-current`
+TARGET_BRANCH=maintenance
+
+PR=$1
+PR_BRANCH=backport-$PR
+
+if git show-ref --quiet refs/heads/$PR_BRANCH; then
+    echo " - Branch '$PR_BRANCH' already exists - aborting"
+    exit 1
+fi
+
+PR_DETAILS=`gh pr view $PR --json title,url,body,commits 2>/dev/null` 
+if [ $? -ne 0 ]
+then
+    echo " - PR #$PR not found - aborting"
+    exit 1
+fi  
+
+PR_TITLE=`printf '%s' "$PR_DETAILS" | jq -c .title | sed -e 's/^"//' -e 's/"$//'`
+PR_BODY=`printf '%s' "$PR_DETAILS" | jq -c .body | sed -e 's/^"//' -e 's/"$//'`
+PR_URL=`printf '%s' "$PR_DETAILS" | jq -c .url | sed -e 's/^"//' -e 's/"$//'`
+PR_COMMITS=`printf '%s' "$PR_DETAILS" | jq -c '.commits[].oid' | sed -e 's/"//g'`
+
+git checkout $TARGET_BRANCH
+git checkout -b $PR_BRANCH
+
+for x in $PR_COMMITS
+do
+   git cherry-pick $x
+done
+
+git push origin $PR_BRANCH
+
+cat <<EOT > $PR_BRANCH".txt"
+Backport of $PR_URL
+
+---
+
+$PR_BODY
+EOT
+
+gh pr create --title "$PR_TITLE (backport #$PR)" -F $PR_BRANCH".txt" -H $PR_BRANCH -B $TARGET_BRANCH
+
+rm $PR_BRANCH".txt"
+
+git checkout $CURRENT_BRANCH

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,19 @@
+name: Backport to maintenance
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'backport')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: .github/scripts/backport.sh $PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Part of #1200 

This adds an action that is triggered whenever a PR is closed or labeled.

If the PR is confirmed to have been merged and has the `backport` label applied, the script will:

 - create a branch called `backport-<#pr>` based on the `maintenance` branch (which I've just created based on `1.x-maint`, our current maintenance branch that will get retired via #1200)
 - cherry-pick the commits from the PR to that branch
 - pushed the branch to origin and creates a PR

The PR title is a copy of the original PR title with (`backport <#pr>`) appended. This ensures the generated changelog is meaningful.

The body of the PR includes a link back to the original PR, plus the body of the original PR.

It *should* get triggered if an already merged PR is retrospectively labelled with `backport`.

Note I have tested the `backport.sh` script locally (see https://github.com/flowforge/flowforge/pull/1271 as an example). But it's hard to do the last mile integration of a GitHub Action without actually doing it. So this PR is that attempt to see if I've got the action right.

Given the action won't do anything until a PR is merged, we'll need to get this PR merged and then I can test be adding `backport` to a suitable candidate PR.