### PR TITLE
Fix backport action to checkout full branch history

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - run: ./.github/scripts/backport.sh $PR
         shell: bash
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -18,3 +20,10 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: Resync Maintenance:
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run:
+          git checkout maintenance
+          git reset --hard main
+          git push --force origin maintenance
+


### PR DESCRIPTION
The backport action failed because it couldn't find the `maintenance` branch. This is because, by default, the checkout action only grabs the pr branch history.

By setting `fetch-depth` to `0`, it grabs the full git history so we can access the maintenance branch.

In addition, this updates the release-publish action to force push `main` to `maintenance` if the release is published on `main`.