### PR TITLE
Fix resync-maintenance action

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Resync Maintenance
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ endsWith(github.ref, '.0') }}
         run:
           git checkout maintenance
           git reset --hard main


### PR DESCRIPTION
Fixes #1313 

Having debugged the issue in a personal repo, the problem was due to the event type we use to trigger the release publish action - `on.push.tags`. For that event type, `github.ref` is set to the **tag** that was pushed - ie `refs/tags/v1.1.0`, not the branch it was created from. Having explored the available properties available in the `github` context object, we don't any way of knowing this tag was created from the `main` branch.

One option would be to change the event trigger to `release.created` - but I'm wary of changing something that works for everything else we need.

Instead, the fix I've gone with, is to change the logic to only do the resync if the tag ends with `.0` - that is what all of our main releases will have. Any maintenance release will have a non-zero last digit so can be ignored.

This has been tested and proven to work in a personal repo here: https://github.com/knolleary/docs-workflow-test-repo/actions. At the time of writing, the last three action runs are for three different tags - `v1.1.1`, `v1.2.3`,  `v2.3.0`. If you click into the run logs, you'll see the first two have skipped the `Log github.ref` step, but the `v2.3.0` run has run that step.


