### PR TITLE
Set callbackUrl rather than path in SAML config

### DIFF
--- a/forge/ee/db/models/SAMLProvider.js
+++ b/forge/ee/db/models/SAMLProvider.js
@@ -37,7 +37,7 @@ module.exports = {
                     const self = this.toJSON()
                     const result = {
                         issuer: self.entityID,
-                        path: '/ee/sso/login/callback',
+                        callbackUrl: process.env.FLOWFORGE_BASE_URL + '/ee/sso/login/callback',
                         ...self.options
                     }
                     if (result.cert) {


### PR DESCRIPTION
Passing in `path` to the SAML config meant it was constructing the callback url with an http protocol rather than honouring what the platform config had set.

We can pass in `callbackUrl` instead to avoid the library having to construct the url, and guarantee it matches what we've said it should be.