### PR TITLE
Make the accordion test screen size agnostic

### DIFF
--- a/test/e2e/frontend/cypress/tests/components/accordian.spec.js
+++ b/test/e2e/frontend/cypress/tests/components/accordian.spec.js
@@ -30,8 +30,9 @@ describe('FlowForge - Accordion Component', () => {
 
         cy.get('[data-el="accordion"]').should('exist')
         cy.get('[data-el="accordion"] span').contains('1 Event')
-        cy.get('[data-el="accordion"] .ff-accordion--content').should('have.css', 'max-height').should('equal', '60px')
+        cy.get('[data-el="accordion"] .ff-accordion--content').should('be.visible')
         cy.get('[data-el="accordion"] button').click()
+        cy.get('[data-el="accordion"] .ff-accordion--content').should('not.be.visible')
         cy.get('[data-el="accordion"] .ff-accordion--content').should('have.css', 'max-height').should('equal', '0px')
     })
 })


### PR DESCRIPTION
E2E were passing locally, but when running in GH, the accordion content size was slightly different (I was checking against 60px, it was 67px). 

The PR showed as passing all tests, but clearly they hadn't, as I then got an email saying they failed once I merged with `main`.

This change makes the check more screen size agnostic.