### PR TITLE
Revert "Remove ff:tooltip from Snapshot component"

### DIFF
--- a/frontend/src/pages/project/components/cells/Snapshot.vue
+++ b/frontend/src/pages/project/components/cells/Snapshot.vue
@@ -3,6 +3,7 @@
         <span
             v-if="activeSnapshot?.id || updateNeeded"
             class="flex items-center space-x-2 text-gray-500 italic"
+            v-ff-tooltip:left="'Target snapshot has not yet been deployed to this device.'"
         >
             <ExclamationIcon
                 v-if="updateNeeded"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@fastify/csrf-protection": "^6.0.0",
         "@fastify/helmet": "^10.0.2",
         "@fastify/static": "^6.5.0",
-        "@flowforge/forge-ui-components": "^0.4.6",
+        "@flowforge/forge-ui-components": "^0.5.0",
         "@flowforge/localfs": "^1.1.0",
         "@headlessui/vue": "1.7.3",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
This reverts commit 5c345e506a2237354a2ed6214d5b323035834a32.

Depends on cutting a new release of forge-ui-components which includes https://github.com/flowforge/forge-ui-components/issues/107