### PR TITLE
Remove old style audit log entries

### DIFF
--- a/forge/auditLog/project.js
+++ b/forge/auditLog/project.js
@@ -13,6 +13,9 @@ module.exports = {
             async started (actionedBy, error, project) {
                 await log('project.started', actionedBy, project?.id, generateBody({ error, project }))
             },
+            async startFailed (actionedBy, error, project) {
+                await log('project.start-failed', actionedBy || 0, project?.id, generateBody({ error }))
+            },
             async stopped (actionedBy, error, project) {
                 await log('project.stopped', actionedBy, project?.id, generateBody({ error, project }))
             },

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -47,7 +47,7 @@ module.exports = {
                     stack: err.stack
                 }
                 this._app.log.error(errorDetail.error)
-                await this._app.AuditLog.Project.project.startFailed(0 /* system */, errorDetail)
+                await this._app.auditLog.Project.project.startFailed(0 /* system */, errorDetail, project)
 
                 // Update the project state to suspended
                 project.state = 'suspended'

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -221,12 +221,6 @@ module.exports = async function (app) {
 
                     sendDeviceUpdate = true
                     await app.auditLog.Team.team.device.assigned(request.session.User, null, request.device.Team, project, request.device)
-                    await app.db.controllers.AuditLog.projectLog(
-                        project.id,
-                        request.session.User.id,
-                        'project.device.assigned',
-                        { id: request.device.hashid }
-                    )
                     await app.auditLog.Project.project.device.assigned(request.session.User, null, project, request.device)
                 }
             }

--- a/test/unit/forge/auditLog/project_spec.js
+++ b/test/unit/forge/auditLog/project_spec.js
@@ -100,6 +100,19 @@ describe('Audit Log > Project', async function () {
         logEntry.body.project.id.should.equal(PROJECT.id)
     })
 
+    it('Provides a logger for project start failure', async function () {
+        await projectLogger.project.startFailed(ACTIONED_BY, { code: 'something_happened', message: 'Project start failed' }, PROJECT)
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'project.start-failed')
+        logEntry.should.have.property('scope', { id: PROJECT.id, type: 'project' })
+        logEntry.should.have.property('trigger', { id: ACTIONED_BY.hashid, type: 'user', name: ACTIONED_BY.username })
+        logEntry.should.have.property('body')
+        logEntry.body.should.only.have.keys('error')
+        logEntry.body.error.code.should.equal('something_happened')
+        logEntry.body.error.message.should.equal('Project start failed')
+    })
+
     it('Provides a logger for stopping a project', async function () {
         await projectLogger.project.stopped(ACTIONED_BY, null, PROJECT)
         // check log stored


### PR DESCRIPTION
fixes #1316

1. Removes a duplicate audit log entry from project scope 
   1. Event 'project.device.assigned' in `forge/routes/api/device.js` had both old and new style logging
2. Replaces an old style audit log entry with new encapsulated function call
   1. Adds `project.startFailed` to `forge\auditLog\project.js`
   2. Replaces old style log entry in `forge/containers/wrapper.js` with a simple call to `project.startFailed()` 
   3. Adds new test case 'Provides a logger for project start failure' in `test/unit/forge/auditLog/project_spec.js`
