### PR TITLE
Add a clear banner with a C2A when a teams subscription has expired

### DIFF
--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -39,8 +39,10 @@ module.exports = {
         const self = this
         return {
             instance: {
+                // Should this subscription be treated as active/usable
+                // Stripe states such as past_due and trialing are still active
                 isActive () {
-                    return this.status === STATUS.ACTIVE
+                    return !this.isCanceled()
                 },
                 isCanceled () {
                     return this.status === STATUS.CANCELED

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -68,6 +68,7 @@ module.exports = async function (app) {
         if (app.license.active() && app.billing) {
             const subscription = await app.db.models.Subscription.byTeam(team.id)
             result.billingSetup = !!subscription
+            result.subscriptionActive = !!subscription?.isActive()
         }
         reply.send(result)
     }

--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -1,5 +1,6 @@
 <template>
     <div
+        v-if="subscriptionExpired"
         class="ff-banner ff-banner-warning"
         data-el="banner-subscription-expired"
     >

--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -12,16 +12,16 @@
             <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
 
             <template v-if="linkToBilling">
-                <template v-if="!onBillingPage">
-                    Please visit <strong>Billing settings</strong> to renew.
-                </template>
+                Please visit <strong>Billing settings</strong> to renew.
             </template>
-            <template v-else>
+            <template v-else-if="!hasPermission('team:edit')">
                 Please ask a team administrator to renew the subscription.
             </template>
         </span>
 
-        <ChevronRightIcon class="ff-icon align-self-right" />
+        <template v-if="linkToBilling">
+            <ChevronRightIcon class="ff-icon align-self-right" />
+        </template>
     </div>
 </template>
 

--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -2,30 +2,31 @@
     <div
         v-if="subscriptionExpired"
         class="ff-banner ff-banner-warning"
+        :class="{
+            'cursor-pointer': linkToBilling
+        }"
         data-el="banner-subscription-expired"
+        @click="navigateToBilling"
     >
-        <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
+        <span>
+            <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
 
-        <template v-if="hasPermission('team:edit')">
-            <template v-if="!onBillingPage">
-                Please visit
-                <router-link
-                    :to="`/team/${team.slug}/billing`"
-                    data-nav="banner-team-billing"
-                >
-                    Billing settings
-                </router-link>
-                to renew.
+            <template v-if="linkToBilling">
+                <template v-if="!onBillingPage">
+                    Please visit <strong>Billing settings</strong> to renew.
+                </template>
             </template>
-        </template>
-        <template v-else>
-            Please ask a team administrator to renew the subscription.
-        </template>
+            <template v-else>
+                Please ask a team administrator to renew the subscription.
+            </template>
+        </span>
+
+        <ChevronRightIcon class="ff-icon align-self-right" />
     </div>
 </template>
 
 <script>
-import { ExclamationCircleIcon } from '@heroicons/vue/outline'
+import { ChevronRightIcon, ExclamationCircleIcon } from '@heroicons/vue/outline'
 
 import { mapState } from 'vuex'
 
@@ -34,7 +35,8 @@ import permissionsMixin from '@/mixins/Permissions'
 export default {
     name: 'SubscriptionExpired',
     components: {
-        ExclamationCircleIcon
+        ExclamationCircleIcon,
+        ChevronRightIcon
     },
     mixins: [permissionsMixin],
     props: {
@@ -45,12 +47,25 @@ export default {
     },
     computed: {
         ...mapState('account', ['teamMembership']),
+        billingPath () {
+            return '/team/' + this.team.slug + '/billing'
+        },
+        linkToBilling () {
+            return this.hasPermission('team:edit') && !this.onBillingPage
+        },
         onBillingPage () {
-            const billingUrl = '/team/' + this.team.slug + '/billing'
-            return this.$route.path.includes(billingUrl)
+            return this.$route.path.includes(this.billingPath)
         },
         subscriptionExpired () {
             return this.team.billingSetup && !this.team.subscriptionActive
+        }
+    },
+    methods: {
+        navigateToBilling () {
+            if (!this.linkToBilling) {
+                return
+            }
+            this.$router.push(this.billingPath)
         }
     }
 }

--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -1,0 +1,56 @@
+<template>
+    <div
+        class="ff-banner ff-banner-warning"
+        data-el="banner-subscription-expired"
+    >
+        <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
+
+        <template v-if="hasPermission('team:edit')">
+            <template v-if="!onBillingPage">
+                Please visit
+                <router-link
+                    :to="`/team/${team.slug}/billing`"
+                    data-nav="banner-team-billing"
+                >
+                    Billing settings
+                </router-link>
+                to renew.
+            </template>
+        </template>
+        <template v-else>
+            Please ask a team administrator to renew the subscription.
+        </template>
+    </div>
+</template>
+
+<script>
+import { ExclamationCircleIcon } from '@heroicons/vue/outline'
+
+import { mapState } from 'vuex'
+
+import permissionsMixin from '@/mixins/Permissions'
+
+export default {
+    name: 'SubscriptionExpired',
+    components: {
+        ExclamationCircleIcon
+    },
+    mixins: [permissionsMixin],
+    props: {
+        team: {
+            type: Object,
+            required: true
+        }
+    },
+    computed: {
+        ...mapState('account', ['teamMembership']),
+        onBillingPage () {
+            const billingUrl = '/team/' + this.team.slug + '/billing'
+            return this.$route.path.includes(billingUrl)
+        },
+        subscriptionExpired () {
+            return this.team.billingSetup && !this.team.subscriptionActive
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -13,8 +13,9 @@
     </Teleport>
     <main>
         <ConfirmProjectDeleteDialog @confirm="deleteProject" ref="confirmProjectDeleteDialog"/>
-        <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
-            <div class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
+        <Teleport v-if="mounted" to="#platform-banner">
+            <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
+            <SubscriptionExpiredBanner :team="team" />
         </Teleport>
         <router-view
             :project="project"
@@ -39,6 +40,7 @@ import projectApi from '@/api/project'
 import snapshotApi from '@/api/projectSnapshots'
 
 import NavItem from '@/components/NavItem'
+import SubscriptionExpiredBanner from '@/components/banners/SubscriptionExpired.vue'
 // import SideNavigation from '@/components/SideNavigation'
 // import SideTeamSelection from '@/components/SideTeamSelection'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
@@ -199,7 +201,8 @@ export default {
     components: {
         NavItem,
         SideNavigationTeamOptions,
-        ConfirmProjectDeleteDialog
+        ConfirmProjectDeleteDialog,
+        SubscriptionExpiredBanner
     }
 }
 </script>

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -1,47 +1,81 @@
 <template>
     <Teleport v-if="mounted" to="#platform-sidenav">
-        <SideNavigationTeamOptions/>
+        <SideNavigationTeamOptions />
     </Teleport>
     <main>
         <template v-if="pendingTeamChange">
             <Loading />
         </template>
         <div v-else-if="team">
-            <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
-                <div class="ff-banner" data-el="banner-team-as-admin">You are viewing this team as an Administrator</div>
+            <Teleport v-if="mounted" to="#platform-banner">
+                <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-team-as-admin">You are viewing this team as an Administrator</div>
+                <div v-if="subscriptionExpired" class="ff-banner ff-banner-warning" data-el="banner-subscription-expired">
+                    <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
+
+                    <template v-if="hasPermission('team:edit')">
+                        <template v-if="!onBillingPage">
+                            Please visit
+                            <router-link :to="`/team/${team.slug}/billing`" data-nav="banner-team-billing">
+                                Billing settings
+                            </router-link>
+                            to renew.
+                        </template>
+                    </template>
+                    <template v-else>
+                        Please ask a team administrator to renew the subscription.
+                    </template>
+                </div>
             </Teleport>
-            <router-view :team="team" :teamMembership="teamMembership"></router-view>
+            <router-view :team="team" :teamMembership="teamMembership" />
         </div>
     </main>
 </template>
 
 <script>
-import Loading from '@/components/Loading'
+import { Roles } from '@core/lib/roles'
+import { ExclamationCircleIcon } from '@heroicons/vue/outline'
 import { useRoute } from 'vue-router'
 import { mapState } from 'vuex'
-import { Roles } from '@core/lib/roles'
 
+import Loading from '@/components/Loading'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'TeamPage',
-    computed: {
-        ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features']),
-        isVisitingAdmin: function () {
-            return (this.teamMembership.role === Roles.Admin)
-        }
-    },
     components: {
         Loading,
-        SideNavigationTeamOptions
+        SideNavigationTeamOptions,
+        ExclamationCircleIcon
+    },
+    mixins: [permissionsMixin],
+    async beforeRouteUpdate (to, from, next) {
+        await this.$store.dispatch('account/setTeam', to.params.team_slug)
+        // even if billing is not yet enabled, users should be able to see these screens,
+        // in order to delete the project, or setup billing
+        await this.checkRoute(to)
+        next()
     },
     data () {
         return {
             mounted: false
         }
     },
+    computed: {
+        ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features']),
+        isVisitingAdmin: function () {
+            return (this.teamMembership.role === Roles.Admin)
+        },
+        subscriptionExpired () {
+            return this.team.billingSetup && !this.team.subscriptionActive
+        }
+    },
     mounted () {
         this.mounted = true
+    },
+    async beforeMount () {
+        await this.$store.dispatch('account/setTeam', useRoute().params.team_slug)
+        this.checkRoute(this.$route)
     },
     methods: {
         checkRoute: async function (route) {
@@ -64,17 +98,6 @@ export default {
                 })
             }
         }
-    },
-    async beforeMount () {
-        await this.$store.dispatch('account/setTeam', useRoute().params.team_slug)
-        this.checkRoute(this.$route)
-    },
-    async beforeRouteUpdate (to, from, next) {
-        await this.$store.dispatch('account/setTeam', to.params.team_slug)
-        // even if billing is not yet enabled, users should be able to see these screens,
-        // in order to delete the project, or setup billing
-        await this.checkRoute(to)
-        next()
     }
 }
 </script>

--- a/frontend/src/pages/team/index.vue
+++ b/frontend/src/pages/team/index.vue
@@ -9,22 +9,7 @@
         <div v-else-if="team">
             <Teleport v-if="mounted" to="#platform-banner">
                 <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-team-as-admin">You are viewing this team as an Administrator</div>
-                <div v-if="subscriptionExpired" class="ff-banner ff-banner-warning" data-el="banner-subscription-expired">
-                    <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
-
-                    <template v-if="hasPermission('team:edit')">
-                        <template v-if="!onBillingPage">
-                            Please visit
-                            <router-link :to="`/team/${team.slug}/billing`" data-nav="banner-team-billing">
-                                Billing settings
-                            </router-link>
-                            to renew.
-                        </template>
-                    </template>
-                    <template v-else>
-                        Please ask a team administrator to renew the subscription.
-                    </template>
-                </div>
+                <SubscriptionExpiredBanner :team="team" />
             </Teleport>
             <router-view :team="team" :teamMembership="teamMembership" />
         </div>
@@ -33,22 +18,20 @@
 
 <script>
 import { Roles } from '@core/lib/roles'
-import { ExclamationCircleIcon } from '@heroicons/vue/outline'
 import { useRoute } from 'vue-router'
 import { mapState } from 'vuex'
 
 import Loading from '@/components/Loading'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
-import permissionsMixin from '@/mixins/Permissions'
+import SubscriptionExpiredBanner from '@/components/banners/SubscriptionExpired.vue'
 
 export default {
     name: 'TeamPage',
     components: {
         Loading,
         SideNavigationTeamOptions,
-        ExclamationCircleIcon
+        SubscriptionExpiredBanner
     },
-    mixins: [permissionsMixin],
     async beforeRouteUpdate (to, from, next) {
         await this.$store.dispatch('account/setTeam', to.params.team_slug)
         // even if billing is not yet enabled, users should be able to see these screens,
@@ -65,9 +48,6 @@ export default {
         ...mapState('account', ['user', 'team', 'teamMembership', 'pendingTeamChange', 'features']),
         isVisitingAdmin: function () {
             return (this.teamMembership.role === Roles.Admin)
-        },
-        subscriptionExpired () {
-            return this.team.billingSetup && !this.team.subscriptionActive
         }
     },
     mounted () {

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -244,9 +244,15 @@ $nav_height: 60px;
     border-bottom: 2px solid $ff-red-500;
 
     &.ff-banner-warning {
-        color: $ff-grey-50;
         background-color: $ff-red-700;
+        color: $ff-grey-50;
+        text-align: left;
         border-bottom: 2px solid $ff-red-800;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-left: 16px;
+        padding-right: 16px;
     }
 }
 .ff-header {

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -242,6 +242,12 @@ $nav_height: 60px;
     padding: 8px;
     text-align: center;
     border-bottom: 2px solid $ff-red-500;
+
+    &.ff-banner-warning {
+        color: $ff-grey-50;
+        background-color: $ff-red-700;
+        border-bottom: 2px solid $ff-red-800;
+    }
 }
 .ff-header {
     z-index: 10;


### PR DESCRIPTION
Fixes https://github.com/flowforge/flowforge/issues/1422

The actual "click here to reactivate billing" work will be handled in the billing page improvements: https://github.com/flowforge/flowforge/issues/1421

This needs some basic E2E test coverage, I'll add as part of the billing page work in#1421 since right now there are no E2E billing tests.

### Admin
<img width="1208" alt="Screenshot 2022-12-15 at 16 02 57" src="https://user-images.githubusercontent.com/507155/207884196-984e7b92-05e5-47a1-aecb-e5133225c332.png">
<img width="1209" alt="Screenshot 2022-12-15 at 16 02 52" src="https://user-images.githubusercontent.com/507155/207884207-07c15b22-237f-46b0-af0c-eea8f3999ebd.png">

### Non-admin
<img width="1207" alt="Screenshot 2022-12-15 at 16 03 30" src="https://user-images.githubusercontent.com/507155/207884167-2c955d5b-1ec3-4d47-bf85-684575ef74b9.png">