### PR TITLE
Add verbose & icon for settings.update from Node-RED

### DIFF
--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -36,7 +36,8 @@ const iconMap = {
     ],
     nodered: [
         'crashed',
-        'stopped'
+        'stopped',
+        'settings.update'
     ],
     project: [
         'project.created',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -331,6 +331,11 @@
         <span>Something has gone wrong. Check the project logs to investigate further.</span>
     </template>
 
+    <template v-else-if="entry.event === 'settings.update'">
+        <label>Node-RED Settings Updated</label>
+        <span>Node-RED editor user settings have been updated.</span>
+    </template>
+
     <!-- Catch All -->
     <template v-else>
         <label>{{ entry.event }}</label>


### PR DESCRIPTION
Had missed this off previously in my sweep of NR events:

<img width="660" alt="Screenshot 2022-12-15 at 15 04 06" src="https://user-images.githubusercontent.com/99246719/207894917-374b3d2f-dc07-44b0-b1d8-e6d68bdb4d1c.png">
