### PR TITLE
docs: Re-request a verification email

### DIFF
--- a/docs/cloud/README.md
+++ b/docs/cloud/README.md
@@ -12,6 +12,12 @@ See the [Billing](./billing.md) page for more detailed answers about billing.
 
 Customers can get support by emailing support@flowforge.com, we presently only offer support for the flowforge application and your account, any issues relating to Node-RED such as your flows or a 3rd party node should be raised in the appropriate community forum, for example https://discourse.nodered.org/ or the GitHub project of the third party node.
 
+### Requesting a new verification email
+
+When a user signs up for FlowForge Cloud an email will be send to verify it.
+If this email doesn't get delivered one can be resend by signin in to FlowForge
+and click the button to resend it.
+
 ## Node-RED on FlowForge Cloud
 
 FlowForge currently offers Node-RED 2.2 and 3.0 to customers. When creating a


### PR DESCRIPTION
On FlowForge Cloud, with email configured, users are required to verify their email address by clicking a link that's send to their email address. Email isn't always delivered and because of this there's a way to request a new verification link.

This change mearly documents the how.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [X] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

