### PR TITLE
Remove the activation price experiment

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -68,13 +68,6 @@ module.exports.init = async function (app) {
                 cancel_url: `${app.config.base_url}/team/${team.slug}/overview`
             }
 
-            if (app.config.billing?.stripe?.activation_price) {
-                sub.line_items.push({
-                    price: app.config.billing.stripe.activation_price,
-                    quantity: 1
-                })
-            }
-
             if (coupon) {
                 sub.discounts = [
                     {

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -93,10 +93,6 @@ module.exports = async function (app) {
                 }
             }
 
-            let invoice
-            let activation = false
-            let invoiceItem
-
             switch (event.type) {
             case 'checkout.session.completed':
                 // console.log(event)
@@ -117,32 +113,6 @@ module.exports = async function (app) {
                 break
             case 'customer.subscription.deleted':
 
-                break
-            case 'charge.succeeded':
-                // gate on config setting
-                if (app.config.billing?.stripe?.activation_price) {
-                    invoice = await stripe.invoices.retrieve(event.data.object.invoice)
-                    invoice.lines.data.forEach(item => {
-                        if (item.price.id === app.config.billing?.stripe?.activation_price) {
-                            activation = true
-                            invoiceItem = item
-                        }
-                    })
-                    if (activation) {
-                        // refund the activation test charge
-                        await stripe.creditNotes.create({
-                            invoice: invoice.id,
-                            lines: [{
-                                type: 'invoice_line_item',
-                                invoice_line_item: invoiceItem.id,
-                                amount: invoiceItem.amount
-                            }],
-                            memo: 'Activation check credit',
-                            credit_amount: invoiceItem.amount
-                        })
-                        app.log.info(`Crediting activation fee to invoice ${invoice.id}`)
-                    }
-                }
                 break
             case 'charge.failed':
                 // TODO: This needs work, we need to count failures and susspend projects

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -78,27 +78,6 @@ describe('Billing', function () {
             result.line_items[0].should.have.property('price', 'starterteampprice')
             result.line_items[0].should.have.property('quantity', 1)
         })
-        it('includes activation line item if configured', async function () {
-            app = await setup({
-                billing: {
-                    stripe: {
-                        key: 1234,
-                        team_product: 'defaultteamprod',
-                        team_price: 'defaultteamprice',
-                        activation_price: 'activationprice'
-                    }
-                }
-            })
-
-            const result = await app.billing.createSubscriptionSession(app.team)
-
-            result.should.have.property('line_items')
-            result.line_items.should.have.length(2)
-            result.line_items[0].should.have.property('price', 'defaultteamprice')
-            result.line_items[0].should.have.property('quantity', 1)
-            result.line_items[1].should.have.property('price', 'activationprice')
-            result.line_items[1].should.have.property('quantity', 1)
-        })
     })
 
     describe('updateTeamMemberCount', async function () {


### PR DESCRIPTION
As part of an effort to simplify the billing logic, particularly around handling stripe callbacks, this PR removes the activation price experiment. Previously added in https://github.com/flowforge/flowforge/pull/476.

