### PR TITLE
Consistent CSS margins & no-data message in Devices

### DIFF
--- a/frontend/src/components/SectionTopMenu.vue
+++ b/frontend/src/components/SectionTopMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-wrap border-b border-gray-700 mb-4 sm:mb-10 text-gray-500 justify-between">
+    <div class="flex flex-wrap border-b border-gray-700 mb-4 sm:mb-2 text-gray-500 justify-between">
         <div class="flex">
             <div class="w-full flex items-center md:w-auto mb-2 mr-8 gap-x-2">
                 <slot name="hero">

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -7,7 +7,7 @@
             </ff-button>
         </template>
     </SectionTopMenu>
-    <form>
+    <form class="pt-4">
         <Loading v-if="loading" size="small" />
         <div v-else-if="billingSetUp">
             <FormHeading class="mb-6">Next Payment: <span v-if="subscription && !subscriptionExpired" class="font-normal">{{ formatDate(subscription.next_billing_date) }}</span></FormHeading>

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -15,6 +15,11 @@
         <ff-loading v-else-if="creatingDevice" message="Creating Device..." />
         <ff-loading v-else-if="deletingDevice" message="Deleting Device..." />
         <template v-else>
+            <template v-if="this.devices.size === 0">
+                <div class="ff-no-data ff-no-data-large">
+                    You don't have any devices yet
+                </div>
+            </template>
             <template v-if="this.devices.size > 0">
                 <ff-data-table
                     data-el="devices"
@@ -33,21 +38,6 @@
                         <ff-list-item v-if="hasPermission('device:delete')" kind="danger" label="Delete Device" @click="deviceAction('delete', row.id)" />
                     </template>
                 </ff-data-table>
-            </template>
-            <template v-else-if="addDeviceEnabled">
-                <div class="flex justify-center mb-4 p-8">
-                    <ff-button data-action="register-device" @click="showCreateDeviceDialog">
-                        <template v-slot:icon-right>
-                            <PlusSmIcon />
-                        </template>
-                        Register Device
-                    </ff-button>
-                </div>
-            </template>
-            <template v-if="this.devices.size === 0">
-                <div class="flex text-gray-500 justify-center italic mb-4 p-8">
-                    You don't have any devices yet
-                </div>
             </template>
         </template>
     </div>

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -7,7 +7,7 @@
             <p>Flows can then be deployed remotely to the devices through a Project Snapshot.</p>
         </template>
         <template v-slot:tools>
-            <ff-button v-if="addDeviceEnabled" kind="primary" size="small" @click="showCreateDeviceDialog"><template v-slot:icon-left><PlusSmIcon /></template>Register Device</ff-button>
+            <ff-button v-if="addDeviceEnabled" data-action="register-device" kind="primary" size="small" @click="showCreateDeviceDialog"><template v-slot:icon-left><PlusSmIcon /></template>Register Device</ff-button>
         </template>
     </SectionTopMenu>
     <div class="space-y-6">

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-loading v-if="loading" message="Loading Team..." />
-    <form v-else class="space-y-6 mb-8">
+    <form v-else class="mb-8">
         <div class="text-right"></div>
         <ff-data-table data-el="members-table" :columns="userColumns" :rows="users" :show-search="true" search-placeholder="Search Team Members..." :search-fields="['name', 'username', 'role']">
             <template v-if="hasPermission('team:user:invite')" v-slot:actions>

--- a/frontend/src/pages/team/Settings/index.vue
+++ b/frontend/src/pages/team/Settings/index.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="">
         <SectionTopMenu hero="Team Settings" :options="sideOptions" />
-        <div class="flex-grow">
+        <div class="flex-grow pt-4">
             <router-view :team="team" :teamMembership="teamMembership"></router-view>
         </div>
     </div>


### PR DESCRIPTION
Have wanted to clean these for a while, as good a time as any. Changes here:
- Make the margin/padding consistent for the SectionTopMenu usage across the app
- Remove the duplicate "Register New Device" button
- Add `ff-no-data-large` to the "No Devices Found" to improve styling