### PR TITLE
Add sso_enabled flag to user model

### DIFF
--- a/docs/contribute/workflows/login.md
+++ b/docs/contribute/workflows/login.md
@@ -10,7 +10,7 @@ participant B as Browser
 participant RT as ForgeApp
 participant DB as Database
 participant IDP as IdentifyProvider
-U->>B: Enters email on sign-up page
+U->>B: Enters username/email on sign-up page
 U->>B: Clicks login
 B->>RT: POST /account/login (username=XYZ)
 RT->DB: Checks username/email against list of SSO registered domains
@@ -25,18 +25,24 @@ alt Email not SSO enabled
 end
 
 alt Email SSO enabled
-    RT->>B: 403:{ code:'sso_required', redirect:'/account/login/sso?u=<base64 encoded email>' }
-    B->>RT: GET /account/login/sso?u=<base64 encoded email>
-    RT->>RT: passport.authenticate
-    RT->>IDP: SAML exchange
-    IDP->>IDP: User authentication
-    IDP->>RT: POST <TBD>
-    RT->>DB: Verify Email against users
-    alt Valid User
-    RT->>DB: create session
-    RT->>B: redirect to /
-    else Unknown User
-    RT->>B: redirect to /
+    alt Username provided or Password provided
+        RT->>B: 403:{ code:'sso_required', error:'Please login with your email' }
+        B->>U: Prompts user to enter email not username
+    end
+    alt Email provided
+        RT->>B: 403:{ code:'sso_required', redirect:'/account/login?u=<base64 encoded email>' }
+        B->>RT: GET /account/login?u=<base64 encoded email>
+        RT->>RT: passport.authenticate
+        RT->>IDP: SAML exchange
+        IDP->>IDP: User authentication
+        IDP->>RT: POST <TBD>
+        RT->>DB: Verify Email against users
+        alt Valid User
+            RT->>DB: create session
+            RT->>B: redirect to /
+            else Unknown User
+            RT->>B: redirect to /
+        end
     end
 end
 ```

--- a/forge/db/migrations/20221207-01-add-user-sso.js
+++ b/forge/db/migrations/20221207-01-add-user-sso.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Add suspended column to Users
+ */
+
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        await context.addColumn('Users', 'sso_enabled', {
+            type: DataTypes.BOOLEAN,
+            defaultValue: false
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/migrations/20221207-01-add-user-sso.js
+++ b/forge/db/migrations/20221207-01-add-user-sso.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 /**
- * Add suspended column to Users
+ * Add sso_enabled column to Users
  */
 
 const { DataTypes, QueryInterface } = require('sequelize')

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -12,6 +12,7 @@ module.exports = {
         name: { type: DataTypes.STRING, validate: { not: /:\/\// } },
         email: { type: DataTypes.STRING, unique: true, validate: { isEmail: true } },
         email_verified: { type: DataTypes.BOOLEAN, defaultValue: false },
+        sso_enabled: { type: DataTypes.BOOLEAN, defaultValue: false },
         password: {
             type: DataTypes.STRING,
             set (value) {

--- a/forge/db/views/User.js
+++ b/forge/db/views/User.js
@@ -46,6 +46,9 @@ module.exports = {
         if (user.defaultTeamId) {
             result.defaultTeam = app.db.models.Team.encodeHashid(user.defaultTeamId)
         }
+        if (app.config.features.enabled('sso')) {
+            result.sso_enabled = !!user.sso_enabled
+        }
         return result
     },
 

--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -5,5 +5,7 @@ module.exports = fp(async function (app, opts, done) {
         app.decorate('billing', await require('./billing').init(app))
     }
     require('./projectComms').init(app)
+    app.decorate('sso', await require('./sso').init(app))
+
     done()
 })

--- a/forge/ee/lib/sso/index.js
+++ b/forge/ee/lib/sso/index.js
@@ -1,0 +1,19 @@
+module.exports.init = async function (app) {
+    // Set the SSO feature flag
+    app.config.features.register('sso', true, true)
+
+    /**
+     * Handle a request POST /account/login to see if SSO should be triggered
+     *
+     * Currently always returns false as SSO is not fully enabled
+     *
+     * @returns whether the request has been handled or not
+     */
+    async function handleLoginRequest (request, reply) {
+        return false
+    }
+
+    return {
+        handleLoginRequest
+    }
+}

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -36,8 +36,6 @@ function base64URLEncode (str) {
 function sha256 (buffer) {
     return crypto.createHash('sha256').update(buffer).digest()
 }
-// var verifier = base64URLEncode(crypto.randomBytes(32));
-// var challenge = base64URLEncode(sha256(verifier));
 
 module.exports = async function (app) {
     app.addContentTypeParser('application/x-www-form-urlencoded', { parseAs: 'string' }, function (req, body, done) {

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -3,7 +3,7 @@
     <form v-else class="space-y-6" @submit.enter.prevent="">
         <FormRow v-model="input.username" :type="editing?'text':'uneditable'" :error="errors.username">Username</FormRow>
         <FormRow v-model="input.name" :type="editing?'text':'uneditable'" :placeholder="input.username" :error="errors.name">Name</FormRow>
-        <FormRow v-model="input.email" :type="editing?'email':'uneditable'" :error="errors.email">Email</FormRow>
+        <FormRow v-model="input.email" :type="emailEditingEnabled?'email':'uneditable'" :error="errors.email">Email</FormRow>
         <FormRow v-if="!editing" v-model="defaultTeamName" :options="teams" type="uneditable">
             Default Team
         </FormRow>
@@ -95,12 +95,16 @@ export default {
     methods: {
         startEdit () {
             this.editing = true
+            if (this.user.sso_enabled) {
+                this.errors.email = 'Cannot modify email for SSO enabled user'
+            }
         },
         cancelEdit () {
             this.input.username = this.user.username
             this.input.name = this.user.name
             this.input.email = this.user.email
             this.input.defaultTeam = this.user.defaultTeam
+            this.errors.email = ''
             this.editing = false
         },
         confirm () {
@@ -166,6 +170,9 @@ export default {
                    (this.input.email && !this.errors.email) &&
                    (this.input.username && !this.errors.username) &&
                    (this.input.name && !this.errors.name)
+        },
+        emailEditingEnabled () {
+            return this.editing && !this.user.sso_enabled
         }
     },
     components: {

--- a/frontend/src/pages/admin/Users/General.vue
+++ b/frontend/src/pages/admin/Users/General.vue
@@ -38,6 +38,8 @@ import { markRaw } from 'vue'
 
 import AdminUserEditDialog from './dialogs/AdminUserEditDialog'
 
+import { mapState } from 'vuex'
+
 export default {
     name: 'AdminUsers',
     data () {
@@ -57,6 +59,14 @@ export default {
     },
     async created () {
         await this.loadItems(true)
+        if (this.features.sso) {
+            this.columns.push({
+                label: 'SSO Enabled', class: ['w-32', 'text-center'], key: 'sso_enabled', sortable: true
+            })
+        }
+    },
+    computed: {
+        ...mapState('account', ['features'])
     },
     watch: {
         userSearch (v) {

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -4,7 +4,12 @@
             <form class="space-y-6" @submit.prevent>
                 <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
                 <FormRow v-model="input.name" :placeholder="input.username">Name</FormRow>
-                <FormRow v-model="input.email" :error="errors.email">Email</FormRow>
+                <FormRow v-model="input.email" :error="errors.email">
+                    Email
+                    <template v-slot:description v-if="user.sso_enabled">
+                        <div class="text-red-700">SSO is enabled for this user.</div>
+                    </template>
+                </FormRow>
                 <FormRow id="email_verified" wrapperClass="flex justify-between items-center" :disabled="email_verifiedLocked" v-model="input.email_verified" type="checkbox">Verified
                     <template v-slot:append>
                         <ff-button v-if="email_verifiedLocked" kind="danger" size="small" @click="unlockEmailVerify()">

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -4,10 +4,10 @@
             <form class="space-y-6" @submit.prevent>
                 <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
                 <FormRow v-model="input.name" :placeholder="input.username">Name</FormRow>
-                <FormRow v-model="input.email" :error="errors.email">
+                <FormRow v-model="input.email" :error="errors.email" :disabled="user.sso_enabled">
                     Email
                     <template v-slot:description v-if="user.sso_enabled">
-                        <div class="text-red-700">SSO is enabled for this user.</div>
+                        <div>SSO is enabled for this user.</div>
                     </template>
                 </FormRow>
                 <FormRow id="email_verified" wrapperClass="flex justify-between items-center" :disabled="email_verifiedLocked" v-model="input.email_verified" type="checkbox">Verified


### PR DESCRIPTION
Part of #226 

 - This adds a new flag to the User model, `sso_enabled` that indicates this user has logged in via SSO.

 - If the flag is true for a given user, they cannot edit their email address.

<img width="460" alt="image" src="https://user-images.githubusercontent.com/51083/206471717-8393ec60-e6b6-4d78-9f4a-50be0f38888a.png">

 - Adds an sso_enabled column to the admin table of users

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/51083/206471829-eb83acdf-7f98-45b2-a509-a9ebf4754692.png">

With this PR, nothing sets this property to true. That'll come in the next PR that introduces SSO login.