### PR TITLE
Add syntax language to code examples for highlighting

### DIFF
--- a/docs/admin/telemetry.md
+++ b/docs/admin/telemetry.md
@@ -22,7 +22,7 @@ Settings section of the platform UI.
 It is also possible to disable in the `flowforge.yml` configuration file. This
 overrides whatever option is set in the Admin Settings UI.
 
-```
+```yaml
 telemetry:
   enabled: false
 ```
@@ -31,7 +31,7 @@ telemetry:
 
 The following pieces of information are included in the telemetry sent back to us:
 
-```
+```js
 {
   instanceId: '5db51f99-c6fb-4340-9c19-78adce58cc1b',
   os: { type: 'Darwin', release: '20.5.0', arch: 'x64' },
@@ -80,7 +80,7 @@ It currently supports using [Plausible Analytics](https://plausible.io/) to gath
 
 Further details about how users are navigating around your instance of FlowForge can be enabled via [Plausible](https://plausible.io/). This can be enabled with:
 
-```
+```yaml
 telemetry:
   enabled: true
   frontend:
@@ -90,7 +90,7 @@ telemetry:
 
 Optionally, you can use a Plausible `extension` too:
 
-```
+```yaml
 telemetry:
   enabled: true
   frontend:

--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -46,17 +46,19 @@ To make it easier, you can use the [FlowForge Development Environment](https://g
 
 The following steps will get your development environment setup in no time:
 
-       git clone https://github.com/flowforge/flowforge-dev-env.git
-       cd flowforge-dev-env
-       npm install
-       npm run init
+```bash
+git clone https://github.com/flowforge/flowforge-dev-env.git
+cd flowforge-dev-env
+npm install
+npm run init
+```
 
 This clones all of the main project repositories, installs their dependencies and builds
 the repositories that need it.
 
 All of the repositories are cloned under the `packages` directory:
 
-```
+```txt
 flowforge-dev-env
 └── packages
     ├── flowforge
@@ -77,7 +79,7 @@ More details on using the FlowForge Development Environment are available in its
 The `flowforge/flowforge` repository is the core of the platform and where you'll 
 likely want to begin.
 
-```
+```txt
 .
 ├── bin
 ├── config               - build config files
@@ -123,7 +125,7 @@ You will need to setup the version(s) of Node-RED you want to use in your stacks
 
 From the `flowforge` directory run
 
-```
+```bash
 npm run install-stack --vers=2.2.2
 ```
 
@@ -134,7 +136,7 @@ Where `2.2.2` is the version of Node-RED you want to use in the stack.
 A number of `npm` tasks are defined in the `package.json` file of this repository.
 To get started from the `flowforge` directory use:
 
-```
+```bash
 npm run serve
 ```
 
@@ -178,7 +180,7 @@ licence is not valid for production usage.
 
 For FlowForge Inc. employees the configuration is provided in 1Password as 'Stripe Testing Configuration'.
 
-```
+```yaml
 license: ***
 
 billing:
@@ -204,7 +206,7 @@ to handle webhook callbacks properly. Install the CLI following their documentat
 run the following command, with the API key using the value of `billing.stripe.key` from
 above.
 
-```
+```bash
 stripe listen --forward-to localhost:3000/ee/billing/callback --api-key ***
 ```
 
@@ -292,7 +294,7 @@ There are 2 other "Run and Debug" entries in the menu...
 * "Debug Current Test" - this will enable you to step debug a test (starts debugging the currently open test file)
 
 #### 
