### PR TITLE
Move linux service start instructions

### DIFF
--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -132,16 +132,18 @@ To run it manually, you can use:
     /opt/flowforge/bin/flowforge.sh
     ```
 
-    If you selected to install as service on Linux then you can use:
-    ```
-    service flowforge start
-    ```
-
  - Windows:
     ```
     c:\flowforge\bin\flowforge.bat
     ```
 
+Or to run as a service:
+
+ - Linux
+ 
+    ```
+    service flowforge start
+    ```
 ## First Run Setup
 
 Once FlowForge is started, you can access the platform in your browser at [http://localhost:3000](http://localhost:3000).

--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -125,17 +125,16 @@ For more information on all of the options available, see the [configuration gui
 
 ## Running FlowForge
 
-If you have installed FlowForge as a service, it can be started by running:
-
-```
-service flowforge start
-```
-
 To run it manually, you can use:
 
  - Linux/MacOS:
     ```
     /opt/flowforge/bin/flowforge.sh
+    ```
+
+    If you selected to install as service on Linux then you can use:
+    ```
+    service flowforge start
     ```
 
  - Windows:


### PR DESCRIPTION
setting up the service is a question asked by the linux install.sh which is why it's not mentioned anywhere else in the docs