### PR TITLE
Simplify Stripe callback handling

### DIFF
--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -1,17 +1,22 @@
 const should = require('should')
+const sinon = require('sinon')
 const setup = require('../../setup')
 
 describe('Stripe Callbacks', function () {
+    const sandbox = sinon.createSandbox()
+
     let app
 
     const callbackURL = '/ee/billing/callback'
 
     beforeEach(async function () {
         app = await setup()
+        sandbox.spy(app.log)
     })
 
     afterEach(async function () {
         await app.close()
+        sandbox.restore()
     })
 
     describe('charge.failed', () => {
@@ -34,11 +39,14 @@ describe('Stripe Callbacks', function () {
                     type: 'charge.failed'
                 }
             })
-            // Should do nothing but return a 200
+
+            should(app.log.info.called).equal(true)
+            app.log.info.lastCall.firstArg.should.equal(`Stripe charge.failed event ch_1234567890 received for team '${app.team.hashid}'`)
+
             should(response).have.property('statusCode', 200)
         })
 
-        it('Does not throw an error for unknown customer', async function () {
+        it('Logs and does not throw an error for unknown customer', async function () {
             const response = await app.inject({
                 method: 'POST',
                 url: callbackURL,
@@ -57,7 +65,10 @@ describe('Stripe Callbacks', function () {
                     type: 'charge.failed'
                 }
             })
-            // Should do nothing but return a 200
+
+            should(app.log.error.called).equal(true)
+            app.log.error.lastCall.firstArg.should.equal("Stripe charge.failed event ch_1234567890 received for unknown team 'cus_does_not_exist'")
+
             should(response).have.property('statusCode', 200)
         })
     })
@@ -85,6 +96,9 @@ describe('Stripe Callbacks', function () {
                     type: 'checkout.session.completed'
                 }
             }))
+            should(app.log.info.called).equal(true)
+            app.log.info.firstCall.firstArg.should.equal(`Stripe checkout.session.completed event cs_1234567890 received for team '${app.team.hashid}'`)
+
             should(response).have.property('statusCode', 200)
             const sub = await app.db.models.Subscription.byCustomer('cus_0987654321')
             should(sub.customer).equal('cus_0987654321')
@@ -93,5 +107,35 @@ describe('Stripe Callbacks', function () {
             should(team.name).equal('ATeam')
         })
     })
+
+    describe('checkout.session.expired', () => {
+        it('Logs and does not throw an error', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_123456790',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'cs_1234567890',
+                            object: 'checkout.session',
+                            customer: 'cus_1234567890',
+                            subscription: 'sub_0987654321',
+                            status: 'expired'
+                        }
+                    },
+                    type: 'checkout.session.expired'
+                }
+            }))
+
+            should(app.log.info.called).equal(true)
+            app.log.info.firstCall.firstArg.should.equal(`Stripe checkout.session.expired event cs_1234567890 received for team '${app.team.hashid}'`)
+
+            should(response).have.property('statusCode', 200)
+        })
     })
 })


### PR DESCRIPTION
This is to be swiftly followed up by implementation of handling subscription creation and cancelation events but pulled this into a separate PR for easier review.

The main objective here was to flatten down the multiple rounds of logic into a single case statement to make it easier to follow when the logic for #1162 is added and increase the test coverage slightly.