-```javascript
+```json
 {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.

--- a/docs/contribute/api-design.md
+++ b/docs/contribute/api-design.md
@@ -16,7 +16,7 @@ of the `id` property. This property should be used on the API but aliased as the
 Each database model has a pair of helper functions to encode and decode hashids
 to/from the true `id` value:
 
-```
+```js
 const encodedHashid = app.db.models.User.encodeHashid(123);
 const objectId = app.db.models.User.decodeHashid("edjEbo2K1w")
 ```
@@ -27,7 +27,7 @@ const objectId = app.db.models.User.decodeHashid("edjEbo2K1w")
 
 All admin-only routes exist under:
 
-```
+```txt
 /api/v1/admin/...
 ```
 
@@ -35,7 +35,7 @@ All admin-only routes exist under:
 
 All routes relating to the logged-in user exist under:
 
-```
+```txt
 /api/v1/user/...
 ```
 
@@ -43,7 +43,7 @@ All routes relating to the logged-in user exist under:
 
 API routes that related to objects in collections follow the pattern:
 
-```
+```txt
 /api/v1/<plural-noun>/<instance-id>/...
 ```
 
@@ -62,7 +62,7 @@ If there is a valid session, `request.session.User` will be the requesting user.
 In rare cases, a route needs to be accessible to anonymous users. To by-pass
 the built-in preHandler, you can set `allowAnonymous` on the routes `config` object:
 
-```
+```js
 app.get('/', { config: { allowAnonymous: true } }, async (request, reply) => {
      ...
 })
@@ -104,7 +104,7 @@ permission.
 For example, to add a user to a team, the requesting user needs to have
 `"team:user:add"`:
 
-```
+```js
 app.post('/', { preHandler: app.needsPermission("team:user:add") }, async (request, reply) => {
     // This is defined under forge/routes/api/teamMembers.js - and is mounted
     // under the path `/api/v1/teams/:teamId/members/`
@@ -117,7 +117,7 @@ app.post('/', { preHandler: app.needsPermission("team:user:add") }, async (reque
 
 If a route needs to return an error it should respond with a payload in the format:
 
-```
+```js
 {
     code: 'error_code',
     error: 'Human-readable message'
@@ -160,12 +160,12 @@ in the collection and provides the starting point for what should be returned.
 
 The response object for paginated end-points should have the format:
 
-```
+```js
 {
     "meta": {
         "next_cursor": "16416724188790000",
     },
-    "<object-type>": [ ]
+    "<object-type>": [ ],
     "count": 123
 }
 ```
@@ -210,7 +210,7 @@ Within a route handler for a paginated end-point, the following helper function
 can be used to get the pagination options from the request, as well as specifying
 default options:
 
-```
+```js
 const paginationOptions = app.getPaginationOptions(request, {limit: 30})
 
 // paginationOptions.limit = how many results to return
@@ -224,7 +224,7 @@ function.
 
 For example, the imaginary `Thing` model:
 
-```
+```js
 const { buildPaginationSearchClause } = require('../utils')
 
 ...

--- a/docs/contribute/db-migrations.md
+++ b/docs/contribute/db-migrations.md
@@ -31,7 +31,7 @@ right order.
 
 The migration code should use the following layout:
 
-```
+```js
 module.exports = {
     up: async (context) => {
         // Apply the migration

--- a/docs/install/dns-setup.md
+++ b/docs/install/dns-setup.md
@@ -43,7 +43,7 @@ The following headings cover how to do this on a number of different operating s
 
 For Docker on Linux you can use `172.17.0.1` as the address for the domain which is the IP address assigned to the `docker0` interface.
 
-```
+```bash
 sudo apt-get install dnsmasq
 sudo echo "bind-interfaces" >> /etc/dnsmasq.conf
 sudo echo "no-resolv" >> /etc/dnsmasq.conf
@@ -60,7 +60,7 @@ sudo service systemd-resolved restart
 For Docker on Linux you can use `172.17.0.1` as the address for the domain which is the IP address assigned to the `docker0` interface.
 
 
-```
+```bash
 sudo dnf install dnsmasq
 sudo echo "bind-interfaces" >> /etc/dnsmasq.conf
 sudo echo "no-resolv" >> /etc/dnsmasq.conf
@@ -81,13 +81,13 @@ Unfortunately dnsmasq will not run on Windows and I have not found something sim
 
 On MacOS you can alias a private IP address to the loop back interface e.g. `10.128.0.1` with
 
-```
+```bash
 sudo ifconfig lo0 alias 10.128.0.1`
 ```
 
 You will need install dnsmasq using [homebrew](https://docs.brew.sh/Installation)
 
-```
+```bash
 brew install dnsmasq
 ```
 
@@ -96,27 +96,27 @@ It appears that the install location differs based on the Apple Hardware. For In
 Then edit a configuration file 
 
 M1 mac
-```
+```bash
 echo "conf-dir=/opt/homebrew/etc/dnsmasq.d" >> /opt/homebrew/etc/dnsmasq.conf
 echo "address=/example.com/10.128.0.1" > /opt/homebrew/etc/dnsmasq.d/ff.conf
 ```
 
 Intel mac
-```
+```bash
 echo "conf-dir=/usr/local/etc/dnsmasq.d" >> /usr/local/etc/dnsmasq.conf
 echo "address=/example.com/10.128.0.1" > /usr/local/etc/dnsmasq.d/ff.conf
 ```
 
 Set dnsmasq to run as a service
 
-```
+```bash
 brew services start dnsmasq
 dscacheutil -flushcache
 ```
 
 Tell MacOS to use dnsmasq for our test domain
 
-```
+```bash
 sudo mkdir -p /etc/resolver
 sudo tee /etc/resolver/example.com > /dev/null <<EOF
 nameserver 127.0.0.1
@@ -127,7 +127,7 @@ EOF
 
 And finally kick the MacOS resolver so it sees the updates
 
-```
+```bash
 sudo killall -HUP mDNSResponder
 ```
 
@@ -137,7 +137,7 @@ Pi Hole is a package that bundles dnsmasq as an image to run on a Raspberry Pi (
 
 Create the following file in `/etc/dnsmasq.d` called `02-flowforge.conf`
 
-```
+```bash
 address=/example.com/192.168.0.22
 ```
 
@@ -145,7 +145,7 @@ Where 192.168.0.22 is the ipv4 address of the Docker host machine or a Kubernete
 
 After making the change you will probably need to restart things with:
 
-```
+```bash
 sudo pihole restartdns
 ```
 

--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -34,7 +34,7 @@ Download the latest release tar.gz from the docker-compose project:
 
 Unpack this and cd into the created directory.	
 
-```
+```bash
 tar zxf v0.x.0.tar.gz
 cd docker-compose-x.x.x
 ```
@@ -54,7 +54,7 @@ set the correct domain name and make the same change to the `public_url` entry i
 
 `docker-compose.yml`
 
-```
+```yaml
   ...
   flowforge-broker:
     image: "iegomez/mosquitto-go-auth"
@@ -73,7 +73,7 @@ set the correct domain name and make the same change to the `public_url` entry i
 
 `etc/flowforge.yml`
 
-```
+```yaml
   ...
   broker:
     url: mqtt://forge:1883
@@ -93,17 +93,17 @@ You  also need to create a copy of the .crt and .key files named `default.crt` &
 
 In the `docker-compose.yml` file, 
 - uncomment the line 
-```
+```yaml
 -   "443:443"
 ```
 
 - Add this line to the `volumes` section of the nginx proxy 
-```
+```yaml
 - "./certs:/etc/nginx/certs"
 ```
 
 If you wish to redirect all traffic to use HTTPS then add the following section to the nginx service on docker-compose.yml
-```
+```yaml
 environment:
       - "HTTPS_METHOD=redirect"
 ```
@@ -113,13 +113,13 @@ If you are running with the MQTT broker then you should adjust the `public_url` 
 #### Let's Encrypt
 
 In the `docker-compose.yml` file, uncomment the following lines
-```
+```yaml
 - "./certs:/etc/nginx/certs"
 ```
-```
+```yaml
 - "443:443"
 ```
-```
+```yaml
   acme:
     image: nginxproxy/acme-companion
     volumes:
@@ -133,19 +133,19 @@ In the `docker-compose.yml` file, uncomment the following lines
       - "nginx"
 ```
 If you wish to redirect all traffic to use HTTPS then add the following section to the nginx service on docker-compose.yml
-```
+```yaml
 environment:
       - "HTTPS_METHOD=redirect"
 ```
 Then, in the `docker-compose.yml` file, edit the following lines added your domain and email address
 
-```
+```yaml
 - "DEFAULT_EMAIL=mail@example.com"
 ```
-```
+```yaml
 - "LETSENCRYPT_HOST=mqtt.example.com"
 ```
-```
+```yaml
 - "LETSENCRYPT_HOST=forge.example.com"
 ```
 
@@ -157,19 +157,19 @@ We need to manually download the `flowforge/node-red` container that will be use
 
 This is done with this command:
 
-```
+```bash
 docker pull flowforge/node-red
 ```
 
 Once that completes we can start FlowForge:
 
 Using the docker compose plugin
-```
+```bash
 docker compose -p flowforge up -d
 ```
 
 Or using the docker-compose command
-```
+```bash
 docker-compose up -p flowforge up -d
 ```
 
@@ -205,7 +205,7 @@ For more information, follow [this guide](../first-run.md).
 - Uncompress the tar file
 - Rebuild the containers with the `./build-containers.sh` script in the new directory
 - Copy the `db` directory from the old version directory to the new (this will probably require root due to file ownership)
-    ```
+    ```bash
     sudo cp -r docker-compose-x.x.x/db docker-compose-y.y.y/db
     ```
 - Start the new version in the new directory `docker-compose -p flowforge up`

--- a/docs/install/email_providers.md
+++ b/docs/install/email_providers.md
@@ -1,7 +1,7 @@
 ## Example configuration for common email platforms
 
 ### GMail
-```
+```yaml
 email:
   enabled: true
   debug: false

--- a/docs/install/file-storage/README.md
+++ b/docs/install/file-storage/README.md
@@ -34,7 +34,7 @@ to persist files.
 The only configuration option used is the path to the directory to use
 as the root of the storage
 
-```
+```yaml
 host: 0.0.0.0
 port: 3001
 base_url: http://flowforge:3000
@@ -59,7 +59,7 @@ For further reference of all available options you can look at the S3Client docu
 
 For example:
 
-```
+```yaml
 host: '0.0.0.0'
 port: 3001
 base_url: http://forge.default

--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -61,7 +61,7 @@ Some features require the ability to send email to users. This can be currently 
 
 #### Download
 
-```
+```bash
 helm repo add flowforge https://flowforge.github.io/helm`
 helm repo update
 ```
@@ -103,18 +103,18 @@ You will need to label at least one node to run the management application and o
 You can do this with the `kubectl` utility. The following command lists 
 all the nodes in the cluster
 
-```
+```bash
 kubectl get nodes
 ```
 
 You can then use `kubectl label node` to add the required labels:
 
 FlowForge management node(s)
-```
+```bash
 kubectl label node <management node name> role=management
 ```
 Node-RED projects node(s)
-```
+```bash
 kubectl label node <projects node name> role=projects
 ```
 
@@ -130,7 +130,7 @@ A full list of all the configurable values can be found in the [Helm Chart READM
 
 The install can then be started with the following command:
 
-```
+```bash
 helm upgrade --atomic --install flowforge flowforge/flowforge -f customization.yml
 ```
 
@@ -138,7 +138,7 @@ helm upgrade --atomic --install flowforge flowforge/flowforge -f customization.y
 
 To enable the MQTT broker with Kubernetes install you need to add the following to the `customization.yml` file
 
-```
+```yaml
 forge:
   broker:
     url: mqtt://forge:1883

--- a/docs/install/kubernetes/aws.md
+++ b/docs/install/kubernetes/aws.md
@@ -48,12 +48,12 @@ Record the host name it will look like `[aws id].dkr.ecr.[aws region].amazonaws.
 ## Create EKS Cluster
 Edit the `cluster.yml` file in `aws_eks` to set your preferred instance type and count along with AWS Region
 
-```
+```bash
 eksctl create cluster -f cluster.yml
 ```
 
 Example cluster.yml (Please visit [eksctl.io](https://eksctl.io/usage/creating-and-managing-clusters/#using-config-files) to be sure you understand what this does.)
-```
+```yaml
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
@@ -87,12 +87,12 @@ nodeGroups:
 ```
 
 Add oidc provider for Loadbalance and IAM roles
-```
+```bash
 eksctl utils associate-iam-oidc-provider --cluster flowforge-test --approve
 ```
 
 Add AWS Load balancer (remember to update `[aws id]`)
-```
+```bash
 curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.2.0/docs/install/iam_policy.json
 
 aws iam create-policy --policy-name AWSLoadBalancerControllerIAMPolicy --policy-document file://iam_policy.json
@@ -120,7 +120,7 @@ Request move to production from sandbox (need to include examples of emails bein
 
 `ses_policy.json` (with suitable aws id, aws region and domain modifications):
 
-```
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -138,7 +138,7 @@ Request move to production from sandbox (need to include examples of emails bein
 }
 ```
 
-```
+```bash
 IAM_POLICY_ARN=$(aws iam create-policy --policy-name FlowForgeSendEmail --policy-document file://ses_policy.json | jq -r .Policy.Arn)
 ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 OIDC_PROVIDER=$(aws eks describe-cluster --name flowforge --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
@@ -191,12 +191,12 @@ A copy of this file can be found [here](setup-rds.sh)
 
 Run the following command
 
-```
+```bash
 ./setup-rds.sh
 ```
 
 Make a note of the postgress hostname
-```
+```bash
 aws rds describe-db-instances | jq .DBInstances[].Endpoint.Address
 ```
 

--- a/docs/install/kubernetes/digital-ocean.md
+++ b/docs/install/kubernetes/digital-ocean.md
@@ -34,7 +34,7 @@ the `k8s-flowforge-kubeconfig.yml` file which will allow you to connect to the c
 
 ## Install Ingress Controller
 
-```
+```bash
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 helm --kubeconfig=./k8s-flowforge-kubeconfig.yaml install nginx-ingress \
@@ -51,7 +51,7 @@ helm --kubeconfig=./k8s-flowforge-kubeconfig.yaml install nginx-ingress \
 Run the following to get the external IP address of the Nginx Ingress 
 Controller
 
-```
+```bash
 kubectl --kubeconfig=./k8s-flowforge-kubeconfig.yaml \
   -n ingress-nginx get service nginx-ingress-ingress-nginx-controller
 ```
@@ -63,7 +63,7 @@ You will need to update the entry in your DNS server to point
 
 Then setup the FlowForge Helm repository
 
-```
+```bash
 helm repo add flowforge https://flowforge.github.io/helm
 helm repo update
 ```
@@ -86,7 +86,7 @@ forge:
 
 Then we use this to install FlowForge
 
-```
+```bash
 helm upgrade --install --kubeconfig ./k8s-flowforge-kubeconfig.yml \
   flowforge flowforge/flowforge -f customizations.yml \
   --wait

--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -43,7 +43,7 @@ You will also need to install the appropriate build tools.
 * **Windows**: the standard Node.js installer will offer to do that for you.
 * **MacOS**: you will need the `XCode Command Line Tools` to be installed. 
   This can be done by running the following command:
-    ```
+    ```bash
     xcode-select --install
     ```
 
@@ -52,13 +52,13 @@ You will also need to install the appropriate build tools.
 1. Create a directory to be the base of your FlowForge install. For example: `/opt/flowforge` or `c:\flowforge`
 
    For Linux/MacOS:
-    ```
+    ```bash
     sudo mkdir /opt/flowforge
     sudo chown $USER /opt/flowforge
     ```
    
    For Windows:
-    ```
+    ```bash
     mkdir c:\flowforge
     ```
 
@@ -70,7 +70,7 @@ You will also need to install the appropriate build tools.
 
    ### For Linux/MacOS: 
    _Assumes `/tmp/` is the directory where you downloaded `flowforge-installer.zip`_
-    ```
+    ```bash
     cd /tmp/
     unzip flowforge-installer.zip
     cp -R flowforge-installer/* /opt/flowforge
@@ -79,7 +79,7 @@ You will also need to install the appropriate build tools.
 
    ### For Windows:
    _Assumes `c:\temp` is the directory where you downloaded `flowforge-installer.zip`_
-    ```
+    ```bash
     cd c:\temp
     tar -xf flowforge-installer.zip
     xcopy /E /I flowforge-installer c:\flowforge
@@ -90,13 +90,13 @@ You will also need to install the appropriate build tools.
 4. Run the installer and follow the prompts
 
    For Linux/MacOS:
-    ```
+    ```bash
     cd /opt/flowforge
     ./install.sh
     ```
 
    For Windows:
-    ```
+    ```bash
     cd c:\flowforge
     install.bat
     ```
@@ -132,12 +132,12 @@ For more information on all of the options available, see the [configuration gui
 To run it manually, you can use:
 
  - Linux/MacOS:
-    ```
+    ```bash
     /opt/flowforge/bin/flowforge.sh
     ```
 
  - Windows:
-    ```
+    ```bash
     c:\flowforge\bin\flowforge.bat
     ```
 
@@ -145,7 +145,7 @@ Or to run as a service:
 
  - Linux
  
-    ```
+    ```bash
     service flowforge start
     ```
 ## First Run Setup
@@ -183,7 +183,7 @@ your operating system.
 Once installed, you will need to build and install the authentication plugin.
 
 1. Clone the plugin repository
-    ```
+    ```bash
     git clone https://github.com/iegomez/mosquitto-go-auth.git
     ```
 
@@ -200,7 +200,7 @@ Once installed, you will need to build and install the authentication plugin.
       - `auth_opt_http_host` / `auth_opt_http_port` - if you plan to run the platform
         on a different port, change these settings to match.
 
-    ```
+    ```bash
     mosquitto -c broker/mosquitto.conf
     ```
 
@@ -210,7 +210,7 @@ Instead of installing and building mosquitto and the authentication plugin from 
 you can use a pre-built docker image that provides everything needed.
 
 1. First pull the latest version of the pre-built container
-    ```
+    ```bash
     docker pull iegomez/mosquitto-go-auth
     ```
 
@@ -221,7 +221,7 @@ you can use a pre-built docker image that provides everything needed.
      - `auth_opt_http_port` if you have changed the port the Forge platform is running on
 
 3. Start the container with the following command
-    ```
+    ```bash
     docker run -d -v /full/path/to/mosquitto.conf:/etc/mosquitto/mosquitto.conf -p 1883:1883 -p 1884:1884 --name flowforge-broker iegomez/mosquitto-go-auth
     ```
 

--- a/docs/install/local/stacks.md
+++ b/docs/install/local/stacks.md
@@ -29,13 +29,13 @@ For a local install there are two steps required:
    must provide the full Node-RED version number, eg `3.0.2`, or use `latest` to install the most recent stable version.
 
    Linux/Mac:
-   ```
+   ```bash
    cd /opt/flowforge
    ./bin/ff-install-stack.sh 3.0.2
    ```
 
    Windows
-   ```
+   ```bash
    cd c:\flowforge
    bin\ff-install-stack.bat 3.0.2
    ```

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -45,7 +45,7 @@ container driver. We are moving from v5.0.2 to v5.0.8.
 There appears to be a clash with the bcrypt module when doing an inplace upgrade of the
 SQLite3 module that gives an error similar to the following:
 
-```
+```bash
 npm ERR! path /opt/share/projects/flowforge/sqlite-test/node_modules/sqlite3
 npm ERR! command failed
 npm ERR! command sh -c node-pre-gyp install --fallback-to-build

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -12,7 +12,7 @@ The Device Agent is published to the public npm repository as [@flowforge/flowfo
 It can be installed as a global npm module. This will ensure the agent
 command is on the path:
 
-```
+```bash
 sudo npm install -g @flowforge/flowforge-device-agent
 ```
 
@@ -26,7 +26,7 @@ This can be overridden with the `-d/--dir` option.
 The directory must exist and be accessible to the user that will be
 running the agent.
 
-```
+```bash
 sudo mkdir /opt/flowforge-device
 sudo chown -R $USER /opt/flowforge-device
 ```
@@ -38,7 +38,7 @@ change this behaviour and listen on another port of choosing: `-p/--port`. This 
 be useful for custom firewall rules, or when running multiple device agents on
 the same machine.
 
-```
+```bash
 flowforge-device-agent --port=1881
 ```
 
@@ -69,7 +69,7 @@ with the `-d` option).
 
 The agent can then be started with the command:
 
-```
+```bash
 flowforge-device-agent
 ```
 

--- a/docs/user/node-red-tools.md
+++ b/docs/user/node-red-tools.md
@@ -15,7 +15,7 @@ be pushed out to your Project's devices through FlowForge.
 This plugin can be installed through the Manage Palette option in the Node-RED
 editor, or on the command-line:
 
-```
+```bash
 cd ~/.node-red
 npm install @flowforge/nr-tools-plugin
 ```


### PR DESCRIPTION
Apologies it's a big one, but it's a pass of all code examples in the docs to add the relevant language in so that our new syntax highlighting applies to them, and we get a "copy to clipboard" button appear.