### PR TITLE
Show custom message when sso-enabled user signs up

### DIFF
--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -123,7 +123,7 @@ module.exports = async function (app) {
                 }, newUser)
                 await app.auditLog.User.users.teamAutoCreated(request.session.User, null, team, logUserInfo)
             }
-            reply.send({ status: 'okay' })
+            reply.send(await app.db.views.User.userProfile(newUser))
         } catch (err) {
             let responseMessage
             let responseCode = 'unexpected_error'

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-layout-box class="ff-signup">
-        <div v-if="!emailSent" class="max-w-md">
+        <div v-if="!emailSent && !ssoCreated" class="max-w-md">
             <h2>Sign Up</h2>
             <div>
                 <label>Username</label>
@@ -26,9 +26,13 @@
                 <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
             </div>
         </div>
-        <div v-else>
+        <div v-else-if="emailSent">
             <h5>Confirm your e-mail address.</h5>
             <p>Please click the link in the email we sent to {{ input.email }}</p>
+        </div>
+        <div v-else>
+            <p>You can now login using your SSO Provider.</p>
+            <ff-button :to="{ name: 'Home' }" data-action="login">Login</ff-button>
         </div>
     </ff-layout-box>
 </template>
@@ -51,6 +55,7 @@ export default {
         return {
             teams: [],
             emailSent: false,
+            ssoCreated: false,
             input: {
                 name: '',
                 username: '',
@@ -120,7 +125,11 @@ export default {
             }
             const opts = { ...this.input, name: this.input.name || this.input.username }
             userApi.registerUser(opts).then(result => {
-                this.emailSent = true
+                if (result.sso_enabled) {
+                    this.ssoCreated = true
+                } else {
+                    this.emailSent = true
+                }
             }).catch(err => {
                 console.log(err.response.data)
                 if (err.response.data) {

--- a/test/unit/forge/ee/routes/sso/index_spec.js
+++ b/test/unit/forge/ee/routes/sso/index_spec.js
@@ -215,6 +215,11 @@ d
                 }
             })
             response.statusCode.should.equal(200)
+            const result = response.json()
+            // Recorded they are an sso user
+            result.should.have.property('sso_enabled', true)
+            // Not verified until they login the first time
+            result.should.have.property('email_verified', false)
             inbox.count().should.equal(0)
         })
 

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -50,7 +50,11 @@ describe('Accounts API', async function () {
                 email: 'u1@example.com'
             })
             response.statusCode.should.equal(200)
-
+            const result = response.json()
+            result.should.have.property('username', 'u1')
+            result.should.have.property('id')
+            // Ensure the id looks like a hash id
+            result.id.should.not.match(/^\d+$/)
             // TODO: check user audit logs - expect 'account.xxx-yyy' { status: 'okay', ... }
         })
 


### PR DESCRIPTION
Fixes #1543

## Description

When a user signs up with an sso-enabled email, we now show the following. The button takes them to the Home page when they can login.

<img width="474" alt="image" src="https://user-images.githubusercontent.com/51083/212131668-2d016292-8891-4304-a180-2c9cd5f3676a.png">


For context, this is instead of showing the existing 'please click a link' message you get if signing up with non-sso-enabled email:

<img width="566" alt="image" src="https://user-images.githubusercontent.com/51083/212131938-d669ea0d-2c8a-4c9e-b28f-11b0f5624d45.png">

To enable this change, the response of the user create api has been modified to return the user profile object, rather than just a 'success' message. That object includes a flag to say if they are an sso-enabled user or not.


## Related Issue(s)

Fixes #1543

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
      - ~we do not have tests on the user create end point. I will add some to this PR.~
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

