### PR TITLE
Downgrade Axios to 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "@flowforge/localfs": "^1.1.0",
         "@headlessui/vue": "1.7.3",
         "@heroicons/vue": "1.0.6",
-        "axios": "^1.2.0",
+        "axios": "^1.1.3",
         "bcrypt": "^5.1.0",
         "cronosjs": "^1.7.1",
         "fastify": "^4.9.2",


### PR DESCRIPTION
Addresses* https://github.com/flowforge/flowforge/issues/1390 by downgrading Axios to a version without issues handling Brotli.

See: https://github.com/axios/axios/issues/5357 and https://github.com/axios/axios/issues/5346 for the issues with 1.2.0 and 1.2.1 respectively.