### PR TITLE
Change 30 to 1000 in order to return more of the audit log

### DIFF
--- a/forge/db/models/AuditLog.js
+++ b/forge/db/models/AuditLog.js
@@ -45,7 +45,7 @@ module.exports = {
                     return M.AuditLog.forEntity(where, pagination)
                 },
                 forEntity: async (where = {}, pagination = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         where.id = { [Op.lt]: M.AuditLog.decodeHashid(pagination.cursor) }
                     }


### PR DESCRIPTION
Ahead of my work on Audit Log accordions, I need to render a longer list of audit events. Whilst we're looking to make pagination/API work a longer term fix for this, for short term, we want to just increase the returned items in a page to 1,000.

This is going in as a standalone PR, rather than part of the accordions stuff just so we can check out staging, where this limit will still be exceeded, and we can check performance.