### PR TITLE
Add instructions to open HTTP/S ports on Digitial Ocean

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -4,13 +4,23 @@ This version of the FlowForge platform is intended for running in the Docker Con
 
 ## Prerequisites
 
+### Platform
+
+The following instructions assume you are running Docker on a Linux or MacOS host system.
+
+If you are using Digital Ocean Docker Droplet to host FlowForge you will need to ensure that port 80 & 443 are opened in the UFW firewall before starting.
+
+```bash
+sudo ufw apply http
+sudo ufw apply https
+```
+
 ### Docker Compose
 
 FlowForge uses Docker Compose to install and manage the required components. Instructions on how to install Docker Compose on your system can be found here:
 
 [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 
-The following instructions assume you are running Docker on a Linux or MacOS host system.
 
 ### DNS
 


### PR DESCRIPTION
## Description

When running on Digital Ocean Docker Droplet the default firewall rules prevent the projects from contacting the Forge app on it's public URL (required for authentication).

This PR adds a paragraph to the Docker Install instructions to cover it.

fixes #1497

## Related Issue(s)

<!-- What issue does this PR relate to? -->

fixes #1497 and #1496

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

