### PR TITLE
@enter function correction on SSO username

### DIFF
--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -5,7 +5,7 @@
             <template v-else>
                 <div>
                     <label>username / email</label>
-                    <ff-text-input ref="login-username" label="username" :error="errors.username" v-model="input.username" @enter="focusPassword"/>
+                    <ff-text-input ref="login-username" label="username" :error="errors.username" v-model="input.username" @enter="login"/>
                     <label class="ff-error-inline" data-el="errors-username">{{ errors.username }}</label>
                     <div v-if="passwordRequired">
                         <label>password</label>


### PR DESCRIPTION
When pressing `enter` after typing out my username, I expect it to attempt the login, then show me the password field. Fairly sure I'd already fixed this as part of a review, but it appears the `@enter` call was reverted for some reason.