### PR TITLE
Allow download of snapshot package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ frontend/dist-setup
 *.env.local
 package-lock.json
 coverage
+test/e2e/frontend/cypress/downloads
 test/e2e/frontend/cypress/videos
 test/e2e/frontend/cypress/screenshots
 test/e2e/frontend/cypress/tests/examples

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -155,9 +155,10 @@ If the device is being run on a offline network or security policies prevent the
 Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
 set of modules.
 
-You can enable this mode by adding `moduleCache: true` to the `device.yml` file. This will 
-cause the Device Agent to load the modules from the `module_cache` directory in the Device
-Agents Configuration directory as describe above. By default this will be `/opt/flowforge-device/module_cache`
+You can enable this mode by adding `moduleCache: true` to the `device.yml` file or adding 
+`-m` to the command line. This will cause the Device Agent to load the modules from the 
+`module_cache` directory in the Device Agents Configuration directory as describe above.
+By default this will be `/opt/flowforge-device/module_cache`.
 
 The easiest way to create the cache is to download the `package.json` for the Snapshot. 
 This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot page.

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -145,24 +145,28 @@ To delete a device:
 The next time the device calls home it will find it is no longer authorised and
 will stop and delete its local copy of the project it was running.
 
-
 ## Running with no access to npmjs.org
 
 By default the Device Agent will try and download the correct version of Node-RED and 
 any nodes required to run the Project Snapshot that is assigned to run on the device.
 
-If the device is being run on a offline network or security policies prevent the 
+If the device is being run on an offline network or security policies prevent the 
 Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
 set of modules.
 
-You can enable this mode by adding `moduleCache: true` to the `device.yml` file or adding 
-`-m` to the command line. This will cause the Device Agent to load the modules from the 
-`module_cache` directory in the Device Agents Configuration directory as describe above.
+You can enable this mode by adding `-m` to the command line adding `moduleCache: true` 
+to the `device.yml` file. This will cause the Device Agent to load the modules from the 
+`module_cache` directory in the Device Agents Configuration directory as described above.
 By default this will be `/opt/flowforge-device/module_cache`.
 
-The easiest way to create the cache is to download the `package.json` for the Snapshot. 
-This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot page.
+### Creating a module cache
 
-Place this file in an empty directory on a machine with the same OS and architecture as 
-the device and run `npm install`. This will create a `node_modules` directory which you 
-should copy into `module_cache` director on the device.
+To create a suitable module cache, you will need to install the modules on a local device with
+access to npmjs.org, ensuring you use the same OS and Architecture as your target
+device, and then copy the modules on to your device.
+
+1. From the Project Snapshot page, select the snapshot you want to deploy and select the option to download its `package.json` file.
+2. Place this file in an empty directory on your local device.
+3. Run `npm install` to install the modules. This will create a `node_modules` directory.
+4. On your target device, create a directory called `module_cache` inside the Device Agent Configuration directory.
+5. Copy the `node_modules` directory from your local device to the target device so that it is under the `module_cache` directory.

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -145,3 +145,23 @@ To delete a device:
 The next time the device calls home it will find it is no longer authorised and
 will stop and delete its local copy of the project it was running.
 
+
+## Running with no access to npmjs.org
+
+By default the Device Agent will try and download the correct version of Node-RED and 
+any nodes required to run the Project Snapshot that is assigned to run on the device.
+
+If the device is being run on a offline network or security policies prevent the 
+Device Agent from connecting to npmjs.org then it can be configured to use a pre-cached 
+set of modules.
+
+You can enable this mode by adding `moduleCache: true` to the `device.yml` file. This will 
+cause the Device Agent to load the modules from the `module_cache` directory in the Device
+Agents Configuration directory as describe above. By default this will be `/opt/flowforge-device/module_cache`
+
+The easiest way to create the cache is to download the `package.json` for the Snapshot. 
+This can be found in the 3 dots menu for the Snapshot on the Project's Snapshot page.
+
+Place this file in an empty directory on a machine with the same OS and architecture as 
+the device and run `npm install`. This will create a `node_modules` directory which you 
+should copy into `module_cache` director on the device.

