### PR TITLE
Add Admin Settings for SSO Provider configurations

### DIFF
--- a/frontend/src/api/sso.js
+++ b/frontend/src/api/sso.js
@@ -1,0 +1,33 @@
+import client from './client'
+
+// Get list of active SSO providers
+const getProviders = async () => {
+    return client.get('/ee/sso/providers').then(res => {
+        return res.data
+    })
+}
+const getProvider = async (id) => {
+    return client.get(`/ee/sso/providers/${id}`).then(res => {
+        return res.data
+    })
+}
+const createProvider = async (options) => {
+    return client.post('/ee/sso/providers', options).then(res => {
+        return res.data
+    })
+}
+const updateProvider = async (id, options) => {
+    return client.put(`/ee/sso/providers/${id}`, options).then(res => {
+        return res.data
+    })
+}
+const deleteProvider = async (id) => {
+    return await client.delete(`/ee/sso/providers/${id}`)
+}
+export default {
+    createProvider,
+    updateProvider,
+    getProvider,
+    deleteProvider,
+    getProviders
+}

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -1,0 +1,173 @@
+<template>
+    <Teleport v-if="mounted" to="#platform-sidenav">
+        <SideNavigation>
+            <template v-slot:back>
+                <router-link :to="{name: 'AdminSettingsSSO'}">
+                    <nav-item :icon="icons.chevronLeft" label="Back to SSO"></nav-item>
+                </router-link>
+            </template>
+        </SideNavigation>
+    </Teleport>
+    <main>
+        <div class="max-w-2xl m-auto">
+            <ff-loading v-if="loading && !isCreate" message="Loading SSO Configuration..."/>
+            <ff-loading v-if="loading && isCreate" message="Creating SSO Configuration..."/>
+            <form v-else class="space-y-6">
+                <FormHeading>{{ pageTitle }}</FormHeading>
+                <FormRow v-model="input.name" :error="errors.name">
+                    Configuration Name
+                </FormRow>
+                <FormRow v-model="input.domainFilter" :error="errors.domainFilter" placeholder="@example.com">
+                    Email Domain
+                    <template v-slot:description>The email domain this provider should be used for.</template>
+                </FormRow>
+                <ff-button v-if="isCreate" :disabled="!formValid" @click="createProvider()">
+                    Create configuration
+                </ff-button>
+                <template v-else>
+                    <FormRow v-model="provider.acsURL" type="uneditable">ACS URL</FormRow>
+                    <FormRow v-model="provider.entityID" type="uneditable">Entity ID / Issuer</FormRow>
+                    <FormRow v-model="input.options.entryPoint">
+                        Identity Provider Single Sign-On URL
+                        <template v-slot:description>Supplied by your Identity Provider</template>
+                    </FormRow>
+                    <FormRow v-model="input.options.idpIssuer">
+                        Identity Provider Issuer ID / URL
+                        <template v-slot:description>Supplied by your Identity Provider</template>
+                    </FormRow>
+                    <FormRow v-model="input.options.cert">
+                        X.509 Certificate Public Key
+                        <template v-slot:description>Supplied by your Identity Provider</template>
+                        <template #input><textarea class="font-mono w-full" placeholder="---BEGIN CERTIFICATE---&#10;loremipsumdolorsitamet&#10;consecteturadipiscinge&#10;---END CERTIFICATE---&#10;" rows="6" v-model="input.options.cert"></textarea></template>
+                    </FormRow>
+                    <FormRow v-model="input.active" type="checkbox">Active</FormRow>
+                    <ff-button :disabled="!formValid" @click="updateProvider()">
+                        Update configuration
+                    </ff-button>
+                </template>
+            </form>
+        </div>
+    </main>
+</template>
+
+<script>
+import ssoApi from '@/api/sso'
+import FormRow from '@/components/FormRow'
+import FormHeading from '@/components/FormHeading'
+import { mapState } from 'vuex'
+
+import NavItem from '@/components/NavItem'
+import SideNavigation from '@/components/SideNavigation'
+import { ChevronLeftIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'AdminEditSSOProvider',
+    data () {
+        return {
+            mounted: false,
+            loading: false,
+            provider: {},
+            icons: {
+                chevronLeft: ChevronLeftIcon
+            },
+            originalValues: '',
+            input: {
+                name: '',
+                domainFilter: '',
+                active: false,
+                options: {}
+            },
+            errors: {}
+        }
+    },
+    computed: {
+        ...mapState('account', ['features']),
+        isCreate () {
+            return this.$route.params.id === 'create'
+        },
+        formValid () {
+            return (this.isCreate && !!this.input.domainFilter) || (!this.isCreate && JSON.stringify(this.input) !== this.originalValues)
+        },
+        pageTitle () {
+            if (this.isCreate) {
+                return 'Create new SSO Configuration'
+            } else {
+                return 'Edit SSO Configuration'
+            }
+        }
+    },
+    async beforeMount () {
+        if (!this.features.sso) {
+            this.$router.push({ path: '/admin/settings' })
+        }
+    },
+    mounted () {
+        this.mounted = true
+    },
+    methods: {
+        createProvider () {
+            if (this.formValid) {
+                this.loading = true
+                // Initial create
+                ssoApi.createProvider({
+                    name: this.input.name,
+                    domainFilter: this.input.domainFilter
+                }).then(response => {
+                    this.$router.push({ name: 'AdminSettingsSSOEdit', params: { id: response.id } })
+                    this.loading = false
+                    this.provider = response
+                })
+            }
+        },
+        updateProvider () {
+            if (this.formValid) {
+                const opts = {
+                    ...this.input
+                }
+                delete opts.id
+                ssoApi.updateProvider(this.provider.id, opts).then(response => {
+                    this.$router.push({ name: 'AdminSettingsSSO' })
+                }).catch(err => {
+                    console.log(err)
+                })
+            }
+        },
+        async loadProvider () {
+            if (this.$route.params.id === 'create') {
+                this.provider = {}
+                this.input.name = ''
+                this.input.domainFilter = ''
+                this.input.active = false
+                this.input.options = {}
+            } else {
+                this.loading = true
+                try {
+                    this.provider = await ssoApi.getProvider(this.$route.params.id)
+                    this.input.name = this.provider.name
+                    this.input.domainFilter = this.provider.domainFilter
+                    this.input.active = this.provider.active
+                    this.input.options = { ...this.provider.options }
+                    this.originalValues = JSON.stringify(this.input)
+                } catch (err) {
+                    if (err.response.status === 404) {
+                        this.$router.push({ name: 'AdminSettingsSSO' })
+                    }
+                    console.log(err)
+                } finally {
+                    this.loading = false
+                }
+            }
+        }
+
+    },
+    async created () {
+        await this.loadProvider()
+    },
+    components: {
+        FormRow,
+        FormHeading,
+        SideNavigation,
+        NavItem
+    }
+}
+</script>

