### PR TITLE
Fixup backport action

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 function usage() {

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: .github/scripts/backport.sh $PR
+      - run: ./.github/scripts/backport.sh $PR
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Having done some iterations on a personal repo, I think I've got this working.

Fixes included:
 - ensure the right shell is used to run the script
 - ensure script is executable

With that done, in my personal repo, the action runs when:
 - PR merges with 'backport' label already applied
 - The 'backport' label is applied to an already merged PR
