### PR TITLE
Refactor and slight redesign of billing page

### DIFF
--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -263,11 +263,11 @@ module.exports = async function (app) {
     }, async (request, response) => {
         const team = request.team
         try {
-            let cookie
+            let coupon
             if (request.cookies.ff_coupon) {
-                cookie = request.unsignCookie(request.cookies.ff_coupon)?.valid ? request.unsignCookie(request.cookies.ff_coupon).value : undefined
+                coupon = request.unsignCookie(request.cookies.ff_coupon)?.valid ? request.unsignCookie(request.cookies.ff_coupon).value : undefined
             }
-            const session = await app.billing.createSubscriptionSession(team, cookie)
+            const session = await app.billing.createSubscriptionSession(team, coupon)
             await app.auditLog.Team.billing.session.created(request.session.User, null, team, session)
             response.code(200).type('application/json').send({ billingURL: session.url })
         } catch (err) {

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -227,26 +227,7 @@ module.exports = async function (app) {
         const team = request.team
         const sub = await app.db.models.Subscription.byTeam(team.id)
         if (!sub) {
-            try {
-                let cookie
-                if (request.cookies.ff_coupon) {
-                    cookie = request.unsignCookie(request.cookies.ff_coupon)?.valid ? request.unsignCookie(request.cookies.ff_coupon).value : undefined
-                }
-                const session = await app.billing.createSubscriptionSession(team, cookie) // request.session.User)
-                await app.auditLog.Team.billing.session.created(request.session.User, null, team, session)
-                response.code(402).type('application/json').send({ billingURL: session.url })
-                return
-            } catch (err) {
-                let responseMessage
-                if (err.errors) {
-                    responseMessage = err.errors.map(err => err.message).join(',')
-                } else {
-                    responseMessage = err.toString()
-                }
-                response.clearCookie('ff_coupon', { path: '/' })
-                response.code(402).type('application/json').send({ error: responseMessage })
-                return
-            }
+            return response.code(404).send({ code: 'not_found', error: 'Team does not have a subscription' })
         }
 
         const stripeSubscription = await stripe.subscriptions.retrieve(
@@ -269,6 +250,38 @@ module.exports = async function (app) {
         })
 
         response.status(200).send(information)
+    })
+
+    /**
+     * Set up new billing subscription for a team
+     * @name /ee/billing/teams/:team
+     * @static
+     * @memberof forge.ee.billing
+     */
+    app.post('/teams/:teamId', {
+        preHandler: app.needsPermission('team:edit')
+    }, async (request, response) => {
+        const team = request.team
+        try {
+            let cookie
+            if (request.cookies.ff_coupon) {
+                cookie = request.unsignCookie(request.cookies.ff_coupon)?.valid ? request.unsignCookie(request.cookies.ff_coupon).value : undefined
+            }
+            const session = await app.billing.createSubscriptionSession(team, cookie)
+            await app.auditLog.Team.billing.session.created(request.session.User, null, team, session)
+            response.code(200).type('application/json').send({ billingURL: session.url })
+        } catch (err) {
+            let responseMessage
+            if (err.errors) {
+                responseMessage = err.errors.map(err => err.message).join(',')
+            } else {
+                responseMessage = err.toString()
+            }
+            response.clearCookie('ff_coupon', { path: '/' })
+
+            // to-do: This should be explicit about coupon errors
+            response.code(402).type('application/json').send({ error: responseMessage })
+        }
     })
 
     /**

--- a/frontend/src/api/billing.js
+++ b/frontend/src/api/billing.js
@@ -12,7 +12,15 @@ const getSubscriptionInfo = async (teamId) => {
     })
 }
 
+// Create a new subscription for a team
+const createSubscription = async (teamId) => {
+    return client.post('/ee/billing/teams/' + teamId).then(res => {
+        return res.data
+    })
+}
+
 export default {
     toCustomerPortal,
-    getSubscriptionInfo
+    getSubscriptionInfo,
+    createSubscription
 }

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -16,8 +16,8 @@
             <div v-if="coupon">
                 <div class="my-3 text-sm">Will apply coupon code <strong>{{ coupon }}</strong> at checkout</div>
             </div>
-            <div v-if="errors.coupon">
-                <div class="ml-9 text-red-400 inline text-xs">{{ errors.coupon }}</div>
+            <div v-else-if="errors.coupon">
+                <div class="my-3 text-red-400">{{ errors.coupon }}</div>
             </div>
             <div class="mt-3">
                 <ff-button data-action="setup-payment-details" class="mx-auto mt-3" @click="setupBilling()">
@@ -141,7 +141,7 @@ export default {
                     const response = await billingApi.createSubscription(this.team.id)
                     billingUrl = response.billingURL
                 } catch (err) {
-                    if (err.response.code === 'invalid_coupon') {
+                    if (err.response.data.code === 'invalid_coupon') {
                         Alerts.emit(`${this.coupon} coupon invalid`, 'warning', 7500)
                         this.errors.coupon = `${this.coupon} is not a valid code. You will be able to provide an alternative code on the Stripe checkout page.`
                         this.coupon = false

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -31,19 +31,16 @@
 
 <script>
 
+import { ExternalLinkIcon } from '@heroicons/vue/outline'
 import { markRaw } from 'vue'
 
 import billingApi from '@/api/billing.js'
-import Loading from '@/components/Loading'
+
 import FormHeading from '@/components/FormHeading'
-
-import formatDateMixin from '@/mixins/DateTime.js'
-import formatCurrency from '@/mixins/Currency.js'
-
-import { ExternalLinkIcon } from '@heroicons/vue/outline'
-
+import Loading from '@/components/Loading'
 import SectionTopMenu from '@/components/SectionTopMenu'
-
+import formatCurrency from '@/mixins/Currency.js'
+import formatDateMixin from '@/mixins/DateTime.js'
 import Alerts from '@/services/alerts'
 
 const priceCell = {
@@ -72,8 +69,14 @@ const totalPriceCell = {
 
 export default {
     name: 'TeamBilling',
-    props: ['billingUrl', 'team', 'teamMembership'],
+    components: {
+        Loading,
+        FormHeading,
+        ExternalLinkIcon,
+        SectionTopMenu
+    },
     mixins: [formatDateMixin, formatCurrency],
+    props: ['billingUrl', 'team', 'teamMembership'],
     data () {
         return {
             loading: false,
@@ -161,12 +164,6 @@ export default {
             }
             return undefined
         }
-    },
-    components: {
-        Loading,
-        FormHeading,
-        ExternalLinkIcon,
-        SectionTopMenu
     }
 }
 </script>

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -1,32 +1,27 @@
 <template>
     <SectionTopMenu hero="Team Billing"/>
     <form>
-        <Loading v-if="loading && !subscription" size="small"/>
-        <div v-else-if="!loading && subscription">
-            <FormHeading v-if="subscription" class="mb-6">Next Bill: <span class="font-normal">{{ formatDate(subscription.next_billing_date) }}</span></FormHeading>
-            <FormHeading>Active Subscriptions</FormHeading>
+        <Loading v-if="loading" size="small" />
+        <div v-else-if="billingSetUp">
+            <FormHeading class="mb-6">Next Payment:</FormHeading>
             <div v-if="subscription">
-                <ff-data-table :columns="columns" :rows="subscription.items"/>
+                <ff-data-table :columns="columns" :rows="subscription.items" />
             </div>
-            <FormHeading class="mt-6">View/Update Payment Details</FormHeading>
-            <div>
-                <ff-button size="small" @click="customerPortal()">
-                    <template v-slot:icon-right><ExternalLinkIcon /></template>
-                    Stripe Customer Portal
-                </ff-button>
+            <div v-else class="ff-no-data ff-no-data-large">
+                Something went wrong loading your subscription information, please try again.
             </div>
         </div>
-        <div v-else>
+        <div v-else class="ff-no-data ff-no-data-large">
             Billing has not yet been configured for this team. Before proceeding further, you must continue to Stripe and complete this.
             <div v-if="coupon">
-                <div class="mb-8 text-sm text-gray-500 space-y-2">Will apply coupon code <span v-text="coupon"></span> at checkout</div>
+                <div class="my-3 text-sm">Will apply coupon code <strong>{{ coupon }}</strong> at checkout</div>
             </div>
             <div v-if="errors.coupon">
-                <div class="ml-9 text-red-400 inline text-xs">{{errors.coupon}}</div>
+                <div class="ml-9 text-red-400 inline text-xs">{{ errors.coupon }}</div>
             </div>
             <div class="mt-3">
-                <ff-button @click="setupBilling()" data-action="setup-payment-details">
-                    <template v-slot:icon-right><ExternalLinkIcon /></template>
+                <ff-button data-action="setup-payment-details" class="mx-auto mt-3" @click="setupBilling()">
+                    <template #icon-right><ExternalLinkIcon /></template>
                     Setup Payment Details
                 </ff-button>
             </div>
@@ -110,30 +105,27 @@ export default {
             errors: {}
         }
     },
+    computed: {
+        billingSetUp () {
+            return this.team.billingSetup
+        }
+    },
     watch: { },
     async mounted () {
-        this.loading = true
-        if (!this.team.billingSetup) {
+        if (!this.billingSetUp) {
             this.coupon = this.getCookie('ff_coupon')?.split('.')[0]
-            this.loading = false
-        } else {
-            try {
-                const billingSubscription = await billingApi.getSubscriptionInfo(this.team.id)
-                billingSubscription.next_billing_date = billingSubscription.next_billing_date * 1000 // API returns Seconds, JS expects miliseconds
-                this.subscription = billingSubscription
-                this.subscription.items.map((item) => {
-                    item.total_price = item.price * item.quantity
-                    return item
-                })
-                this.loading = false
-            } catch (err) {
-                // check for 402 and redirect if 402 returned
-                if (err.response.status === 402) {
-                    this.coupon = this.getCookie('ff_coupon')?.split('.')[0]
-                    this.loading = false
-                }
-            }
+            return
         }
+
+        this.loading = true
+        const billingSubscription = await billingApi.getSubscriptionInfo(this.team.id)
+        billingSubscription.next_billing_date = billingSubscription.next_billing_date * 1000 // API returns Seconds, JS expects miliseconds
+        this.subscription = billingSubscription
+        this.subscription.items.map((item) => {
+            item.total_price = item.price * item.quantity
+            return item
+        })
+        this.loading = false
     },
     methods: {
         customerPortal () {
@@ -143,17 +135,15 @@ export default {
             let billingUrl = this.$route.query.billingUrl
             if (!billingUrl) {
                 try {
-                    billingUrl = await billingApi.getSubscriptionInfo(this.team.id)
+                    const response = await billingApi.createSubscription(this.team.id)
+                    billingUrl = response.billingURL
                 } catch (err) {
-                    if (err.response.status === 402) {
-                        if (err.response.data.billingURL) {
-                            billingUrl = err.response.data.billingURL
-                        } else if (err.response.data.error) {
-                            Alerts.emit(`${this.coupon} coupon invalid`, 'warning', 7500)
-                            this.errors.coupon = `${this.coupon} is not a valid code. You will be able to provide an alternative code on the Stripe checkout page.`
-                            this.coupon = false
-                            return
-                        }
+                    if (err.response.code === 'invalid_coupon') {
+                        Alerts.emit(`${this.coupon} coupon invalid`, 'warning', 7500)
+                        this.errors.coupon = `${this.coupon} is not a valid code. You will be able to provide an alternative code on the Stripe checkout page.`
+                        this.coupon = false
+                    } else {
+                        throw err
                     }
                 }
             }

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -3,7 +3,7 @@
     <form>
         <Loading v-if="loading" size="small" />
         <div v-else-if="billingSetUp">
-            <FormHeading class="mb-6">Next Payment:</FormHeading>
+            <FormHeading class="mb-6">Next Payment: <span class="font-normal" v-if="subscription">{{ formatDate(subscription.next_billing_date) }}</span></FormHeading>
             <div v-if="subscription">
                 <ff-data-table :columns="columns" :rows="subscription.items" />
             </div>

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -1,9 +1,16 @@
 <template>
-    <SectionTopMenu hero="Team Billing"/>
+    <SectionTopMenu hero="Team Billing">
+        <template #tools>
+            <ff-button v-if="subscription" size="small" @click="customerPortal()">
+                <template #icon-right><ExternalLinkIcon /></template>
+                Stripe Customer Portal
+            </ff-button>
+        </template>
+    </SectionTopMenu>
     <form>
         <Loading v-if="loading" size="small" />
         <div v-else-if="billingSetUp">
-            <FormHeading class="mb-6">Next Payment: <span class="font-normal" v-if="subscription">{{ formatDate(subscription.next_billing_date) }}</span></FormHeading>
+            <FormHeading class="mb-6">Next Payment: <span v-if="subscription" class="font-normal">{{ formatDate(subscription.next_billing_date) }}</span></FormHeading>
             <div v-if="subscription">
                 <ff-data-table :columns="columns" :rows="subscription.items" />
             </div>

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -64,6 +64,10 @@
     border: $ff-grey-200 solid 1px;
     padding: 12px;
     text-align: center;
+
+    &.ff-no-data-large {
+        padding: 64px 12px;
+    }
 }
 
 label {


### PR DESCRIPTION
Part of #1421, to be followed up by a PR that adds handling of the subscription cancelled state.

This PR:
 - Changes the API to separate getting and creation of subscriptions
 - Updates the frontend to consider the above change
 - More explicitly handles the invalid coupon error from stripe
 - Makes subtle changes to the billing page to get it more in line with the design from #1421 (still needs to be added to)

Might be easier to view commit by commit due to [28d3a48](https://github.com/flowforge/flowforge/pull/1455/commits/28d3a48064b0b32d2342d6b17e1877a8275916f4)

### Before

<img width="1445" alt="Screenshot 2022-12-16 at 16 38 31" src="https://user-images.githubusercontent.com/507155/208122054-4f55d02b-48d2-4ee8-bfd0-3502d449a56b.png">

<img width="1450" alt="Screenshot 2022-12-16 at 16 38 21" src="https://user-images.githubusercontent.com/507155/208122068-47603964-6524-4501-bf73-d435e0a68338.png">

### After

<img width="1447" alt="Screenshot 2022-12-16 at 16 34 14" src="https://user-images.githubusercontent.com/507155/208121276-9a671b89-bd92-4ef6-a905-b388907b50b6.png">

<img width="1229" alt="Screenshot 2022-12-16 at 16 06 26" src="https://user-images.githubusercontent.com/507155/208117063-989bcbd5-c106-4468-8d1f-9eca786fea40.png">

<img width="1051" alt="Screenshot 2022-12-16 at 16 33 16" src="https://user-images.githubusercontent.com/507155/208121478-dbe33941-6041-4dc9-a019-511ccae49973.png">
