### PR TITLE
Link to the admin docs from the Projects Stacks concept docs

### DIFF
--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -49,6 +49,9 @@ Project Stacks are created and owned by the platform Administrator. When a User
 comes to create a new project, they chose from the available stacks associated
 with the chosen Project Type.
 
+For details on how to adminster and manage Stacks, please see the
+[Administering FlowForge](/docs/admin/#managing-stacks) docs.
+
 #### Project Template
 
 A Project Template describes properties of Node-RED itself. It is how many of the


### PR DESCRIPTION
Found myself navigating to the "Projects Concepts" documentation when wanting a reminder on how to add a new Project Stack locally, but this just gave me an explanation of the concept, without linking to anything useful on administering them.

This PR adds a link to the Admin docs from the Project Stacks concept.