### PR TITLE
Fix sso warning

### DIFF
--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -310,7 +310,7 @@ module.exports = fp(async function (app, opts, done) {
         }
         let requireEmailVerification = true
         if (app.config.features.enabled('sso') && request.body.email) {
-            if (app.sso.isSSOEnabledForEmail(request.body.email)) {
+            if (await app.sso.isSSOEnabledForEmail(request.body.email)) {
                 // This user is signing up with an SSO enabled email domain
                 // 1. validate they are not trying to use a plus-address (name+extra@domain)
                 if (/^.*\+.*@[^@]+$/.test(request.body.email)) {

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -140,6 +140,21 @@ describe('Accounts API', async function () {
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
+
+        it('allows user to register with + in email (no sso)', async function () {
+            app = await setup()
+            app.settings.set('user:signup', true)
+
+            const response = await registerUser({
+                username: 'u7',
+                password: '12345678',
+                name: 'u7',
+                email: 'u7+test@example.com'
+            })
+            response.statusCode.should.equal(200)
+
+            // TODO: check user audit logs - expect 'account.xxx-yyy' { status: 'okay', ... }
+        })
     })
 
     describe('Verify FF Tokens', async function () {


### PR DESCRIPTION
## Description

Users signing up with emails addresses with `+` fails with SSO warning because the test was not waiting for the async call to resolve.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes #1514 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

