### PR TITLE
Ensure resync-maintenance task runs individual commands

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Resync Maintenance
         if: ${{ endsWith(github.ref, '.0') }}
-        run:
+        run: |
           git checkout maintenance
           git reset --hard main
           git push --force origin maintenance


### PR DESCRIPTION
Fixes #1484

## Description

The resync maintenance GH action failed because it was treating the multiple commands as a single command.

The fix is to add `|` to the start of the `run` definition so it treats each line as a separate command.

## Related Issue(s)

#1484 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