--- a/forge/db/views/ProjectSnapshot.js
+++ b/forge/db/views/ProjectSnapshot.js
@@ -12,6 +12,9 @@ module.exports = {
             if (snapshot.User) {
                 filtered.user = app.db.views.User.shortProfile(snapshot.User)
             }
+            if (snapshot.settings?.modules) {
+                filtered.modules = snapshot.settings.modules
+            }
             return filtered
         } else {
             return null

--- a/frontend/src/pages/project/Snapshots/index.vue
+++ b/frontend/src/pages/project/Snapshots/index.vue
@@ -18,6 +18,7 @@
                 </template>
                 <template v-if="showContextMenu" v-slot:context-menu="{row}">
                     <ff-list-item v-if="hasPermission('project:snapshot:rollback')" label="Rollback" @click="showRollbackDialog(row)" />
+                    <ff-list-item v-if="hasPermission('project:snapshot:read')"  label="Download package.json" @click="downloadSnapshotPackage(row)"/>
                     <ff-list-item v-if="hasPermission('project:snapshot:set-target')" label="Set as Device Target" @click="showDeviceTargetDialog(row)"/>
                     <ff-list-item v-if="hasPermission('project:snapshot:delete')" label="Delete Snapshot" kind="danger" @click="showDeleteSnapshotDialog(row)"/>
                 </template>
@@ -147,6 +148,23 @@ export default {
         },
         snapshotCreated (snapshot) {
             this.snapshots.unshift(snapshot)
+        },
+        async downloadSnapshotPackage (snapshot) {
+            const ss = await snapshotApi.getSnapshot(this.project.id, snapshot.id)
+            const packageJSON = {
+                name: 'flowforge-project',
+                description: 'A FlowForge Project',
+                private: true,
+                version: '0.0.1',
+                dependencies: ss.modules
+            }
+            const element = document.createElement('a')
+            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(JSON.stringify(packageJSON, null, 2)))
+            element.setAttribute('download', 'package.json')
+            element.style.display = 'none'
+            document.body.appendChild(element)
+            element.click()
+            document.body.removeChild(element)
         }
     },
     computed: {

--- a/frontend/src/pages/project/Snapshots/index.vue
+++ b/frontend/src/pages/project/Snapshots/index.vue
@@ -152,10 +152,10 @@ export default {
         async downloadSnapshotPackage (snapshot) {
             const ss = await snapshotApi.getSnapshot(this.project.id, snapshot.id)
             const packageJSON = {
-                name: 'flowforge-project',
-                description: 'A FlowForge Project',
+                name: this.project.safeName,
+                description: `${snapshot.name} - ${snapshot.description}`,
                 private: true,
-                version: '0.0.1',
+                version: '0.0.0-' + snapshot.id,
                 dependencies: ss.modules
             }
             const element = document.createElement('a')

--- a/test/e2e/frontend/cypress/tests/projects/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/projects/snapshots.spec.js
@@ -47,11 +47,8 @@ describe('FlowForge - Project Snapshots', () => {
         // click the 2nd option (Download)
         cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(1).click()
 
-        const downloadsFolder = Cypress.config('downloadsFolder');
-        const packFile = cy.readFile(path.join(downloadsFolder, 'package.json'))
-        
-        // const packJSON = JSON.parse(packFile)
-        // console.log(packJSON)
+        const downloadsFolder = Cypress.config('downloadsFolder')
+        cy.readFile(path.join(downloadsFolder, 'package.json'))
     })
 
     it('can delete a snapshot', () => {

--- a/test/e2e/frontend/cypress/tests/projects/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/projects/snapshots.spec.js
@@ -1,3 +1,4 @@
+const path = require('path')
 describe('FlowForge - Project Snapshots', () => {
     beforeEach(() => {
         cy.intercept('GET', '/api/*/projects/*/snapshots').as('getProjectSnapshots')
@@ -40,13 +41,26 @@ describe('FlowForge - Project Snapshots', () => {
         cy.get('[data-el="snapshots"] tbody').find('tr').contains('snapshot1')
     })
 
+    it('download snapshot package.json', () => {
+        // click kebab menu in row 1
+        cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
+        // click the 2nd option (Download)
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(1).click()
+
+        const downloadsFolder = Cypress.config('downloadsFolder');
+        const packFile = cy.readFile(path.join(downloadsFolder, 'package.json'))
+        
+        // const packJSON = JSON.parse(packFile)
+        // console.log(packJSON)
+    })
+
     it('can delete a snapshot', () => {
         cy.intercept('DELETE', '/api/*/projects/*/snapshots/*').as('deleteSnapshot')
 
         // click kebab menu in row 1
         cy.get('[data-el="snapshots"] tbody').find('.ff-kebab-menu').eq(0).click()
-        // click the 3rd option (Delete)
-        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(2).click()
+        // click the 4th option (Delete)
+        cy.get('[data-el="snapshots"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(3).click()
 
         cy.get('[data-el="platform-dialog"]').should('be.visible')
         cy.get('[data-el="platform-dialog"] .ff-dialog-header').contains('Delete Snapshot')


### PR DESCRIPTION
## Description

This allows a user to download the package.json that represents the Node-RED version and all the installed nodes for a snapshot.

This can be used to create an offLine cache to be used with the Device Agent for instances where they can not connect out to npmjs.org

## Related Issue(s)

<!-- What issue does this PR relate to? -->
part of flowforge/flowforge-device-agent#45

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

