### PR TITLE
Improve User Settings email validation and error flow

### DIFF
--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -155,9 +155,11 @@ module.exports = {
             } else {
                 responseMessage = err.toString()
             }
-            console.log(err.toString())
-            console.log(responseMessage)
-            const resp = { code: 'unexpected_error', error: responseMessage }
+            let errorCode = 'unexpected_error'
+            if (responseMessage.includes('isEmail on email')) {
+                errorCode = 'invalid_email'
+            }
+            const resp = { code: errorCode, error: responseMessage }
             await auditLog.updatedUser(request.session.User, resp, null, user) // log as error
             reply.code(400).send(resp)
         }

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -3,7 +3,7 @@
     <form v-else class="space-y-6" @submit.enter.prevent="">
         <FormRow v-model="input.username" :type="editing?'text':'uneditable'" :error="errors.username">Username</FormRow>
         <FormRow v-model="input.name" :type="editing?'text':'uneditable'" :placeholder="input.username" :error="errors.name">Name</FormRow>
-        <FormRow v-model="input.email" :type="editing?'text':'uneditable'" :error="errors.email">Email</FormRow>
+        <FormRow v-model="input.email" :type="editing?'email':'uneditable'" :error="errors.email">Email</FormRow>
         <FormRow v-if="!editing" v-model="defaultTeamName" :options="teams" type="uneditable">
             Default Team
         </FormRow>
@@ -105,7 +105,6 @@ export default {
         },
         confirm () {
             this.loading = true
-            this.editing = false
             const opts = {}
             let changed = false
             if (this.input.username !== this.user.username) {
@@ -139,11 +138,14 @@ export default {
                         }
                     })
                     this.changed = {}
+                    this.editing = false
                 }).catch(err => {
-                    console.log(err.response.data)
                     if (err.response.data) {
                         if (/username/.test(err.response.data.error)) {
                             this.errors.username = 'Username unavailable'
+                        }
+                        if (err.response.data.code === 'invalid_email') {
+                            this.errors.email = 'Invalid email'
                         }
                         if (/password/.test(err.response.data.error)) {
                             this.errors.password = 'Invalid username'

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -131,6 +131,21 @@ describe('User API', async function () {
             // auditLogs.log[0].body.should.have.a.property('updates')
             // auditLogs.log[0].body.updates.should.have.a.property('length', 4)
         })
+        it('member user cannot set invalid email', async function () {
+            await login('elvis', 'eePassword')
+            const response = await app.inject({
+                method: 'PUT',
+                url: '/api/v1/user',
+                cookies: { sid: TestObjects.tokens.elvis },
+                payload: {
+                    email: 'afkae@example.com@test' // user setting
+                }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'invalid_email')
+            result.should.have.property('error', 'Validation isEmail on email failed')
+        })
         it('member user cannot modify admin settings (email_verified, admin)', async function () {
             await login('elvis', 'eePassword')
             const response = await app.inject({


### PR DESCRIPTION
This PR solves https://github.com/flowforge/flowforge/issues/1281

**Changes**
- In the users api:
  - added `invalid_email` error code when email validation fails
  - added unit test to verify whether sending an invalid email returns the new error code 
- Improved a few things in the frontend for the settings view 
  - In the template, the email field's `type` attribute is now set to `email`, instead of `text`
  - The form will remain in `editing` mode when receiving errors from remote
  - The `invalid_email` error code will result in a message being shown under the email field