--- a/frontend/src/pages/admin/Settings/SSO/index.vue
+++ b/frontend/src/pages/admin/Settings/SSO/index.vue
@@ -1,0 +1,95 @@
+<template>
+    <FormHeading>SSO Configurations</FormHeading>
+    <ff-data-table
+        data-el="sso-providers"
+        :columns="providerColumns"
+        :rows="providers"
+        :rows-selectable="true"
+        @row-selected="providerSelected"
+        :show-search="true"
+    >
+        <template v-slot:actions>
+            <ff-button :to="{ name: 'AdminSettingsSSOEdit', params: { id: 'create' } }">
+                <template v-slot:icon-right>
+                    <PlusSmIcon />
+                </template>
+                Create SSO SAML Configuration
+            </ff-button>
+        </template>
+        <template v-slot:context-menu="{row}">
+            <ff-list-item label="Edit Properties" @click.stop="providerSelected(row)"/>
+            <ff-list-item label="Delete SAML Configuration" kind="danger" @click.stop="deleteProvider(row)"/>
+        </template>
+    </ff-data-table>
+</template>
+
+<script>
+import FormHeading from '@/components/FormHeading'
+import { mapState } from 'vuex'
+import ssoApi from '@/api/sso'
+import { PlusSmIcon } from '@heroicons/vue/outline'
+import Alerts from '@/services/alerts'
+import Dialog from '@/services/dialog'
+
+export default {
+    name: 'AdminSettingsSSO',
+    computed: {
+        ...mapState('account', ['features']),
+        providerColumns () {
+            return [
+                { label: 'Active', key: 'active', class: ['w-16'] },
+                { label: 'Configuration Name', key: 'name' },
+                { label: 'Email Domain', key: 'domainFilter' }
+            ]
+        }
+    },
+    data () {
+        return {
+            loading: false,
+            providers: [],
+            selectedProvider: null
+        }
+    },
+    methods: {
+        fetchData: async function () {
+            const data = await ssoApi.getProviders()
+            this.providers = data.providers
+            this.loading = false
+        },
+        providerSelected: function (provider) {
+            this.$router.push({ name: 'AdminSettingsSSOEdit', params: { id: provider.id } })
+        },
+        deleteProvider: function (provider) {
+            Dialog.show({
+                header: 'Delete SAML Provider',
+                kind: 'danger',
+                text: 'Are you sure you want to delete this SAML Provider configuration? Any users with a matching email domain will no longer be able to login using SSO and will have to reset their FlowForge password to continue.',
+                confirmLabel: 'Delete'
+            }, async () => {
+                ssoApi.deleteProvider(provider.id)
+                    .then(() => {
+                        this.fetchData()
+                    }).catch((err) => {
+                        if (err.response && err.response.data && err.response.data.error) {
+                            Alerts.emit(err.response.data.error, 'warning')
+                        } else {
+                            Alerts.emit(err.message, 'warning')
+                        }
+                    })
+            })
+        }
+    },
+    async beforeMount () {
+        if (!this.features.sso) {
+            this.$router.push({ path: '/admin/settings' })
+        }
+    },
+    mounted () {
+        this.fetchData()
+    },
+    components: {
+        FormHeading,
+        PlusSmIcon
+    }
+}
+</script>

