### PR TITLE
Remove the test step from the release GHA

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 16
       - run: npm install
       - run: npm run build
-      - run: npm run test
+      # - run: npm run test
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Description

Removes the test step from the release publish, because at the point this has run the code should already have been tested when the PR that bumped the version numbers was raised and merged.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

