### PR TITLE
Change default obj names

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -48,6 +48,18 @@ const forge = require('./forge')
                 console.error(err)
                 process.exit(1)
             }
+
+            if (!server.settings.get('setup:initialised')) {
+                server.log.info('****************************************************')
+                server.log.info('* To finish setting up FlowForge, open this url:   *')
+                server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
+                server.log.info('****************************************************')
+            } else {
+                server.log.info('****************************************************')
+                server.log.info('* FlowForge is now running and can be accessed at: *')
+                server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
+                server.log.info('****************************************************')
+            }
         })
     } catch (err) {
         console.error(err)

--- a/forge/app.js
+++ b/forge/app.js
@@ -50,9 +50,10 @@ const forge = require('./forge')
             }
 
             if (!server.settings.get('setup:initialised')) {
+                const setupURL = server.config.base_url.replace(/\/$/, '') + '/setup'
                 server.log.info('****************************************************')
                 server.log.info('* To finish setting up FlowForge, open this url:   *')
-                server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
+                server.log.info(`*   ${setupURL.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
             } else {
                 server.log.info('****************************************************')

--- a/forge/db/controllers/ProjectStack.js
+++ b/forge/db/controllers/ProjectStack.js
@@ -1,9 +1,16 @@
 module.exports = {
     createDefaultProjectStack: async function (app, projectType) {
         const properties = app.containers.getDefaultStackProperties()
+        console.log(properties)
+        let name = 'Default'
+        let label = 'Default'
+        if (properties.nodered) {
+            label = `Node-RED ${properties.nodered}`
+            name = label.toLowerCase().replace(/[ .]/g, '-')
+        }
         const stack = await app.db.models.ProjectStack.create({
-            name: 'default',
-            label: 'default',
+            name,
+            label,
             active: true,
             order: 1,
             description: '',

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -191,7 +191,7 @@ module.exports = {
             setTemplateValue(policy, name, defaultTemplatePolicy[name])
         })
         const template = await app.db.models.ProjectTemplate.create({
-            name: 'default',
+            name: 'Default',
             active: true,
             settings,
             policy

--- a/forge/db/controllers/ProjectType.js
+++ b/forge/db/controllers/ProjectType.js
@@ -1,7 +1,7 @@
 module.exports = {
     createDefaultProjectType: async function (app) {
         return await app.db.models.ProjectType.create({
-            name: 'default',
+            name: 'Default',
             active: true,
             order: 1,
             description: '',

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -53,10 +53,16 @@ module.exports = async function (app) {
                 }
             })
             const projectType = await app.db.controllers.ProjectType.createDefaultProjectType()
+            app.log.info('[SETUP] Created default ProjectType')
             await app.db.controllers.ProjectTemplate.createDefaultTemplate(adminUser)
+            app.log.info('[SETUP] Created default ProjectTemplate')
             await app.db.controllers.ProjectStack.createDefaultProjectStack(projectType)
-
+            app.log.info('[SETUP] Created default ProjectStack')
             await app.settings.set('setup:initialised', true)
+            app.log.info('****************************************************')
+            app.log.info('* FlowForge setup is complete. You can login at:   *')
+            app.log.info(`*   ${app.config.base_url.padEnd(47, ' ')}*`)
+            app.log.info('****************************************************')
             reply.send({ status: 'okay' })
         } catch (err) {
             app.log.error(`Failed to create default ProjectStack: ${err.toString()}`)
@@ -99,6 +105,7 @@ module.exports = async function (app) {
                 password: request.body.password,
                 admin: true
             })
+            app.log.info(`[SETUP] Created admin user ${request.body.username}`)
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage
@@ -128,6 +135,7 @@ module.exports = async function (app) {
         }
         try {
             await app.license.apply(request.body.license)
+            app.log.info('[SETUP] Applied license')
             reply.send({ status: 'okay' })
         } catch (err) {
             let responseMessage = err.toString()
@@ -156,6 +164,7 @@ module.exports = async function (app) {
         }
         try {
             await app.settings.set('telemetry:enabled', request.body.telemetry)
+            app.log.info('[SETUP] Applied settings')
             reply.send({ status: 'okay' })
         } catch (err) {
             console.log(err)


### PR DESCRIPTION
(this branches off #1284 so includes its commits...)

This changes the names/labels of the default ProjectType, Stack and Template from `default` to `Default`.

In the case of Stack, *if* the driver properties include `nodered` (ie localfs), we set the label to `Node-RED x.y.z` where `x.y.z` is the value of `nodered`. The name of the stack is that with spaces and `.` replace with `-`.

This is much more useful for users:

<img width="247" alt="image" src="https://user-images.githubusercontent.com/51083/203385559-61e75caf-85ea-4d49-86d0-a7672db0570e.png">

(ignore version `9.9.9`... was testing something ...)

