### PR TITLE
Improve activity logs

### DIFF
--- a/frontend/src/components/Accordion.vue
+++ b/frontend/src/components/Accordion.vue
@@ -37,11 +37,14 @@ export default {
             isOpen: false
         }
     },
-    computed: {
-        contentHeight: function () {
-            if (this.isOpen) {
-                const content = this.$refs.content
-                return (2 * content.scrollHeight) + 'px'
+    watch: {
+        isOpen: function (value) {
+            if (value) {
+                this.$nextTick(() => {
+                    // wait until content has been added to DOM
+                    const content = this.$refs.content
+                    return (2 * content.scrollHeight) + 'px'
+                })
             } else {
                 return null
             }

--- a/frontend/src/components/audit-log/AuditLog.vue
+++ b/frontend/src/components/audit-log/AuditLog.vue
@@ -3,7 +3,7 @@
     <div v-if="hasNoEntries && !loading" class="ff-no-data">
         No Activity Found
     </div>
-    <ff-accordion v-for="(entries, date) in logEntriesByDate" :key="date" :label="date" :set-open="true" data-el="accordion" :disabled="disableAccordion">
+    <ff-accordion v-for="(entries, date, $index) in logEntriesByDate" :key="date" :label="date" :set-open="$index < 3" data-el="accordion" :disabled="disableAccordion">
         <template v-slot:meta>
             <span>{{ entries.length }} Event{{ entries.length === 1 ? '' : 's' }}</span>
         </template>
@@ -108,9 +108,7 @@ export default {
         },
         groupResults (log) {
             let lastDate = null
-            if (!this.logEntriesByDate) {
-                this.logEntriesByDate = {}
-            }
+            this.logEntriesByDate = {}
             log.forEach((entry) => {
                 if (!entry.time) {
                     const date = new Date(entry.createdAt)

--- a/frontend/src/pages/admin/AuditLog.vue
+++ b/frontend/src/pages/admin/AuditLog.vue
@@ -24,7 +24,7 @@ export default {
     },
     methods: {
         loadItems: async function (entityId, cursor) {
-            return await adminApi.getPlatformAuditLog(cursor)
+            return await adminApi.getPlatformAuditLog(cursor, 200)
         },
         fetchData: async function () {
             this.entity = { id: 'audit' }

--- a/frontend/src/pages/project/Activity.vue
+++ b/frontend/src/pages/project/Activity.vue
@@ -20,7 +20,7 @@ export default {
     },
     methods: {
         loadItems: async function (projectId, cursor) {
-            return projectApi.getProjectAuditLog(projectId, cursor)
+            return projectApi.getProjectAuditLog(projectId, cursor, 200)
         }
     },
     components: {

--- a/frontend/src/pages/team/AuditLog.vue
+++ b/frontend/src/pages/team/AuditLog.vue
@@ -27,7 +27,7 @@ export default {
     },
     methods: {
         loadItems: async function (projectId, cursor) {
-            return await teamApi.getTeamAuditLog(projectId, cursor)
+            return await teamApi.getTeamAuditLog(projectId, cursor, 200)
         },
         fetchData: async function (newVal) {
             if (this.hasPermission('team:audit-log')) {

--- a/frontend/src/stylesheets/components/accordion.scss
+++ b/frontend/src/stylesheets/components/accordion.scss
@@ -29,8 +29,8 @@
         }
     }
     &--content {
-        max-height: 0;
-        overflow: hidden;
+        display: none;
+        // max-height: 0;
         transition: max-height 0.6s ease-out;
         .ff-audit-entry {
             padding: 12px;
@@ -39,6 +39,9 @@
         }
     }
     &.open {
+        .ff-accordion--content {
+            display: block;
+        }
         .ff-accordion--button .ff-icon {
             transform: rotate(-90deg);
         }

--- a/test/e2e/frontend/cypress/tests/admin/project-types.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/project-types.spec.js
@@ -79,7 +79,7 @@ describe('FlowForge - Project Types', () => {
 
 describe('FlowForge shows audit logs', () => {
     beforeEach(() => {
-        cy.intercept('GET', '/api/**/audit-log').as('getAuditLog')
+        cy.intercept('GET', '/api/**/audit-log?*').as('getAuditLog')
 
         cy.login('alice', 'aaPassword')
         cy.home()

--- a/test/e2e/frontend/cypress/tests/admin/stacks.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/stacks.spec.js
@@ -100,7 +100,7 @@ describe('FlowForge - Stacks', () => {
 
 describe('FlowForge shows audit logs', () => {
     beforeEach(() => {
-        cy.intercept('GET', '/api/**/audit-log').as('getAuditLog')
+        cy.intercept('GET', '/api/**/audit-log?*').as('getAuditLog')
 
         cy.login('alice', 'aaPassword')
         cy.home()

--- a/test/e2e/frontend/cypress/tests/components/accordian.spec.js
+++ b/test/e2e/frontend/cypress/tests/components/accordian.spec.js
@@ -5,7 +5,7 @@ describe('FlowForge - Accordion Component', () => {
     })
 
     it('can be open and closed', () => {
-        cy.intercept('/api/*/teams/*/audit-log', {
+        cy.intercept('/api/*/teams/*/audit-log?*', {
             log: [{
                 event: 'auth.login',
                 id: '12345678',
@@ -33,6 +33,6 @@ describe('FlowForge - Accordion Component', () => {
         cy.get('[data-el="accordion"] .ff-accordion--content').should('be.visible')
         cy.get('[data-el="accordion"] button').click()
         cy.get('[data-el="accordion"] .ff-accordion--content').should('not.be.visible')
-        cy.get('[data-el="accordion"] .ff-accordion--content').should('have.css', 'max-height').should('equal', '0px')
+        // cy.get('[data-el="accordion"] .ff-accordion--content').should('have.css', 'max-height').should('equal', '0px')
     })
 })

--- a/test/e2e/frontend/cypress/tests/team/audit-log.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/audit-log.spec.js
@@ -5,7 +5,7 @@ describe('FlowForge - Team Audit Log', () => {
     })
 
     it('should show a placeholder if no activity is present', () => {
-        cy.intercept('/api/*/teams/*/audit-log', {
+        cy.intercept('/api/*/teams/*/audit-log?*', {
             log: [],
             meta: {}
         }).as('getAuditLog')


### PR DESCRIPTION
fixes #1461 

Additional issues discovered and temporary containment discussed with @joepavitt  

* Rendering all accordions instead of only open accordions was slowing down page changes
   * Unfortunately the temporary (until Audit Logs 1.5 work is complete) open/close transistions would not work correctly (expanding accordion would not show content due to zero size calculations under the hood) 
  * Joe provided a temporary fix and understands this will be picked up in the overhaul
* When a user has 1000+ log entries, page changes from ~ to log view pages very slow (see flame chart below)



BEFORE THIS PR...
![image](https://user-images.githubusercontent.com/44235289/208953793-24bb7e8b-f644-41a1-a6ae-4ca45a814357.png)


AFTER THIS PR...
![image](https://user-images.githubusercontent.com/44235289/208953857-0b021f84-0268-4562-a92d-09a11f1e23fb.png)

