### PR TITLE
Remove ff:tooltip from Snapshot component

### DIFF
--- a/frontend/src/pages/project/components/cells/Snapshot.vue
+++ b/frontend/src/pages/project/components/cells/Snapshot.vue
@@ -3,7 +3,6 @@
         <span
             v-if="activeSnapshot?.id || updateNeeded"
             class="flex items-center space-x-2 text-gray-500 italic"
-            v-ff-tooltip:left="'Target snapshot has not yet been deployed to this device.'"
         >
             <ExclamationIcon
                 v-if="updateNeeded"


### PR DESCRIPTION
Fixes #1302

Tracked down the cause of the hanging UI to be related to the new tooltip directive on the containing span.

Removing the tooltip to get it working.