### PR TITLE
Add telemetry reporting of configured features

### DIFF
--- a/forge/monitor/metrics/004-platform.js
+++ b/forge/monitor/metrics/004-platform.js
@@ -7,6 +7,9 @@ module.exports = async (app) => {
         'platform.counts.projectSnapshots': await app.db.models.ProjectSnapshot.count(),
         'platform.counts.projectTemplates': await app.db.models.ProjectStack.count(),
         'platform.counts.projectStacks': await app.db.models.ProjectTemplate.count(),
-        'platform.config.driver': app.config.driver.type
+        'platform.config.driver': app.config.driver.type,
+        'platform.config.broker.enabled': !!app.config.broker,
+        'platform.config.fileStore.enabled': !!app.config.fileStore,
+        'platform.config.email.enabled': app.postoffice.enabled()
     }
 }

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -127,7 +127,7 @@ module.exports = fp(async function (app, _opts, next) {
     }
 
     function enabled () {
-        return EMAIL_ENABLED
+        return !!EMAIL_ENABLED
     }
 
     app.decorate('postoffice', {


### PR DESCRIPTION
Adds three new boolean properties to the telemetry ping:

 - `platform.config.broker.enabled`
 - `platform.config.fileStore.enabled`
 - `platform.config.email.enabled`

These are the features that require additional work by users to enable fully. Adding it to telemetry will help give some insight on how successful users are being in adding them to their platforms.