### PR TITLE
Allow sso-user to edit non-email settings

### DIFF
--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -167,7 +167,7 @@ export default {
     computed: {
         formValid () {
             return (this.changed.name || this.changed.username || this.changed.email || this.changed.defaultTeam) &&
-                   (this.input.email && !this.errors.email) &&
+                   (!this.emailEditingEnabled || (this.input.email && !this.errors.email)) &&
                    (this.input.username && !this.errors.username) &&
                    (this.input.name && !this.errors.name)
         },


### PR DESCRIPTION
Fixes #1542

## Description

When we introduced SSO users, we added a computed property on the User Settings page (`emailEditingEnabled`) to control whether the 'email' field could be edited. If they are a SSO user, we display a notice to say they cannot edit the email field. This was done by setting the error property of the field to be that message.

The 'save' button is controlled by the 'formValid' computed property. This was not taking into account the value of `emailEditingEnabled` and saw the sso message as an error against the email field and prevented the form from being submitted.

## Related Issue(s)

 - #1542 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

