### PR TITLE
Increase default pagination limit

### DIFF
--- a/docs/contribute/api-design.md
+++ b/docs/contribute/api-design.md
@@ -211,7 +211,7 @@ can be used to get the pagination options from the request, as well as specifyin
 default options:
 
 ```js
-const paginationOptions = app.getPaginationOptions(request, {limit: 30})
+const paginationOptions = app.getPaginationOptions(request, {limit: 1000})
 
 // paginationOptions.limit = how many results to return
 // paginationOptions.cursor = starting cursor
@@ -231,7 +231,7 @@ const { buildPaginationSearchClause } = require('../utils')
 
 getAll: async (pagination = {}, where = {}) => {
     // Ensure a sensible default limit for this particular type of thing
-    const limit = parseInt(pagination.limit) || 30
+    const limit = parseInt(pagination.limit) || 1000
 
     // Decode the cursor from hashid to database id
     if (pagination.cursor) {

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -205,10 +205,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    let limit = parseInt(pagination.limit)
-                    if (isNaN(limit)) {
-                        limit = 30
-                    }
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         pagination.cursor = M.Device.decodeHashid(pagination.cursor)
                     }

--- a/forge/db/models/ProjectSnapshot.js
+++ b/forge/db/models/ProjectSnapshot.js
@@ -54,7 +54,7 @@ module.exports = {
                     })
                 },
                 forProject: async (projectId, pagination = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     const where = {
                         ProjectId: projectId
                     }

--- a/forge/db/models/ProjectStack.js
+++ b/forge/db/models/ProjectStack.js
@@ -70,7 +70,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         pagination.cursor = M.ProjectStack.decodeHashid(pagination.cursor)
                     }

--- a/forge/db/models/ProjectTemplate.js
+++ b/forge/db/models/ProjectTemplate.js
@@ -82,7 +82,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         pagination.cursor = M.ProjectTemplate.decodeHashid(pagination.cursor)
                     }

--- a/forge/db/models/ProjectType.js
+++ b/forge/db/models/ProjectType.js
@@ -76,7 +76,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
 
                     if (pagination.cursor) {
                         pagination.cursor = M.ProjectType.decodeHashid(pagination.cursor)

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -172,7 +172,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         pagination.cursor = M.Team.decodeHashid(pagination.cursor)
                     }

--- a/forge/db/models/TeamType.js
+++ b/forge/db/models/TeamType.js
@@ -44,7 +44,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         pagination.cursor = M.TeamType.decodeHashid(pagination.cursor)
                     }

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -198,7 +198,7 @@ module.exports = {
                     })
                 },
                 getAll: async (pagination = {}, where = {}) => {
-                    const limit = parseInt(pagination.limit) || 30
+                    const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
                         pagination.cursor = M.User.decodeHashid(pagination.cursor)
                     }


### PR DESCRIPTION
Partially addresses https://github.com/flowforge/forge-ui-components/issues/101 and https://github.com/flowforge/flowforge/issues/1160

This is a shorter term fix and should be followed up by setting front-end side limits on any endpoints that we wish to paginate for **UX** reasons, that is to say, the server sets the default limit for technical/performance reasons, and the UI is responsible for setting the limit for any user experience or UI reason.

This effectively de-prioritises https://github.com/flowforge/flowforge/issues/1160 as significantly fewer users will be seeing pagination in the first place, but the long term solution is still to update our data tables to automatically fallback to server side search and sort when there is more than one page of results (https://github.com/flowforge/forge-ui-components/issues/101 and https://github.com/flowforge/flowforge/issues/1160).