### PR TITLE
Run E2E tests for package.json changes

### DIFF
--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'frontend/**'
       - 'test/e2e/frontend/**'
+      - 'package.json'
   pull_request:
     paths:
       - 'frontend/**'
       - 'test/e2e/frontend/**'
+      - 'package.json'
 
 jobs:
   cypress-run:


### PR DESCRIPTION
https://github.com/flowforge/flowforge/pull/1329 introduced a cypress bug which wasn't caught until the next PR that touched our frontend files.
E2E tests should also run whenever package.json changes.

This becomes increasingly important as dependabot touches all our dependencies.