### PR TITLE
API support for setting a projects hostname

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
 const semver = require('semver')
 
-const { SETTINGS_KEY } = require('../models/ProjectSettings')
+const { KEY_SETTINGS } = require('../models/ProjectSettings')
 
 /**
  * inflightProjectState - when projects are transitioning between states, there
@@ -61,7 +61,7 @@ module.exports = {
                 })
             }
         }
-        const projectSettingsRow = project.ProjectSettings.find((projectSetting) => projectSetting.key === SETTINGS_KEY)
+        const projectSettingsRow = project.ProjectSettings.find((projectSetting) => projectSetting.key === KEY_SETTINGS)
         if (projectSettingsRow) {
             const projectSettings = projectSettingsRow.value
             result = app.db.controllers.ProjectTemplate.mergeSettings(result, projectSettings)

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -1,6 +1,8 @@
 const crypto = require('crypto')
 const semver = require('semver')
 
+const { SETTINGS_KEY } = require('../models/ProjectSettings')
+
 /**
  * inflightProjectState - when projects are transitioning between states, there
  * is no need to store that in the database. But we do need to know it so the
@@ -59,8 +61,9 @@ module.exports = {
                 })
             }
         }
-        if (project.ProjectSettings[0]?.key === 'settings') {
-            const projectSettings = project.ProjectSettings[0].value
+        const projectSettingsRow = project.ProjectSettings.find((projectSetting) => projectSetting.key === SETTINGS_KEY)
+        if (projectSettingsRow) {
+            const projectSettings = projectSettingsRow.value
             result = app.db.controllers.ProjectTemplate.mergeSettings(result, projectSettings)
             const envVars = app.db.controllers.Project.insertPlatformSpecificEnvVars(project, result.env)
             // convert  [{name: 'a', value: '1'}, {name: 'b', value: '2'}]  >> to >>  { a: 1, b: 2 }

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -14,6 +14,8 @@
 const { DataTypes } = require('sequelize')
 const Controllers = require('../controllers')
 
+const { KEY_SETTINGS } = require('./ProjectSettings')
+
 /** @type {FFModel} */
 module.exports = {
     name: 'Project',
@@ -33,7 +35,8 @@ module.exports = {
             allowNull: false,
             get () {
                 const originalUrl = this.getDataValue('url')?.replace(/\/$/, '') || ''
-                let httpAdminRoot = this.ProjectSettings?.[0]?.value.httpAdminRoot
+                const projectSettingsRow = this.ProjectSettings?.find((projectSetting) => projectSetting.key === KEY_SETTINGS)
+                let httpAdminRoot = projectSettingsRow?.value.httpAdminRoot
                 if (httpAdminRoot === undefined) {
                     httpAdminRoot = this.ProjectTemplate?.settings?.httpAdminRoot
                 }
@@ -287,7 +290,7 @@ module.exports = {
                             },
                             {
                                 model: M.ProjectSettings,
-                                where: { key: 'settings' },
+                                where: { key: KEY_SETTINGS },
                                 required: false
                             }
                         ]

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -11,10 +11,10 @@
  * @typedef {{name: string, schema: ModelAttributes, model: Model, indexes?: ModelIndexesOptions[], scopes?: ModelScopeOptions, options?: InitOptions}} FFModel
  */
 
-const { DataTypes } = require('sequelize')
+const { DataTypes, Op } = require('sequelize')
 const Controllers = require('../controllers')
 
-const { KEY_SETTINGS } = require('./ProjectSettings')
+const { KEY_HOSTNAME, KEY_SETTINGS } = require('./ProjectSettings')
 
 /** @type {FFModel} */
 module.exports = {
@@ -290,7 +290,12 @@ module.exports = {
                             },
                             {
                                 model: M.ProjectSettings,
-                                where: { key: KEY_SETTINGS },
+                                where: {
+                                    [Op.or]: [
+                                        { key: KEY_SETTINGS },
+                                        { key: KEY_HOSTNAME }
+                                    ]
+                                },
                                 required: false
                             }
                         ]

--- a/forge/db/models/ProjectSettings.js
+++ b/forge/db/models/ProjectSettings.js
@@ -44,6 +44,18 @@ module.exports = {
     associations: function (M) {
         this.belongsTo(M.Project)
     },
+    finders: function (M) {
+        return {
+            static: {
+                isHostnameUsed: async (hostname) => {
+                    const count = await this.count({
+                        where: { key: KEY_HOSTNAME, value: hostname.toLowerCase() }
+                    })
+                    return count !== 0
+                }
+            }
+        }
+    },
     meta: {
         slug: false,
         hashid: false,

--- a/forge/db/models/ProjectSettings.js
+++ b/forge/db/models/ProjectSettings.js
@@ -10,9 +10,11 @@ const SettingTypes = {
 }
 
 const KEY_SETTINGS = 'settings'
+const KEY_HOSTNAME = 'hostname'
 
 module.exports = {
     KEY_SETTINGS,
+    KEY_HOSTNAME,
     name: 'ProjectSettings',
     schema: {
         ProjectId: { type: DataTypes.UUID, unique: 'pk_settings' },

--- a/forge/db/models/ProjectSettings.js
+++ b/forge/db/models/ProjectSettings.js
@@ -9,7 +9,10 @@ const SettingTypes = {
     JSON: 1
 }
 
+const KEY_SETTINGS = 'settings'
+
 module.exports = {
+    KEY_SETTINGS,
     name: 'ProjectSettings',
     schema: {
         ProjectId: { type: DataTypes.UUID, unique: 'pk_settings' },

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -13,7 +13,7 @@ module.exports = {
         }
 
         // proj.ProjectSettings
-        const settingsSettingsRow = proj.ProjectSettings.find((projectSettingsRow) => projectSettingsRow.key === KEY_SETTINGS)
+        const settingsSettingsRow = proj.ProjectSettings?.find((projectSettingsRow) => projectSettingsRow.key === KEY_SETTINGS)
         if (settingsSettingsRow) {
             result.settings = settingsSettingsRow?.value || {}
             if (result.settings.httpNodeAuth) {
@@ -31,7 +31,7 @@ module.exports = {
             result.settings.palette.modules = await app.db.controllers.StorageSettings.getProjectModules(project)
         }
 
-        const settingsHostnameRow = proj.ProjectSettings.find((projectSettingsRow) => projectSettingsRow.key === KEY_HOSTNAME)
+        const settingsHostnameRow = proj.ProjectSettings?.find((projectSettingsRow) => projectSettingsRow.key === KEY_HOSTNAME)
         result.hostname = settingsHostnameRow?.value || ''
 
         if (proj.Team) {

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -1,4 +1,4 @@
-const { KEY_SETTINGS } = require('../models/ProjectSettings')
+const { KEY_HOSTNAME, KEY_SETTINGS } = require('../models/ProjectSettings')
 
 module.exports = {
     project: async function (app, project) {
@@ -30,6 +30,10 @@ module.exports = {
             result.settings.palette = result.settings.palette || {}
             result.settings.palette.modules = await app.db.controllers.StorageSettings.getProjectModules(project)
         }
+
+        const settingsHostnameRow = proj.ProjectSettings.find((projectSettingsRow) => projectSettingsRow.key === KEY_HOSTNAME)
+        result.hostname = settingsHostnameRow?.value || ''
+
         if (proj.Team) {
             result.team = {
                 id: proj.Team.hashid,

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -1,3 +1,5 @@
+const { KEY_SETTINGS } = require('../models/ProjectSettings')
+
 module.exports = {
     project: async function (app, project) {
         const proj = project.toJSON()
@@ -9,8 +11,11 @@ module.exports = {
             createdAt: proj.createdAt,
             updatedAt: proj.updatedAt
         }
-        if (proj.ProjectSettings && proj.ProjectSettings.length === 1 && proj.ProjectSettings[0].key === 'settings') {
-            result.settings = proj.ProjectSettings[0].value || {}
+
+        // proj.ProjectSettings
+        const settingsSettingsRow = proj.ProjectSettings.find((projectSettingsRow) => projectSettingsRow.key === KEY_SETTINGS)
+        if (settingsSettingsRow) {
+            result.settings = settingsSettingsRow?.value || {}
             if (result.settings.httpNodeAuth) {
                 // Only return whether a password is set or not
                 result.settings.httpNodeAuth.pass = !!result.settings.httpNodeAuth.pass

--- a/forge/lib/validate.js
+++ b/forge/lib/validate.js
@@ -1,0 +1,7 @@
+module.exports = {
+    isFQDN (string) {
+        const regex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}\.?$)/
+
+        return regex.test(string)
+    }
+}

--- a/forge/lib/validate.js
+++ b/forge/lib/validate.js
@@ -1,6 +1,10 @@
 module.exports = {
     isFQDN (string) {
-        const regex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}\.?$)/
+        // Maximum of 253 characters
+        // Made up of alphanumeric+hyphen segments up 1-63 characters long that does not start/end in hyphens
+        // Ends in a TLD of 2-63 alphanumeric characters
+        // Optional trailing .
+        const regex = /(?=^.{4,253}\.?$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)/
 
         return regex.test(string)
     }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -582,7 +582,9 @@ module.exports = async function (app) {
                     return
                 }
 
-                if (await app.db.models.ProjectSettings.isHostnameUsed(newHostname)) {
+                const hostnameInUse = await app.db.models.ProjectSettings.isHostnameUsed(newHostname)
+                const hostnameMatchesDomain = (app.config.domain && newHostname.endsWith(app.config.domain.toLowerCase()))
+                if (hostnameInUse || hostnameMatchesDomain) {
                     reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is already in use' })
                     return
                 }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -4,6 +4,9 @@ const ProjectActions = require('./projectActions')
 const ProjectDevices = require('./projectDevices')
 const ProjectSnapshots = require('./projectSnapshots')
 
+const { KEY_HOSTNAME } = require('../../db/models/ProjectSettings')
+const { isFQDN } = require('../../lib/validate')
+
 /**
  * Instance api routes
  *
@@ -495,7 +498,7 @@ module.exports = async function (app) {
                 await request.project.save()
                 await request.project.reload()
             }
-            // Get the source project settings
+            // Get the source project settings - ignore hostname
             const sourceProjectSettings = await sourceProject.getSetting('settings') || { env: [] }
             // Get the target project settings
             let targetProjectSettings = await request.project.getSetting('settings') || { env: [] }
@@ -570,6 +573,30 @@ module.exports = async function (app) {
                 changed = true
                 updates.push('name', projectName, reqName)
             }
+
+            const newHostname = request.body.hostname?.toLowerCase().replace(/\.$/, '') // trim trailing .
+            const oldHostname = await request.project.getSetting('hostname')
+            if (newHostname && newHostname !== oldHostname) {
+                if (!isFQDN(newHostname)) {
+                    reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is not an FQDN' })
+                    return
+                }
+
+                if (await app.db.models.ProjectSettings.isHostnameUsed(newHostname)) {
+                    reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is already in use' })
+                    return
+                }
+
+                await request.project.updateSetting(KEY_HOSTNAME, newHostname)
+                await request.project.reload({
+                    include: [
+                        { model: app.db.models.ProjectSettings }
+                    ]
+                })
+                changed = true
+                updates.push('hostname', newHostname, oldHostname)
+            }
+
             if (request.body.settings) {
                 let bodySettings
                 if (request.allSettingsEdit) {

--- a/test/unit/forge/lib/validate_spec.js
+++ b/test/unit/forge/lib/validate_spec.js
@@ -1,0 +1,59 @@
+const should = require('should') // eslint-disable-line
+
+const validate = require('../../../../forge/lib/validate')
+
+describe('Validate', function () {
+    describe('isFQDN', function () {
+        it('Validates fully qualified domain names made up of labels', async function () {
+            validate.isFQDN('example.com').should.be.true()
+            validate.isFQDN('project.example.com').should.be.true()
+            validate.isFQDN('project.example.customtld').should.be.true()
+        })
+
+        it('Allows hyphens outside of the TLD but not at the beginning or end of each label', async function () {
+            validate.isFQDN('exam-ple.com').should.be.true()
+            validate.isFQDN('the-nested.project.example.com').should.be.true()
+            validate.isFQDN('the-nested.pro-ject.example.com').should.be.true()
+
+            validate.isFQDN('project.example.custom-tld').should.be.false()
+            validate.isFQDN('project.example-.com').should.be.false()
+            validate.isFQDN('project.-example.com').should.be.false()
+            validate.isFQDN('-project.-example.com').should.be.false()
+            validate.isFQDN('project-.-example.com').should.be.false()
+        })
+
+        it('Allows numbers in the labels but not in the TLD', async function () {
+            validate.isFQDN('1example.com').should.be.true()
+            validate.isFQDN('project1.example.com').should.be.true()
+
+            validate.isFQDN('example.co1').should.be.false()
+        })
+
+        it('Only allows labels up to 63 characters long', async function () {
+            validate.isFQDN(`${'x'.repeat(63)}.com`).should.be.true()
+            validate.isFQDN(`${'x'.repeat(63)}.${'y'.repeat(63)}.com`).should.be.true()
+            validate.isFQDN(`${'x'.repeat(63)}.${'y'.repeat(63)}.${'z'.repeat(63)}.com`).should.be.true()
+
+            validate.isFQDN('x'.repeat(64) + '.com').should.be.false()
+        })
+
+        it('Only allows FQDNs less than 253 characters long', async function () {
+            validate.isFQDN('x.'.repeat(125) + 'com').should.be.true()
+
+            validate.isFQDN('x.'.repeat(126) + 'com').should.be.false()
+        })
+
+        it('Requires FQDNs to be at least 4 characters long excluding trailing .', async function () {
+            validate.isFQDN('t.c').should.be.false()
+            validate.isFQDN('t.c.').should.be.false()
+
+            validate.isFQDN('t.co').should.be.true()
+        })
+
+        it('Allows a single trailing full stop', async function () {
+            validate.isFQDN('example.com.').should.be.true()
+
+            validate.isFQDN('example.com..').should.be.false()
+        })
+    })
+})

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -5,6 +5,8 @@ const crypto = require('crypto')
 const sleep = require('util').promisify(setTimeout)
 const setup = require('../setup')
 
+const { KEY_HOSTNAME } = require('../../../../../forge/db/models/ProjectSettings')
+
 function encryptCredentials (key, plain) {
     const initVector = crypto.randomBytes(16)
     const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
@@ -1103,6 +1105,68 @@ describe('Project API', function () {
                 { name: 'two', value: '2' }
             ]) // should be unchanged
         })
+
+        describe('Update hostname', function () {
+            it('Changes the projects hostname', async function () {
+                // call "Update a project" with a new hostname
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${TestObjects.project1.id}`,
+                    payload: {
+                        hostname: 'host.example.com'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                response.json().should.have.property('hostname', 'host.example.com')
+            })
+
+            it('Trims a trailing full-stop', async function () {
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${TestObjects.project1.id}`,
+                    payload: {
+                        hostname: 'my-project.flowforge.com.'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                response.json().should.have.property('hostname', 'my-project.flowforge.com')
+            })
+
+            it('Requires a FQDN', async function () {
+                // call "Update a project" with a new hostname
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${TestObjects.project1.id}`,
+                    payload: {
+                        hostname: 'examplecom'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(409)
+                response.json().should.have.property('code', 'invalid_hostname')
+            })
+
+            it('Requires the hostname to be unique case-insensitively', async function () {
+                const existingProject = await app.db.models.Project.create({ name: 'project2', type: '', url: '' })
+                existingProject.updateSetting(KEY_HOSTNAME, 'already-in-use.flowforge.dev')
+
+                // call "Update a project" with a new hostname
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${TestObjects.project1.id}`,
+                    payload: {
+                        hostname: 'Already-In-Use.FlowForge.dev'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(409)
+                response.json().code.should.match('invalid_hostname')
+                response.json().error.should.containEql('in use')
+            })
+        })
+
         it('Export to another project - includes everything ', async function () {
             // Setup some flows/credentials
             await addFlowsToProject(TestObjects.project1.id,


### PR DESCRIPTION
Part of https://github.com/flowforge/flowforge/issues/1344

This PR adds a project hostname setting, which is stored on the ProjectSettings table via the existing hasMany.

Due to some existing assumptions that a project has only one ProjectSettings, some re-jigging was required first. This is likely easier to review commit by commit as a result.