### PR TITLE
Improve stuck intermediate status of project when starting

### DIFF
--- a/frontend/src/pages/project/components/ProjectStatusBadge.vue
+++ b/frontend/src/pages/project/components/ProjectStatusBadge.vue
@@ -5,6 +5,7 @@
         <PlayIcon v-if="status === 'running'" class="w-4 h-4" />
         <StopIcon v-if="status === 'stopped'" class="w-4 h-4" />
         <DotsCircleHorizontalIcon v-if="status === 'starting'" class="w-4 h-4" />
+        <CloudUploadIcon v-if="status === 'loading'" class="w-4 h-4" />
         <CloudDownloadIcon v-if="status === 'installing'" class="w-4 h-4" />
         <SupportIcon v-if="status === 'safe'" class="w-4 h-4" />
         <span class="ml-1">{{ status }}</span>
@@ -12,13 +13,13 @@
 </template>
 
 <script>
-import { ExclamationIcon, ExclamationCircleIcon, PlayIcon, StopIcon, DotsCircleHorizontalIcon, SupportIcon, CloudDownloadIcon } from '@heroicons/vue/outline'
+import { ExclamationIcon, ExclamationCircleIcon, PlayIcon, StopIcon, DotsCircleHorizontalIcon, SupportIcon, CloudDownloadIcon, CloudUploadIcon } from '@heroicons/vue/outline'
 
 export default {
     name: 'ProjectStatusBadge',
     props: ['status', 'pendingStateChange'],
     components: {
-        ExclamationIcon, ExclamationCircleIcon, PlayIcon, StopIcon, DotsCircleHorizontalIcon, SupportIcon, CloudDownloadIcon
+        ExclamationIcon, ExclamationCircleIcon, PlayIcon, StopIcon, DotsCircleHorizontalIcon, SupportIcon, CloudDownloadIcon, CloudUploadIcon
     }
 }
 </script>

--- a/test/unit/forge/routes/logging/index_spec.js
+++ b/test/unit/forge/routes/logging/index_spec.js
@@ -3,35 +3,74 @@ const setup = require('../setup')
 
 describe('Logging API', function () {
     let app
-    let project
-    // let tokens
-    let project2
-    let tokens2
+    const TestObjects = {
+        tokens: {
+            alice: null,
+            project1: null,
+            project2: null
+        },
+        team1: null,
+        project1: null,
+        project2: null,
+        alice: null
+    }
 
-    beforeEach(async function () {
-        app = await setup()
-        project = app.project
-        // tokens = await project.refreshAuthTokens()
-
-        project2 = await app.db.models.Project.create({ name: 'project2', type: '', url: '' })
-        await app.team.addProject(project2)
-        tokens2 = await project2.refreshAuthTokens()
+    before(async function () {
+        app = await setup({})
+        TestObjects.alice = await app.db.models.User.byUsername('alice')
+        TestObjects.team1 = app.team
+        TestObjects.project1 = app.project
+        TestObjects.project2 = await app.db.models.Project.create({ name: 'project2', type: '', url: '' })
+        await TestObjects.team1.addProject(TestObjects.project2)
+        TestObjects.tokens.project1 = (await TestObjects.project1.refreshAuthTokens()).token
+        TestObjects.tokens.project2 = (await TestObjects.project2.refreshAuthTokens()).token
     })
 
-    afterEach(async function () {
-        await app.close()
+    after(async () => {
+        app && await app.close()
+        delete TestObjects.tokens
+        delete TestObjects.team1
+        delete TestObjects.project1
+        delete TestObjects.project2
+        delete TestObjects.alice
     })
 
-    it('POST Rejects invalid token /audit', async function () {
-        const url = `/logging/${project.id}/audit`
+    it('Accepts valid token', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
         const response = await app.inject({
             method: 'POST',
             url,
             headers: {
-                authorization: `Bearer ${tokens2.token}`
+                authorization: `Bearer ${TestObjects.tokens.project1}`
+            },
+            payload: { event: 'started' }
+        })
+        response.should.have.property('statusCode', 200)
+    })
+
+    it('Rejects invalid token', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
+        const response = await app.inject({
+            method: 'POST',
+            url,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project2}`
             },
             payload: {}
         })
-        response.statusCode.should.equal(404)
+        response.should.have.property('statusCode', 404)
+    })
+
+    it('Allows error to be included in body', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
+        const response = await app.inject({
+            method: 'POST',
+            url,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project1}`
+            },
+            payload: { event: 'start-failed', error: { code: 'test_code', error: 'test_error' } }
+        })
+        response.should.have.property('statusCode', 200)
     })
 })


### PR DESCRIPTION
## Description

Part of #1232

* Ensures known audit log entry "start-failed" to call the structured audit logger
* Permits body data in audit log entry made via API
* Introduces new icon for "loading" state (see other PR in launcher)

## Related Issue(s)

#1232 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions - NA
    - [-] Configuration details - NA
    - [-] Concepts - NA

## Labels

 - [-] Backport needed? -> add the `backport` label - NA
 - [-] Includes a DB migration? -> add the `area:migration` label - NA

