### PR TITLE
Improve logging of setup process

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -48,6 +48,18 @@ const forge = require('./forge')
                 console.error(err)
                 process.exit(1)
             }
+
+            if (!server.settings.get('setup:initialised')) {
+                server.log.info('****************************************************')
+                server.log.info('* To finish setting up FlowForge, open this url:   *')
+                server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
+                server.log.info('****************************************************')
+            } else {
+                server.log.info('****************************************************')
+                server.log.info('* FlowForge is now running and can be accessed at: *')
+                server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
+                server.log.info('****************************************************')
+            }
         })
     } catch (err) {
         console.error(err)

--- a/forge/app.js
+++ b/forge/app.js
@@ -50,9 +50,10 @@ const forge = require('./forge')
             }
 
             if (!server.settings.get('setup:initialised')) {
+                const setupURL = server.config.base_url.replace(/\/$/, '') + '/setup'
                 server.log.info('****************************************************')
                 server.log.info('* To finish setting up FlowForge, open this url:   *')
-                server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
+                server.log.info(`*   ${setupURL.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
             } else {
                 server.log.info('****************************************************')

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -53,10 +53,16 @@ module.exports = async function (app) {
                 }
             })
             const projectType = await app.db.controllers.ProjectType.createDefaultProjectType()
+            app.log.info('[SETUP] Created default ProjectType')
             await app.db.controllers.ProjectTemplate.createDefaultTemplate(adminUser)
+            app.log.info('[SETUP] Created default ProjectTemplate')
             await app.db.controllers.ProjectStack.createDefaultProjectStack(projectType)
-
+            app.log.info('[SETUP] Created default ProjectStack')
             await app.settings.set('setup:initialised', true)
+            app.log.info('****************************************************')
+            app.log.info('* FlowForge setup is complete. You can login at:   *')
+            app.log.info(`*   ${app.config.base_url.padEnd(47, ' ')}*`)
+            app.log.info('****************************************************')
             reply.send({ status: 'okay' })
         } catch (err) {
             app.log.error(`Failed to create default ProjectStack: ${err.toString()}`)
@@ -99,6 +105,7 @@ module.exports = async function (app) {
                 password: request.body.password,
                 admin: true
             })
+            app.log.info(`[SETUP] Created admin user ${request.body.username}`)
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage
@@ -128,6 +135,7 @@ module.exports = async function (app) {
         }
         try {
             await app.license.apply(request.body.license)
+            app.log.info('[SETUP] Applied license')
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage = err.toString()
@@ -156,6 +164,7 @@ module.exports = async function (app) {
         }
         try {
             await app.settings.set('telemetry:enabled', request.body.telemetry)
+            app.log.info('[SETUP] Applied settings')
             reply.send({ status: 'okay' })
         } catch (err) {
             console.log(err)


### PR DESCRIPTION
Currently fastify logs the interfaces it is listening on. This can be confusing as it might not be a suitable url for navigating to.

Whilst those logs lines do serve a purpose, this PR adds additional logging to make it clearer where the user should go.


For an already configured FF instance:

```
[2022-11-22T17:13:21.337Z] INFO: Server listening at http://127.0.0.1:3000/
[2022-11-22T17:13:21.340Z] INFO: Server listening at http://[::1]:3000
[2022-11-22T17:13:21.341Z] INFO: ****************************************************
[2022-11-22T17:13:21.341Z] INFO: * FlowForge is now running and can be accessed at: *
[2022-11-22T17:13:21.341Z] INFO: *   http://localhost:3000/                         *
[2022-11-22T17:13:21.341Z] INFO: ****************************************************
```

For a new instance that needs to go through setup:

```
[2022-11-22T17:27:01.951Z] INFO: ****************************************************
[2022-11-22T17:27:01.952Z] INFO: * To finish setting up FlowForge, open this url:   *
[2022-11-22T17:27:01.952Z] INFO: *   http://localhost:3000/                         *
[2022-11-22T17:27:01.952Z] INFO: ****************************************************
```

This also adds more logging as the setup process is stepped through:
```
[2022-11-22T17:27:21.720Z] INFO: [SETUP] Created admin user nick
[2022-11-22T17:27:25.926Z] INFO: [SETUP] Applied settings
[2022-11-22T17:27:30.278Z] INFO: [SETUP] Created default ProjectType
[2022-11-22T17:27:30.294Z] INFO: [SETUP] Created default ProjectTemplate
[2022-11-22T17:27:30.311Z] INFO: [SETUP] Created default ProjectStack
[2022-11-22T17:27:30.316Z] INFO: ****************************************************
[2022-11-22T17:27:30.316Z] INFO: * FlowForge setup is complete. You can login at:   *
[2022-11-22T17:27:30.316Z] INFO: *   http://localhost:3000/                         *
[2022-11-22T17:27:30.316Z] INFO: ****************************************************
```

