### PR TITLE
Handle Stripe subscription cancellations

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -137,7 +137,7 @@ module.exports = {
                 }, 250)
             })
         } else {
-            throw new Error({ error: project.id + ' not found' })
+            throw new Error(`${project.id} not found`)
         }
     },
     /**

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -158,11 +158,15 @@ module.exports = {
         if (project.state !== 'suspended') {
             // Only updated billing if the project isn't already suspended
             if (this._isBillingEnabled()) {
-                await this._subscriptionHandler.requireSubscription(project.Team)
-                try {
-                    await this._app.billing.removeProject(project.Team, project)
-                } catch (err) {
-                    throw new Error('Problem with removing project from subscription')
+                const subscription = await this._subscriptionHandler.requireSubscription(project.Team)
+                if (!subscription.isCanceled()) {
+                    try {
+                        await this._app.billing.removeProject(project.Team, project)
+                    } catch (err) {
+                        throw new Error('Problem with removing project from subscription')
+                    }
+                } else {
+                    this._app.log.warn(`Skipped removing project '${project.id}' from subscription for canceled subscription '${subscription.subscription}'`)
                 }
             }
         }

--- a/forge/db/migrations/20221208-01-add-state-to-subscription.js
+++ b/forge/db/migrations/20221208-01-add-state-to-subscription.js
@@ -6,7 +6,12 @@ const { DataTypes } = require('sequelize')
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-    async up (queryInterface, Sequelize) {
+    async up (queryInterface) {
+        const tableExists = await queryInterface.tableExists('Subscriptions')
+        if (!tableExists) {
+            return queryInterface.sequelize.log('Skipping Subscription migration as table does not exist')
+        }
+
         await queryInterface.addColumn('Subscriptions', 'status', {
             type: DataTypes.ENUM,
             values: ['active', 'canceled'], // Full list from stripe: trialing,active,incomplete,incomplete_expired,past_due,canceled,unpaid
@@ -14,7 +19,12 @@ module.exports = {
         })
     },
 
-    async down (queryInterface, Sequelize) {
+    async down (queryInterface) {
+        const tableExists = await queryInterface.tableExists('Subscriptions')
+        if (!tableExists) {
+            return queryInterface.sequelize.log('Skipping Subscription migration as table does not exist')
+        }
+
         await queryInterface.removeColumn('Subscriptions', 'status')
     }
 }

--- a/forge/db/migrations/20221208-01-add-state-to-subscription.js
+++ b/forge/db/migrations/20221208-01-add-state-to-subscription.js
@@ -1,0 +1,20 @@
+/**
+ * Add status to subscriptions
+ */
+
+const { DataTypes } = require('sequelize')
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up (queryInterface, Sequelize) {
+        await queryInterface.addColumn('Subscriptions', 'status', {
+            type: DataTypes.ENUM,
+            values: ['active', 'canceled'], // Full list from stripe: trialing,active,incomplete,incomplete_expired,past_due,canceled,unpaid
+            defaultValue: 'active'
+        })
+    },
+
+    async down (queryInterface, Sequelize) {
+        await queryInterface.removeColumn('Subscriptions', 'status')
+    }
+}

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -42,7 +42,6 @@ module.exports = {
         const self = this
         return {
             instance: {
-                STATUS,
                 isActive () {
                     return this.status === STATUS.ACTIVE
                 },
@@ -51,6 +50,7 @@ module.exports = {
                 }
             },
             static: {
+                STATUS,
                 byTeam: async function (team) {
                     if (typeof team === 'string') {
                         team = M.Team.decodeHashid(team)

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -23,7 +23,8 @@ module.exports = {
         },
         status: {
             type: DataTypes.ENUM(Object.values(STATUS)),
-            allowNull: false
+            allowNull: false,
+            defaultValue: STATUS.ACTIVE
         }
     },
     associations: function (M) {

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -2,6 +2,14 @@ const {
     DataTypes
 } = require('sequelize')
 
+// A subset of the statuses on Stripe that are important to FlowForge
+// https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses
+const STATUS = {
+    ACTIVE: 'active',
+    CANCELED: 'canceled'
+}
+Object.freeze(STATUS)
+
 module.exports = {
     name: 'Subscription',
     schema: {
@@ -11,6 +19,10 @@ module.exports = {
         },
         subscription: {
             type: DataTypes.STRING,
+            allowNull: false
+        },
+        status: {
+            type: DataTypes.ENUM(Object.values(STATUS)),
             allowNull: false
         }
     },
@@ -29,6 +41,15 @@ module.exports = {
     finders: function (M) {
         const self = this
         return {
+            instance: {
+                STATUS,
+                isActive () {
+                    return this.status === STATUS.ACTIVE
+                },
+                isCanceled () {
+                    return this.status === STATUS.CANCELED
+                }
+            },
             static: {
                 byTeam: async function (team) {
                     if (typeof team === 'string') {

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -13,10 +13,15 @@ Object.freeze(STATUS)
 module.exports = {
     name: 'Subscription',
     schema: {
+        // Customer ID from stripe, e.g. cus_xyz123
+        // Each team has one subscription, that is tied to a single stripe customer, via the customer ID field
         customer: {
             type: DataTypes.STRING,
             allowNull: false
         },
+        // Subscription ID from stripe e.g. sub_xyz123
+        // Stored for reference only, Stripe events should only be matched to subscription objects via
+        // the customer field
         subscription: {
             type: DataTypes.STRING,
             allowNull: false
@@ -29,15 +34,6 @@ module.exports = {
     },
     associations: function (M) {
         this.belongsTo(M.Team)
-    },
-    hooks: function (M) {
-        // M.Team.addHook('afterCreate', (Team, options) => {
-        //     console.log("Subscription hook on Team")
-        // })
-        // M.Team.addHook('afterDestroy', (Team, options) => {
-        //     console.log("Subscription destroy hook on Team")
-        // })
-        return {}
     },
     finders: function (M) {
         const self = this

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -166,6 +166,10 @@ module.exports = async function (app) {
 
             case 'customer.subscription.updated': {
                 const { stripeSubscriptionId, subscription } = await parseSubscriptionEvent(event)
+                if (!subscription) {
+                    response.status(200).send()
+                    return
+                }
 
                 const stripeSubscriptionStatus = event.data.object.status
                 if (Object.values(app.db.models.Subscription.STATUS).includes(stripeSubscriptionStatus)) {

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -32,6 +32,8 @@ module.exports = async function (app) {
             }
             reply.send()
         } catch (err) {
+            app.db.controllers.Project.clearInflightState(request.project)
+
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.Project.project.started(request.session.User, resp, request.project)
             reply.code(500).send(resp)
@@ -52,6 +54,8 @@ module.exports = async function (app) {
             app.db.controllers.Project.clearInflightState(request.project)
             reply.send(result)
         } catch (err) {
+            app.db.controllers.Project.clearInflightState(request.project)
+
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.Project.project.stopped(request.session.User, resp, request.project)
             reply.code(500).send(resp)
@@ -72,6 +76,8 @@ module.exports = async function (app) {
             app.db.controllers.Project.clearInflightState(request.project)
             reply.send(result)
         } catch (err) {
+            app.db.controllers.Project.clearInflightState(request.project)
+
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.Project.project.restarted(request.session.User, resp, request.project)
             reply.code(500).send(resp)
@@ -90,6 +96,8 @@ module.exports = async function (app) {
             await app.auditLog.Project.project.suspended(request.session.User, null, request.project)
             reply.send()
         } catch (err) {
+            app.db.controllers.Project.clearInflightState(request.project)
+
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.Project.project.suspended(request.session.User, resp, request.project)
             reply.code(500).send(resp)
@@ -121,6 +129,8 @@ module.exports = async function (app) {
             }
             reply.send({ status: 'okay' })
         } catch (err) {
+            app.db.controllers.Project.clearInflightState(request.project)
+
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.Project.project.snapshot.rolledBack(request.session.User, resp, request.project)
             reply.code(500).send(resp)

--- a/test/unit/forge/containers/index_spec.js
+++ b/test/unit/forge/containers/index_spec.js
@@ -238,7 +238,7 @@ describe('Container Wrapper', function () {
                 const project = await setupProject()
                 const team = await app.db.models.Team.byName('ATeam')
                 await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
-                const result = app.containers.start(project)
+                const result = await app.containers.start(project)
                 await result.started
 
                 await app.db.controllers.Subscription.deleteSubscription(team)

--- a/test/unit/forge/containers/index_spec.js
+++ b/test/unit/forge/containers/index_spec.js
@@ -167,6 +167,19 @@ describe('Container Wrapper', function () {
                 await promise.should.be.rejectedWith(/No Subscription for this team/)
             })
 
+            it('rejects if team does not have an active subscription', async function () {
+                const project = await setupProject()
+                const team = await app.db.models.Team.byName('ATeam')
+
+                const subscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+                subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                await subscription.save()
+                should(subscription.isCanceled()).equal(true)
+
+                const promise = app.containers.start(project)
+                await promise.should.be.rejectedWith(/Teams subscription is currently canceled/)
+            })
+
             it('adds project to team subscription', async function () {
                 const project = await setupProject()
                 const team = await app.db.models.Team.byName('ATeam')
@@ -245,6 +258,23 @@ describe('Container Wrapper', function () {
 
                 await app.containers.stop(project).should.be.rejectedWith(/No Subscription for this team/)
             })
+
+            it('still stops the project even if the team does not have an active subscription', async function () {
+                const project = await setupProject()
+                const team = await app.db.models.Team.byName('ATeam')
+
+                const subscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+
+                const result = await app.containers.start(project)
+                await result.started
+
+                subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                await subscription.save()
+                should(subscription.isCanceled()).equal(true)
+
+                await app.containers.stop(project)
+                project.state.should.equal('suspended')
+            })
         })
 
         describe('remove', function () {
@@ -302,6 +332,110 @@ describe('Container Wrapper', function () {
                 const promise = app.containers.stop(project)
                 await promise
                 promise.should.be.rejectedWith(/No Subscription for this team/)
+            })
+
+            it('removes the running project from the driver but not billing if the subscription is cancelled', async function () {
+                const project = await setupProject()
+                const team = await app.db.models.Team.byName('ATeam')
+                const subscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+                const result = await app.containers.start(project)
+                await result.started
+
+                subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                await subscription.save()
+                should(subscription.isCanceled()).equal(true)
+
+                await app.containers.remove(project)
+                stubBilling.removeProject.callCount.should.equal(0)
+            })
+        })
+
+        describe('mock driver', function () {
+            const sandbox = sinon.createSandbox()
+
+            let mockDriver
+
+            beforeEach(function () {
+                mockDriver = {
+                    startFlows: sandbox.fake(),
+                    stopFlows: sandbox.fake(),
+                    restartFlows: sandbox.fake()
+                }
+
+                app.containers.init(app, mockDriver, {})
+            })
+
+            afterEach(function () {
+                sandbox.restore()
+            })
+
+            describe('startFlows', function () {
+                it('starts flows if the team has an active subscription', async function () {
+                    const project = await setupProject()
+                    const team = await app.db.models.Team.byName('ATeam')
+                    await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+                    await app.containers.startFlows(project, {})
+
+                    mockDriver.startFlows.callCount.should.equal(1)
+                })
+
+                it('does not start the flows if the teams subscription is cancelled', async function () {
+                    const project = await setupProject()
+                    const team = await app.db.models.Team.byName('ATeam')
+                    const subscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+
+                    subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                    await subscription.save()
+                    should(subscription.isCanceled()).equal(true)
+
+                    const promise = app.containers.startFlows(project, {})
+                    await promise.should.be.rejectedWith(/Teams subscription is currently canceled/)
+
+                    mockDriver.startFlows.callCount.should.equal(0)
+                })
+            })
+
+            describe('stopFlows', function () {
+                it('still stops even if the team had a cancelled subscription', async function () {
+                    const project = await setupProject()
+                    const team = await app.db.models.Team.byName('ATeam')
+                    const subscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+
+                    subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                    await subscription.save()
+                    should(subscription.isCanceled()).equal(true)
+
+                    await app.containers.stopFlows(project, {})
+
+                    mockDriver.stopFlows.callCount.should.equal(1)
+                })
+            })
+
+            describe('restartFlows', function () {
+                it('restarts if the team has an active subscription', async function () {
+                    const project = await setupProject()
+                    const team = await app.db.models.Team.byName('ATeam')
+                    await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+
+                    await app.containers.restartFlows(project, {})
+
+                    mockDriver.restartFlows.callCount.should.equal(1)
+                })
+
+                it('does not restart the flows if the teams subscription is cancelled', async function () {
+                    const project = await setupProject()
+                    const team = await app.db.models.Team.byName('ATeam')
+                    const subscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+
+                    subscription.status = app.db.models.Subscription.STATUS.CANCELED
+                    await subscription.save()
+                    should(subscription.isCanceled()).equal(true)
+
+                    const promise = app.containers.restartFlows(project, {})
+                    await promise.should.be.rejectedWith(/Teams subscription is currently canceled/)
+
+                    mockDriver.restartFlows.callCount.should.equal(0)
+                })
             })
         })
     })

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -310,8 +310,8 @@ describe('Stripe Callbacks', function () {
                         object: {
                             id: 'sub_unknown',
                             object: 'subscription',
-                            customer: 'sub_unknown',
-                            status: 'past_due'
+                            customer: 'cus_unknown',
+                            status: 'canceled'
                         },
                         previous_attributes: {
                             status: 'active'
@@ -322,7 +322,7 @@ describe('Stripe Callbacks', function () {
             }))
 
             should(app.log.error.called).equal(true)
-            app.log.error.firstCall.firstArg.should.equal("Stripe customer.subscription.updated event sub_unknown received for unknown team 'sub_unknown'")
+            app.log.error.firstCall.firstArg.should.equal("Stripe customer.subscription.updated event sub_unknown received for unknown team 'cus_unknown'")
 
             should(response).have.property('statusCode', 200)
 

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -12,6 +12,7 @@ describe('Stripe Callbacks', function () {
     beforeEach(async function () {
         app = await setup()
         sandbox.spy(app.log)
+        sandbox.stub(app.billing)
     })
 
     afterEach(async function () {
@@ -163,6 +164,310 @@ describe('Stripe Callbacks', function () {
 
             should(app.log.info.called).equal(true)
             app.log.info.firstCall.firstArg.should.equal(`Stripe checkout.session.expired event cs_1234567890 received for team '${app.team.hashid}'`)
+
+            should(response).have.property('statusCode', 200)
+        })
+    })
+
+    describe('customer.subscription.created', () => {
+        it('Logs known subscriptions', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_123456790',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_1234567890',
+                            object: 'subscription',
+                            customer: 'cus_1234567890',
+                            status: 'active'
+                        }
+                    },
+                    type: 'customer.subscription.created'
+                }
+            }))
+
+            should(app.log.info.called).equal(true)
+            app.log.info.firstCall.firstArg.should.equal(`Stripe customer.subscription.created event sub_1234567890 received for team '${app.team.hashid}'`)
+
+            should(response).have.property('statusCode', 200)
+        })
+
+        it('Logs events for unknown customers', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_123456790',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_unknown',
+                            object: 'subscription',
+                            customer: 'cus_unknown',
+                            status: 'active'
+                        }
+                    },
+                    type: 'customer.subscription.created'
+                }
+            }))
+
+            should(app.log.error.called).equal(true)
+            app.log.error.firstCall.firstArg.should.equal('Stripe customer.subscription.created event sub_unknown received for unknown team \'cus_unknown\'')
+
+            should(response).have.property('statusCode', 200)
+        })
+    })
+
+    describe('customer.subscription.updated', () => {
+        it('Updates existing subscription status if it changes', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_1MEUqIJ6VWAujNoLDtlTRH3f',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_1234567890',
+                            object: 'subscription',
+                            customer: 'cus_1234567890',
+                            status: 'canceled'
+                        },
+                        previous_attributes: {
+                            status: 'active'
+                        }
+                    },
+                    type: 'customer.subscription.updated'
+                }
+            }))
+
+            should(app.log.info.called).equal(true)
+            app.log.info.firstCall.firstArg.should.equal(`Stripe customer.subscription.updated event sub_1234567890 received for team '${app.team.hashid}'`)
+
+            should(response).have.property('statusCode', 200)
+
+            const subscription = await app.db.models.Subscription.byCustomer('cus_1234567890')
+            should(subscription.status).equal(app.db.models.Subscription.STATUS.CANCELED)
+        })
+
+        it('Ignores changes to unhandled statuses', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_1MEUqIJ6VWAujNoLDtlTRH3f',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_1234567890',
+                            object: 'subscription',
+                            customer: 'cus_1234567890',
+                            status: 'past_due'
+                        },
+                        previous_attributes: {
+                            status: 'active'
+                        }
+                    },
+                    type: 'customer.subscription.updated'
+                }
+            }))
+
+            should(app.log.warn.called).equal(true)
+            app.log.warn.firstCall.firstArg.should.equal("Stripe subscription sub_1234567890 has transitioned in Stripe to a state not currently handled: 'past_due'")
+
+            should(response).have.property('statusCode', 200)
+
+            const subscription = await app.db.models.Subscription.byCustomer('cus_1234567890')
+            should(subscription.status).equal(app.db.models.Subscription.STATUS.ACTIVE)
+        })
+
+        it('Logs updates events to unknown subscriptions or customers without error', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_1MEUqIJ6VWAujNoLDtlTRH3f',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_unknown',
+                            object: 'subscription',
+                            customer: 'sub_unknown',
+                            status: 'past_due'
+                        },
+                        previous_attributes: {
+                            status: 'active'
+                        }
+                    },
+                    type: 'customer.subscription.updated'
+                }
+            }))
+
+            should(app.log.error.called).equal(true)
+            app.log.error.firstCall.firstArg.should.equal("Stripe customer.subscription.updated event sub_unknown received for unknown team 'sub_unknown'")
+
+            should(response).have.property('statusCode', 200)
+
+            const subscription = await app.db.models.Subscription.byCustomer('cus_1234567890')
+            should(subscription.status).equal(app.db.models.Subscription.STATUS.ACTIVE) // no change
+        })
+    })
+
+    describe('customer.subscription.deleted', () => {
+        it('Cancels the teams subscription and stops all running projects', async () => {
+            const project1 = await app.db.models.Project.create({ name: 'project-1', type: '', url: '' })
+            await project1.setProjectStack(app.stack)
+            await app.team.addProject(project1)
+
+            const project2 = await app.db.models.Project.create({ name: 'project-2', type: '', url: '' })
+            await project2.setProjectStack(app.stack)
+            await app.team.addProject(project2)
+
+            const project3 = await app.db.models.Project.create({ name: 'project-3', type: '', url: '' })
+            await project3.setProjectStack(app.stack)
+            await app.team.addProject(project3)
+
+            // Ensure the team prop is loaded properly - wrapper assumes project.Team is defined
+            await project1.reload({
+                include: [
+                    { model: app.db.models.Team },
+                    { model: app.db.models.ProjectStack }
+                ]
+            })
+            await project2.reload({
+                include: [
+                    { model: app.db.models.Team },
+                    { model: app.db.models.ProjectStack }
+                ]
+            })
+            await project3.reload({
+                include: [
+                    { model: app.db.models.Team },
+                    { model: app.db.models.ProjectStack }
+                ]
+            })
+
+            // project 1 & 2 are running
+            await app.containers.start(project1)
+            await app.containers.start(project2)
+
+            // project3 is suspended
+            await app.containers.start(project3)
+            await app.containers.stop(project3)
+
+            // Assert state before
+            const teamProjects = await app.db.models.Project.byTeam(app.team.hashid)
+            should(teamProjects.length).equal(3)
+            const projectsStatesBefore = await app.db.models.Project.byTeam(app.team.hashid)
+            projectsStatesBefore.map((project) => project.state).should.match(['running', 'running', 'suspended'])
+
+            app.log.info.resetHistory()
+
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_1MEVSfJ6VWAujNoLCPdYq9kn',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_1234567890',
+                            object: 'subscription',
+                            customer: 'cus_1234567890',
+                            status: 'canceled'
+                        }
+                    },
+                    type: 'customer.subscription.deleted'
+                }
+            }))
+
+            should(app.log.info.called).equal(true)
+            app.log.info.firstCall.firstArg.should.equal(`Stripe customer.subscription.deleted event sub_1234567890 received for team '${app.team.hashid}'`)
+
+            should(response).have.property('statusCode', 200)
+
+            const subscription = await app.db.models.Subscription.byCustomer('cus_1234567890')
+            should(subscription.status).equal(app.db.models.Subscription.STATUS.CANCELED)
+
+            const projectsStatesAfter = await app.db.models.Project.byTeam(app.team.hashid)
+            projectsStatesAfter.map((project) => project.state).should.match(['suspended', 'suspended', 'suspended'])
+        })
+
+        it('Handles cancellation for unknown customers', async () => {
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_1MEVSfJ6VWAujNoLCPdYq9kn',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_1234567890',
+                            object: 'subscription',
+                            customer: 'cus_unknown',
+                            status: 'canceled'
+                        }
+                    },
+                    type: 'customer.subscription.deleted'
+                }
+            }))
+
+            should(app.log.error.called).equal(true)
+            app.log.error.firstCall.firstArg.should.equal('Stripe customer.subscription.deleted event sub_1234567890 received for unknown team \'cus_unknown\'')
+
+            should(response).have.property('statusCode', 200)
+        })
+
+        it('Handles cancellation for unknown subscriptions without error', async () => {
+            await app.db.controllers.Subscription.deleteSubscription(app.team)
+
+            const response = await (app.inject({
+                method: 'POST',
+                url: callbackURL,
+                headers: {
+                    'content-type': 'application/json'
+                },
+                payload: {
+                    id: 'evt_1MEVSfJ6VWAujNoLCPdYq9kn',
+                    object: 'event',
+                    data: {
+                        object: {
+                            id: 'sub_1234567890',
+                            object: 'subscription',
+                            customer: 'cus_1234567890',
+                            status: 'canceled'
+                        }
+                    },
+                    type: 'customer.subscription.deleted'
+                }
+            }))
+
+            should(app.log.error.called).equal(true)
+            app.log.error.firstCall.firstArg.should.equal('Stripe customer.subscription.deleted event sub_1234567890 received for unknown team \'cus_1234567890\'')
 
             should(response).have.property('statusCode', 200)
         })

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -35,17 +35,20 @@ module.exports = async function (config = {}) {
     const template = await forge.db.models.ProjectTemplate.create(templateProperties)
     template.setOwner(userAlice)
     await template.save()
-    // const stackProperties = {
-    //     name: 'stack1',
-    //     active: true,
-    //     properties: { nodered: '2.2.2' }
-    // }
-    // const stack = await forge.db.models.ProjectStack.create(stackProperties)
+
+    const stackProperties = {
+        name: 'stack1',
+        active: true,
+        properties: { nodered: '2.2.2' }
+    }
+    const stack = await forge.db.models.ProjectStack.create(stackProperties)
+
     const subscription = 'sub_1234567890'
     const customer = 'cus_1234567890'
     await forge.db.controllers.Subscription.createSubscription(team1, subscription, customer)
 
     forge.team = team1
+    forge.stack = stack
 
     return forge
 }


### PR DESCRIPTION
Part of https://github.com/flowforge/flowforge/issues/1162

This PR:

 - Adds a new column, status, to subscriptions
 - Updates that status when FlowForge receives a Stripe callback for the subscription cancellations 
 - Blocks starting of projects and flows if the subscription is marked as cancelled
 - Updates project actions to always reset inflight state on request failure