### PR TITLE
Allow SSO login to redirect to originally requested url

### DIFF
--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -82,7 +82,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['settings', 'pending', 'loginError'])
+        ...mapState('account', ['settings', 'pending', 'loginError', 'redirectUrlAfterLogin'])
     },
     async mounted () {
         await this.$nextTick()
@@ -102,7 +102,11 @@ export default {
                 this.passwordRequired = false
                 this.input.password = ''
                 if (newError.redirect) {
-                    window.location = newError.redirect
+                    let redirectPath = newError.redirect
+                    if (this.redirectUrlAfterLogin !== '/') {
+                        redirectPath += '&r=' + encodeURIComponent(this.redirectUrlAfterLogin)
+                    }
+                    window.location = redirectPath
                 } else {
                     this.loggingIn = false
                     await this.$nextTick()

--- a/frontend/src/pages/account/AccessRequestEditor.vue
+++ b/frontend/src/pages/account/AccessRequestEditor.vue
@@ -1,0 +1,33 @@
+<template>
+    <div class="flex flex-col items-center">
+        <h2>Redirecting back to your project editor</h2>
+        <div v-if="user" class="flex flex-row justify-center">
+            <div class="flex" >
+                <div class="ff-user">
+                    <img :src="user.avatar" class="ff-avatar-large"/>
+                </div>
+                <ArrowSmRightIcon class="w-8" />
+                <TemplateIcon class="w-12" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { TemplateIcon, ArrowSmRightIcon } from '@heroicons/vue/solid'
+
+export default {
+    name: 'AccessRequest',
+    computed: {
+        ...mapState('account', ['user', 'team'])
+    },
+    components: {
+        TemplateIcon,
+        ArrowSmRightIcon
+    },
+    mounted () {
+        window.location.href = `/account/complete/${this.$router.currentRoute.value.params.id}`
+    }
+}
+</script>

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -7,6 +7,7 @@ import AccountTeams from '@/pages/account/Teams/index.vue'
 import AccountTeamTeams from '@/pages/account/Teams/Teams.vue'
 import AccountTeamInvitations from '@/pages/account/Teams/Invitations.vue'
 import AccessRequest from '@/pages/account/AccessRequest.vue'
+import AccessRequestEditor from '@/pages/account/AccessRequestEditor.vue'
 import AccountCreate from '@/pages/account/Create.vue'
 import VerifyEmail from '@/pages/account/VerifyEmail.vue'
 import ForgotPassword from '@/pages/account/ForgotPassword'
@@ -17,33 +18,17 @@ import store from '@/store'
 
 export default [
     {
-        // This is the editor being authenticated. Bounce straight to complete
-        // the auth flow rather than ask permission
+        // This is the editor being authenticated. This component bounces the user
+        // straight back to the editor without any additional actions.
         path: '/account/request/:id/editor',
-        component: AccessRequest,
-        beforeEnter: (to, _, next) => {
-            let removeWatch
-            function proceed () {
-                if (removeWatch) {
-                    removeWatch()
-                }
-                if (store.state.account.user) {
-                    window.location.href = `/account/complete/${to.params.id}`
-                }
-            }
-            // Check if we've loaded the current user yet
-            if (!store.state.account.user) {
-                // Setup a watch
-                removeWatch = store.watch(
-                    (state) => state.account.user,
-                    (_) => { proceed() }
-                )
-            } else {
-                proceed()
-            }
+        component: AccessRequestEditor,
+        meta: {
+            modal: true
         }
     },
     {
+        // This is the FF Tools Plugin requesting access. This component asks the
+        // user to confirm access
         path: '/account/request/:id',
         component: AccessRequest,
         meta: {


### PR DESCRIPTION
Fixes
 - #1481

This is also required as part of:
 - #1325 

## Description

As described in #1481, when logging in via SSO, you would end up on the FF platform home page - not the url you were originally trying to access.

This meant logged-out users trying to access the editor directly would end up on the FF platform home, and would have to navigate to the editor again - this time getting in as they are logged in.

The fix involved passing the originally requested path through the SAML exchange as part of the `RelayState` object - a SAML property for just this sort of use case. This means we can redirect the user back to where they wanted to be after a successful login.

To get this to work properly for accessing the editor, I also modified how we handle the editor access check. Previously we were using a `beforeEnter` guard. This proved problematic as it causes checks to be made when the router has not yet been updated to the desired route - so we think they are accessing `/`, not proper oauth end point. This PR changes it to direct those routes to a new Component that just bounces them back to the editor as expected. The benefit being we can show a meaningful message on screen, rather than flash up the dashboard homepage as we did previously.

## Related Issue(s)

 - #1481
 - #1325 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
    - we do not have system tests for SAML login.
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

