### PR TITLE
Update Docker/Kube docs (backport #1337)

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -22,6 +22,8 @@ The FlowForge Application will be hosted on `http://forge.example.com`
 
 **Note** When testing locally you can add entries for each project to your `/etc/hosts` file but you must use the external IP address of the host machine, not the loopback address (`127.0.0.1`).
 
+Notes on how to setup DNS can be found [here](../dns-setup.md).
+
 ### Installing FlowForge
 
 #### Download

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -37,22 +37,6 @@ tar zxf v0.x.0.tar.gz
 cd docker-compose-x.x.x
 ```
 
-#### Building Containers
-
-To build the 2 required containers run `./build-containers.sh`.
-
-This will build and tag both `flowforge/forge-docker` and `flowforge/node-red`
-
-##### flowforge/flowforge-docker
-
-This container holds the FlowForge App and the Docker Driver
-
-##### flowforge/node-red
-
-This is a basic Node-RED image with the FlowForge Launcher and the required Node-RED plugins to talk to the FlowForge Platform. This is the basis for the initial Stack.
-
-This is the container you can customise for your deployment.
-
 ### Configuring FlowForge
 
 Configuration details are stored in the `etc/flowforge.yml` file which is mapped into the `flowforge/forge-docker` container. You will need to edit this file to update the `domain` and `base_url` entries to match the DNS settings. Please note that once set, the `domain` and `base_url` values should not be changed as these values are used as part of the configuration stored in the database of each project. The ability to migrate `domains` is on the feature backlog.
@@ -97,10 +81,10 @@ set the correct domain name and make the same change to the `public_url` entry i
 
 
 
-#### SSL (optional)
-If you want to serve the forge app and projects via SSL you will need to obtain wildcard SSL certs for the domain you are using eg `*.example.com` or you can use the Letsencrypt acme-companion.
+#### HTTPS (optional)
+If you want to serve the forge app and projects via SSL you will need to obtain a wildcard TSL certificate for the domain you are using eg `*.example.com` or you can use the LetsEncrypt acme-companion.
 
-### Wilcard SSL
+### Wildcard TLS Certificate
 
 Create a folder in the `docker-compose-0.x.0` directory named `certs`, place your .crt and .key files in there, they should be named for the domain without the `*` eg `example.com.crt` & `example.com.key`
 You  also need to create a copy of the .crt and .key files named `default.crt` & `default.key` in the same folder. This is used for serving unknown hosts.
@@ -163,7 +147,7 @@ Then, in the `docker-compose.yml` file, edit the following lines added your doma
 - "LETSENCRYPT_HOST=forge.example.com"
 ```
 
-As with the Wilcard SSL method, if you are running with the MQTT broker then you should adjust the `public_url` to start with `wss://` rather than `ws://`
+As with the Wildcard TLS method, if you are running with the MQTT broker then you should adjust the `public_url` to start with `wss://` rather than `ws://`
 
 #### Running FlowForge
 

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -151,14 +151,22 @@ As with the Wildcard TLS method, if you are running with the MQTT broker then yo
 
 #### Running FlowForge
 
-Once the containers have been built you can start FlowForge by running:
+We need to manually download the `flowforge/node-red` container that will be used for the default stack.
+
+This is done with this command:
+
+```
+docker pull flowforge/node-red
+```
+
+Once that completes we can start FlowForge:
 
 Using the docker compose plugin
 ```
 docker compose -p flowforge up -d
 ```
 
-Using the docker-compose command
+Or using the docker-compose command
 ```
 docker-compose up -p flowforge up -d
 ```

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -86,7 +86,7 @@ If you want to serve the forge app and projects via SSL you will need to obtain 
 
 ### Wildcard TLS Certificate
 
-Create a folder in the `docker-compose-0.x.0` directory named `certs`, place your .crt and .key files in there, they should be named for the domain without the `*` eg `example.com.crt` & `example.com.key`
+Create a folder in the `docker-compose-1.x.0` directory named `certs`, place your .crt and .key files in there, they should be named for the domain without the `*` eg `example.com.crt` & `example.com.key`
 You  also need to create a copy of the .crt and .key files named `default.crt` & `default.key` in the same folder. This is used for serving unknown hosts.
 
 In the `docker-compose.yml` file, 

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -1,51 +1,35 @@
 # Kubernetes Install
 
 This version of the FlowForge platform is intended for running in the Kubernetes (sometimes referred to as K8s)
-Container management system. Typically suited for large on permise deployments or deployment in Cloud infrastucture.
+Container management system. Typically suited for large on premise deployments or deployment in Cloud infrastructure.
 
 ### Prerequisites
+
+#### Kubectl
+
+To manage a Kubernetes cluster you will need a copy of the `kubectl` utility. Instructions on 
+how to install it can be found [here](https://kubernetes.io/docs/tasks/tools/).
+#### Helm
+
+FlowForge uses a Helm Chart to manage deployment. Installation can be done
+through the instructions on [their website](https://helm.sh).
 
 #### Kubernetes
 
 You will need a Kubernetes environment. The deployment has currently been tested on the following environments:
 
- - AWS EKS
+ - [AWS EKS](aws.md)
+ - Digital Ocean
  - MicroK8s
 
  It should run on any Kubernetes platform, but may require some changes for vendor specific Ingress setup.
 
  By default the Helm chart assumes that the Kubernetes cluster has at least 2 nodes:
 
- 1. Used to run the FlowForge management infrastructor
- 2. Used to run the Node-RED Project instances
+ - One used to run the FlowForge management infrastructure
+ - One or more used to run the Node-RED Project instances
 
-These are assigned using node labels as follows:
-
-FlowForge management
-```
-kubectl label node <management node name> role=management
-```
-Node-RED projects
-```
-kubectl label node <projects node name> role=projects
-```
-
-It is possible to run on a single node cluster by overiding the values of `forge.managementSelector` and `forge.projectSelector` when configuring the Helm chart. Details are in the Configuring FlowForge section below.
-
-#### Helm
-
-FlowForge uses a Helm Chart to manage deployment. Installation can be done
-through the instructions on [their website](https://helm.sh).
-
-#### Docker Container Registry
-
-FlowForge on Kubernetes will require a Docker Container Registry to host both
-the core platform container and the containers that back any Node-RED stacks you
-wish to deploy.
-
-You can use [Dockers public registry](https://hub.docker.com). If you do, make
-sure you create two repositories: `forge-k8s` and `node-red` under your namespace.
-Also ensure you're signed in locally by running `docker login` in your terminal.
+You can run a small scale PoC on a single node cluster, details of how to do this can be found in the [Configure FlowForge](#configure-flowforge) section below. 
 
 #### PostgreSQL Database
 
@@ -59,60 +43,17 @@ A wildcard DNS entry will be needed to point to the domain that is used fro the 
 
 Some features require the ability to send email to users. This can be currently be provided by:
 
-- Details of a SMTP server
+- SMTP server
 - AWS SES
 
 ### Installing FlowForge
 
 #### Download
 
-Download the [FlowForge Helm Charts](https://github.com/flowforge/helm/archive/refs/heads/main.zip)
-and extract the ZIP archive.
-
-#### Building Containers
-
-At a minimum there are 2 container required.
-
- - flowforge/forge-k8s
- - flowforge/node-red
-
-These can be built using the `./build-containers.sh` script in the root of the
-`helm` repository. This script takes the hostname of the Docker Container
-Registry as it's only argument. This will be pre-pended to the constainer names.
-For example:
-
 ```
-./build-containers.sh containers.example.com
+helm repo add flowforge https://flowforge.github.io/helm`
+helm repo update
 ```
-
-This will build two containers
-
-- containers.example.com/flowforge/forge-k8s:<current-version>
-- containers.example.com/flowforge/node-red:<current-version>
-
-If you're using Dockers Hub you need to create two repositories: `forge-k8s` and
-`node-red`. When done retag and push the containers:
-
-```
-docker tag containers.example.com/flowforge/forge-k8s:<current-version> <your-docker-username>/forge-k8s:<current-version>
-docker tag containers.example.com/flowforge/forge-k8s:<current-version> <your-docker-username>/forge-k8s:<current-version>
-
-docker login
-
-docker push <your-docker-username>/forge-k8s:<current-version>
-docker push <your-docker-username>/node-red:<current-version>
-```
-
-##### flowforge/forge-k8s
-
-This container includes the FlowForge application and the Kubernetes drivers.
-
-##### flowforge/node-red
-
-This is the default Node-RED image with the FlowForge components needed to talk
-to the FlowForge Platform. This is the basis for the initial [Node-RED stack][stacks].
-
-This is the container you can customise for your deployment.
 
 ### Configure FlowForge
 
@@ -125,8 +66,6 @@ forge:
   entryPoint: forge.example.com
   domain: example.com
   https: false
-  registry: containers.example.com
-  registrySecret: password
   localPostgresql: true
 ```
 
@@ -136,7 +75,6 @@ When running on AWS EKS and using AWS SES for email (The IAMRole needs to have t
 forge:
   entryPoint: forge.example.com
   domain: example.com
-  registry: <aws-account-id>.dkr.ecr.eu-west-1.amazonaws.com
   cloudProvider: aws
   aws:
     IAMRole: arn:aws:iam::<aws-account-id>:role/flowforge_service_account_role
@@ -147,7 +85,29 @@ forge:
 
 A more detailed example for running on AWS can be found [here](aws.md)
 
-As mentioned earlier the Helm chart defaults to expecting at least 2 nodes in the Kubernetes cluster. To overide this you can remove the node selectors with the following which will mean that all pods can run on any nodes.
+As mentioned earlier the Helm chart defaults to expecting at least 2 nodes in the Kubernetes cluster.
+
+You will need to label at least one node to run the management application and one to run the Node-RED Projects.
+
+You can do this with the `kubectl` utility. The following command lists 
+all the nodes in the cluster
+
+```
+kubectl get nodes
+```
+
+You can then use `kubectl label node` to add the required labels:
+
+FlowForge management node(s)
+```
+kubectl label node <management node name> role=management
+```
+Node-RED projects node(s)
+```
+kubectl label node <projects node name> role=projects
+```
+
+To override this you can remove the node selectors with the following which will mean that all pods can run on any nodes.
 
 ```yaml
 forge:
@@ -155,12 +115,12 @@ forge:
   managementSelector:
 ```
 
-A full list of all the configable values can be found in the [Helm Chart README](https://github.com/flowforge/helm/blob/main/helm/flowforge/README.md).
+A full list of all the configurable values can be found in the [Helm Chart README](https://github.com/flowforge/helm/blob/main/helm/flowforge/README.md).
 
-The install can then be started with the following command, should be run from the `helm` dirctory:
+The install can then be started with the following command:
 
 ```
-helm upgrade --install flowforge flowforge -f customization.yml
+helm upgrade --install flowforge flowforge/flowforge -f customization.yml
 ```
 
 #### Enabling the MQTT broker
@@ -180,7 +140,7 @@ The `forge.broker.public_url` value will be generated by prepending `ws://mqtt` 
 FlowForge projects when running in Kubernetes do not have direct 
 access to a persistent file system to store files.
 
-We recomend disabling the Node-RED core file nodes in the FlowForge
+We recommend disabling the Node-RED core file nodes in the FlowForge
 Template.
 
 <img src="../images/file-node-template.png" width=500 />

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -39,6 +39,8 @@ The Helm chart can either install a dedicated PostgreSQL database into the same 
 
 A wildcard DNS entry will be needed to point to the domain that is used fro the project instances. This will need to point to the K8s Ingress controller.
 
+Notes on how to setup DNS can be found [here](../dns-setup.md).
+
 #### Email
 
 Some features require the ability to send email to users. This can be currently be provided by:

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -19,7 +19,7 @@ through the instructions on [their website](https://helm.sh).
 You will need a Kubernetes environment. The deployment has currently been tested on the following environments:
 
  - [AWS EKS](aws.md)
- - Digital Ocean
+ - [Digital Ocean](dgitial-ocean.md)
  - MicroK8s
 
  It should run on any Kubernetes platform, but may require some changes for vendor specific Ingress setup.

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -29,7 +29,7 @@ You will need a Kubernetes environment. The deployment has currently been tested
  - One used to run the FlowForge management infrastructure
  - One or more used to run the Node-RED Project instances
 
-You can run a small scale PoC on a single node cluster, details of how to do this can be found in the [Configure FlowForge](#configure-flowforge) section below. 
+You can run a small scale Proof-of-Concept on a single node cluster, details of how to do this can be found in the [Configure FlowForge](#configure-flowforge) section below. 
 
 #### PostgreSQL Database
 

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -122,7 +122,7 @@ A full list of all the configurable values can be found in the [Helm Chart READM
 The install can then be started with the following command:
 
 ```
-helm upgrade --install flowforge flowforge/flowforge -f customization.yml
+helm upgrade --atomic --install flowforge flowforge/flowforge -f customization.yml
 ```
 
 #### Enabling the MQTT broker


### PR DESCRIPTION
Backport of https://github.com/flowforge/flowforge/pull/1337

---

 - Remove instructions about building containers as not needed\r\n - Rework K8s instructions about labeling nodes\r\n - Add kubectl requirement\r\n - Update HTTP/TLS language for Docker\r\n - Add Digital Ocean to list of tested envs for k8s\r\n\r\npart of flowforge/helm#69
