### PR TITLE
Ensure "non user" triggering an auditlog entry is logged correctly

### DIFF
--- a/forge/auditLog/platform.js
+++ b/forge/auditLog/platform.js
@@ -47,8 +47,17 @@ module.exports = {
         }
 
         const log = async (event, actionedBy, body) => {
-            const trigger = triggerObject(actionedBy)
-            await app.db.controllers.AuditLog.platformLog(trigger.id, event, body)
+            try {
+                const trigger = triggerObject(actionedBy)
+                let whoDidIt = trigger?.id
+                if (typeof whoDidIt !== 'number' || whoDidIt <= 0) {
+                    whoDidIt = null
+                    body.trigger = trigger
+                }
+                await app.db.controllers.AuditLog.platformLog(whoDidIt, event, body)
+            } catch (error) {
+                console.warn('Failed to log platform scope audit event', event, error)
+            }
         }
         return {
             platform

--- a/forge/auditLog/project.js
+++ b/forge/auditLog/project.js
@@ -60,8 +60,17 @@ module.exports = {
         }
 
         const log = async (event, actionedBy, projectId, body) => {
-            const trigger = triggerObject(actionedBy)
-            await app.db.controllers.AuditLog.projectLog(projectId, trigger.id, event, body)
+            try {
+                const trigger = triggerObject(actionedBy)
+                let whoDidIt = trigger.id
+                if (typeof trigger.id !== 'number' || trigger.id <= 0) {
+                    whoDidIt = null
+                    body.trigger = trigger
+                }
+                await app.db.controllers.AuditLog.projectLog(projectId, whoDidIt, event, body)
+            } catch (error) {
+                console.warn('Failed to log project scope audit event', event, error)
+            }
         }
         return {
             project

--- a/forge/auditLog/team.js
+++ b/forge/auditLog/team.js
@@ -101,15 +101,18 @@ module.exports = {
         }
 
         const log = async (event, actionedBy, teamId, body) => {
-            const trigger = triggerObject(actionedBy)
-            if (typeof trigger?.id === 'number' && trigger?.id <= 0) {
-                body.trigger = trigger // store trigger in body since it's not a real user
-                await app.db.controllers.AuditLog.teamLog(teamId, null, event, body)
-            } else {
-                await app.db.controllers.AuditLog.teamLog(teamId, trigger.id, event, body)
+            try {
+                const trigger = triggerObject(actionedBy)
+                let whoDidIt = trigger?.id
+                if (typeof whoDidIt !== 'number' || whoDidIt <= 0) {
+                    whoDidIt = null
+                    body.trigger = trigger
+                }
+                await app.db.controllers.AuditLog.teamLog(teamId, whoDidIt, event, body)
+            } catch (error) {
+                console.warn('Failed to log team scope audit event', event, error)
             }
         }
-
         return {
             team,
             project,

--- a/forge/auditLog/user.js
+++ b/forge/auditLog/user.js
@@ -82,13 +82,31 @@ module.exports = {
 
         // log as operation on self
         const log = async (event, actionedBy, body) => {
-            const trigger = triggerObject(actionedBy)
-            await app.db.controllers.AuditLog.userLog(trigger.id, event, body, trigger.id)
+            try {
+                const trigger = triggerObject(actionedBy)
+                let whoDidIt = trigger?.id
+                if (typeof whoDidIt !== 'number' || whoDidIt <= 0) {
+                    whoDidIt = null
+                    body.trigger = trigger
+                }
+                await app.db.controllers.AuditLog.userLog(whoDidIt, event, body, whoDidIt)
+            } catch (error) {
+                console.warn('Failed to log user scope audit event', event, error)
+            }
         }
         // log as operation on another entity
         const logUser = async (event, actionedBy, body, entityId) => {
-            const trigger = triggerObject(actionedBy)
-            await app.db.controllers.AuditLog.userLog(trigger.id, event, body, entityId)
+            try {
+                const trigger = triggerObject(actionedBy)
+                let whoDidIt = trigger?.id
+                if (typeof whoDidIt !== 'number' || whoDidIt <= 0) {
+                    whoDidIt = null
+                    body.trigger = trigger
+                }
+                await app.db.controllers.AuditLog.userLog(whoDidIt, event, body, entityId)
+            } catch (error) {
+                console.warn('Failed to log users scope audit event', event, error)
+            }
         }
         return {
             user,

--- a/test/unit/forge/auditLog/platform_spec.js
+++ b/test/unit/forge/auditLog/platform_spec.js
@@ -46,6 +46,20 @@ describe('Audit Log > Platform', async function () {
         return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
     }
 
+    // #region Common Tests
+
+    it('Permits a logger to be triggered by system user id', async function () {
+        // call any function to trigger the logger with a system user id
+        await platformLogger.platform.stack.created(0, null, STACK)
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('trigger', { id: 'system', type: 'system', name: 'Forge Platform' })
+        logEntry.should.have.property('body').and.be.an.Object()
+        logEntry.body.should.not.have.property('trigger')
+    })
+
+    // #endregion
+
     it('Provides a logger for platform settings', async function () {
         await platformLogger.platform.settings.updated(ACTIONED_BY, null, [{}])
 

--- a/test/unit/forge/auditLog/project_spec.js
+++ b/test/unit/forge/auditLog/project_spec.js
@@ -55,6 +55,23 @@ describe('Audit Log > Project', async function () {
         return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
     }
 
+    // #region Common Tests
+
+    it('Permits a logger to be triggered by system', async function () {
+        // call any function to trigger the logger with a system user id
+        await projectLogger.project.started(0 /* system */, null, PROJECT)
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'project.started')
+        logEntry.should.have.property('scope', { id: PROJECT.id, type: 'project' })
+        logEntry.should.have.property('trigger', { id: 'system', type: 'system', name: 'Forge Platform' })
+        logEntry.should.have.property('body')
+        logEntry.body.should.only.have.keys('project') // should exclude the 'trigger' property from body
+        logEntry.body.project.should.only.have.keys('id', 'name')
+    })
+
+    // #endregion
+
     // #region Project - Actions
 
     it('Provides a logger for creating a project', async function () {

--- a/test/unit/forge/auditLog/team_spec.js
+++ b/test/unit/forge/auditLog/team_spec.js
@@ -50,6 +50,20 @@ describe('Audit Log > Team', async function () {
         return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
     }
 
+    // #region Common Tests
+
+    it('Permits a logger to be triggered by system user id', async function () {
+        // call any function to trigger the logger with a system user id
+        await teamLogger.team.device.created(0, null, TEAM, DEVICE)
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('trigger', { id: 'system', type: 'system', name: 'Forge Platform' })
+        logEntry.should.have.property('body').and.be.an.Object()
+        logEntry.body.should.not.have.property('trigger')
+    })
+
+    // #endregion
+
     // #region Team - Team Actions
 
     it('Provides a logger for creating a team', async function () {

--- a/test/unit/forge/auditLog/user_spec.js
+++ b/test/unit/forge/auditLog/user_spec.js
@@ -42,6 +42,20 @@ describe('Audit Log > User', async function () {
         return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
     }
 
+    // #region Common Tests
+
+    it('Permits a logger to be triggered by system user id', async function () {
+        // call any function to trigger the logger with a system user id
+        await userLogger.account.verify.autoCreateTeam(0, null, TEAM)
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('trigger', { id: 'system', type: 'system', name: 'Forge Platform' })
+        logEntry.should.have.property('body').and.be.an.Object()
+        logEntry.body.should.not.have.property('trigger')
+    })
+
+    // #endregion
+
     // #region User - Account
 
     it('Provides a logger for registering an account', async function () {


### PR DESCRIPTION
closes #1320

NOTE: Until #1318 there were no logs made by "system" (or anyone but a user via an API) so this issue was not found.

TODO...

- [x] Add tests
- [x] Switch from Draft to Ready for Review
- [ ] Re-run tests on 1318 after merge