### PR TITLE
Allow email transport to retry connection without having to restart the platform

### DIFF
--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -27,7 +27,7 @@ module.exports = fp(async function (app, _opts, next) {
                         }
                     })
                 } else {
-                    clearTimeout(poStartupCheck)
+                    clearInterval(poStartupCheck)
                 }
             }, 1000 * 60 * 5) // check every 5 minutes until successful
         }

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -134,7 +134,7 @@ module.exports = fp(async function (app, _opts, next) {
                 })
             }
         }
-        if (isConfigured && app.config.email.debug) {
+        if (app.config.email.debug) {
             app.log.info(`
 -----------------------------------
 to: ${mail.to}

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -23,7 +23,7 @@ module.exports = fp(async function (app, _opts, next) {
                 if (notReady) {
                     init(true, (err, success) => {
                         if (!err && success) {
-                            clearTimeout(poStartupCheck)
+                            clearInerval(poStartupCheck)
                         }
                     })
                 } else {

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -23,7 +23,7 @@ module.exports = fp(async function (app, _opts, next) {
                 if (notReady) {
                     init(true, (err, success) => {
                         if (!err && success) {
-                            clearInerval(poStartupCheck)
+                            clearInterval(poStartupCheck)
                         }
                     })
                 } else {

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -51,6 +51,7 @@ module.exports = fp(async function (app, _opts, next) {
                         app.log.error('Failed to verify email connection: %s', err.toString())
                         EMAIL_ENABLED = false
                     } else {
+                        app.log.info('Connected to SMTP server')
                         EMAIL_ENABLED = true
                     }
                     callback && callback(err, EMAIL_ENABLED)
@@ -86,6 +87,7 @@ module.exports = fp(async function (app, _opts, next) {
                         app.log.error('Failed to verify email connection: %s', err.toString())
                         EMAIL_ENABLED = false
                     } else {
+                        app.log.info('Connected to AWS SES')
                         EMAIL_ENABLED = true
                     }
                     callback && callback(err, EMAIL_ENABLED)


### PR DESCRIPTION
closes #1159

In a nutshell, 

This PR only concerns itself with retrying the email transport initialisation IF it is enabled and configured but failed to connect.

It does not attempt to reconnect if a transport failure occurs later.

Currently, the retry is hard coded at 5min. We may wish to expose this in the config yml.

