### PR TITLE
Do not allow sso email domains to be registered with + emails

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-layout-box class="ff-signup">
-        <div v-if="!emailSent">
+        <div v-if="!emailSent" class="max-w-md">
             <h2>Sign Up</h2>
             <div>
                 <label>Username</label>
@@ -130,7 +130,9 @@ export default {
                     if (/password/.test(err.response.data.error)) {
                         this.errors.password = 'Invalid username'
                     }
-                    if (/email/.test(err.response.data.error)) {
+                    if (err.response.data.code === 'invalid_sso_email') {
+                        this.errors.email = err.response.data.error
+                    } else if (/email/.test(err.response.data.error)) {
                         this.errors.email = 'Email unavailable'
                     }
                     if (err.response.data.error === 'user registration not enabled') {


### PR DESCRIPTION
Fixes #1460 

If a user attempts to create an account with a plus-address in their email (`foo+bar@example.com`) we reject the request with a message asking them to use the email their SSO provider identifies them as.

If a user does sign-up with a SSO-enabled email domain, we also now skip sending the email verification request - when they successfully login for the first time, we already set the `email_verified` flag on the account.