### PR TITLE
Stripe Callback Improvements

### DIFF
--- a/forge/auditLog/team.js
+++ b/forge/auditLog/team.js
@@ -92,9 +92,12 @@ module.exports = {
                 }
             },
             subscription: {
+                async updated (actionedBy, error, team, subscription, updates) {
+                    const body = generateBody({ error, team, subscription, updates })
+                    await log('billing.subscription.updated', actionedBy, team?.id, body)
+                },
                 async deleted (actionedBy, error, team, subscription) {
-                    const body = generateBody({ error, team })
-                    body.subscription = { subscription: subscription.subscription }
+                    const body = generateBody({ error, team, subscription })
                     await log('billing.subscription.deleted', actionedBy, team?.id, body)
                 }
             }

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -285,7 +285,8 @@ module.exports.init = async function (app) {
                 invoice_now: true,
                 prorate: true
             })
-            await subscription.destroy()
+            subscription.status = app.db.models.Subscription.STATUS.CANCELED
+            await subscription.save()
         }
     }
 }

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -243,7 +243,6 @@ module.exports = async function (app) {
                 if (subscription) {
                     // const subId = subscription.subscription
                     await app.billing.closeSubscription(subscription)
-                    await app.auditLog.Team.billing.subscription.deleted(request.session.User, null, request.team, subscription)
                 }
             }
             await request.team.destroy()

--- a/test/unit/forge/auditLog/team_spec.js
+++ b/test/unit/forge/auditLog/team_spec.js
@@ -385,7 +385,24 @@ describe('Audit Log > Team', async function () {
         logEntry.body.team.id.should.equal(TEAM.hashid)
     })
 
-    it('Provides a logger for deleting a billing session in a team', async function () {
+    it('Provides a logger for updating a subscription in a team', async function () {
+        await teamLogger.billing.subscription.updated(ACTIONED_BY, null, TEAM, SUBSCRIPTION, [{ key: 'status', old: 'active', new: 'canceled' }])
+        // check log stored
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'billing.subscription.updated')
+        logEntry.should.have.property('scope', { id: TEAM.hashid, type: 'team' })
+        logEntry.should.have.property('trigger', { id: ACTIONED_BY.hashid, type: 'user', name: ACTIONED_BY.username })
+        logEntry.should.have.property('body')
+        logEntry.body.should.only.have.keys('subscription', 'team', 'updates')
+        logEntry.body.subscription.should.only.have.keys('subscription')
+        logEntry.body.subscription.subscription.should.equal('subscription')
+        logEntry.body.team.should.only.have.keys('id', 'name', 'slug', 'type')
+        logEntry.body.team.id.should.equal(TEAM.hashid)
+        logEntry.body.updates.should.have.length(1)
+        logEntry.body.updates[0].should.eql({ key: 'status', old: 'active', new: 'canceled' })
+    })
+
+    it('Provides a logger for deleting a subscription in a team', async function () {
         await teamLogger.billing.subscription.deleted(ACTIONED_BY, null, TEAM, SUBSCRIPTION)
         // check log stored
         const logEntry = await getLog()


### PR DESCRIPTION
## Description

- Adds audit log reporting for subscription status changes
- Prevents the unwanted error messages raised when a team is deleted and stripe sends the subscription cancellation callback from:  https://github.com/flowforge/security/issues/13

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