--- a/frontend/src/pages/admin/Settings/index.vue
+++ b/frontend/src/pages/admin/Settings/index.vue
@@ -7,24 +7,27 @@
 
 <script>
 import SectionTopMenu from '@/components/SectionTopMenu'
-
-const sideNavigation = [
-    { name: 'General', path: './general' },
-    // { name: "Permissions", path: "./permissions" },
-    { name: 'License', path: './license' },
-    { name: 'Email', path: './email' }
-]
+import { mapState } from 'vuex'
 
 export default {
     name: 'AdminSettings',
-    setup () {
-        return {
-            sideNavigation
-        }
-    },
     data () {
         return {
+            sideNavigation: [
+                { name: 'General', path: './general' },
+                // { name: "Permissions", path: "./permissions" },
+                { name: 'License', path: './license' },
+                { name: 'Email', path: './email' }
+            ]
         }
+    },
+    mounted () {
+        if (this.features.sso) {
+            this.sideNavigation.push({ name: 'SSO', path: './sso' })
+        }
+    },
+    computed: {
+        ...mapState('account', ['features'])
     },
     components: {
         SectionTopMenu

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -4,6 +4,8 @@ import AdminSettings from '@/pages/admin/Settings/index.vue'
 import AdminSettingsGeneral from '@/pages/admin/Settings/General.vue'
 import AdminSettingsLicense from '@/pages/admin/Settings/License.vue'
 import AdminSettingsEmail from '@/pages/admin/Settings/Email.vue'
+import AdminSettingsSSO from '@/pages/admin/Settings/SSO/index.vue'
+import AdminSettingsSSOEdit from '@/pages/admin/Settings/SSO/createEditProvider.vue'
 // import AdminSettingsPermissions from '@/pages/admin/Settings/Permissions.vue'
 import AdminUsers from '@/pages/admin/Users/index.vue'
 import AdminUsersGeneral from '@/pages/admin/Users/General.vue'
@@ -33,6 +35,15 @@ export default [
         }
     },
     {
+        path: '/admin/settings/sso/:id',
+        name: 'AdminSettingsSSOEdit',
+        beforeEnter: ensureAdmin,
+        component: AdminSettingsSSOEdit,
+        meta: {
+            title: 'Admin - Settings - SSO Configuration'
+        }
+    },
+    {
         path: '/admin/',
         profileLink: true,
         profileMenuIndex: 50,
@@ -58,7 +69,8 @@ export default [
                     { path: 'general', component: AdminSettingsGeneral },
                     // { path: 'permissions', component: AdminSettingsPermissions },
                     { path: 'license', component: AdminSettingsLicense },
-                    { path: 'email', component: AdminSettingsEmail }
+                    { path: 'email', component: AdminSettingsEmail },
+                    { path: 'sso', name: 'AdminSettingsSSO', component: AdminSettingsSSO }
                 ]
             },
             {


### PR DESCRIPTION
Part of #226 

This adds the frontend views for managing the SSO provider configurations.

This PR targets the `sso-config` branch that does all the backend work for provider configurations. I've split the frontend into its own PR for ease of review.

SSO SAML Provider configuration is hard. There are a small number of fields needed, but there is a lot of variation in how those fields are referred to be different identity providers.

<details>
This [doc from Okta](https://support.okta.com/help/s/article/okta-saml?language=en_US#:~:text=This%20is%20common,information%20they%27re%20providing) provides a good summary of the situation:

> This is common because there's unfortunately not much of a standard as far as SAML terminology is concerned. For example, some vendors may refer to the Assertion Consumer Service or Entity ID by a term unique to them. Because of this discrepancy in terminology, it can sometimes be a challenge to simply discover what information the vendor is asking for, or what to do with the information they're providing
</details>

I believe I've used the most consistent set of terms, but we'll need some good user docs - with worked examples for certain providers - to help the user. That PR will be coming tomorrow...

