### PR TITLE
Add HubSpot Support/Chat Widget

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -116,6 +116,16 @@ Option        | Description
 `telemetry.frontend.posthog.capture_pageview` | FlowForge is designed as to provide custom posthog `$pageview` events that provide more detail on navigation than the default, and suit a single page application better. As such, we recommend setting this to false in order to prevent duplicate `pageleave`/`pageview` events firing. Default: `true`
 
 
+## Support configuration
+
+It is possible to add a [HubSpot Support Widget](https://knowledge.hubspot.com/chatflows/create-a-live-chat) into FlowForge. This will appear as a floating chat bubble on the bottom-right corner of the screen. To enable this, you'll need to provide the 
+
+Option        | Description
+--------------|------------
+`support.enabled` | Enables the chat support widget in the UI. Default: `false`
+`support.frontend.hubspot.trackingcode` | The numerical identifier within your [HubSpot Tracking Code](https://knowledge.hubspot.com/conversations/chat-widget-is-not-appearing-on-your-pages). Default: `null`
+
+
 ## MQTT Broker configuration
 
 The platform depends on the [Mosquitto MQTT Broker](https://mosquitto.org/) to

--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -54,6 +54,13 @@ module.exports = async function (app) {
             </script>`
             }
 
+            if (feConfig.hubspot?.trackingcode) {
+                const trackingCode = feConfig.hubspot.trackingcode
+                injection += `<!-- Start of HubSpot Embed Code -->
+                <script type="text/javascript" id="hs-script-loader" async defer src="//js-eu1.hs-scripts.com/${trackingCode}.js"></script>
+              <!-- End of HubSpot Embed Code -->`
+            }
+
             // inject into index.html
             cachedIndex = data.replace(/<script>\/\*inject-ff-scripts\*\/<\/script>/g, injection)
         }


### PR DESCRIPTION
## Description

With the success of adding the chat widget to the Website, we also wanted to include this in the application. I have built this such that it injects much like PostHog.

I have updated the documentation to include the new `yml` options.

For our own production `yml` we will need to include:

```
#################################################
# Support Widget Configuration                  #
#################################################

support:
  enabled: true
  frontend:
    hubspot:
      trackingcode: <number-to-be-sent-privately>
```

## Related Issue(s)

Issue: https://github.com/flowforge/flowforge/issues/1053

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated
    - [x] Configuration details
