### PR TITLE
Free Trials: Charges section on create project page

### DIFF
--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -19,34 +19,38 @@
                 <div class="mb-8 text-sm text-gray-500">
                     <template v-if="!isCopyProject">Let's get your new Node-RED project setup in no time.</template>
                 </div>
-                <div v-if="subscription?.customer?.balance < 0" class="ff-banner ff-banner-info">
-                    You have a credit balance of {{ formatCurrency(Math.abs(subscription.customer.balance)) }} that will be applied to this project.
-                </div>
                 <div>
-                    <FormRow :error="errors.name" v-model="input.name">
-                        <template v-slot:default>Project Name</template>
-                        <template v-slot:append>
-                            <ff-button kind="secondary" @click="refreshName"><template v-slot:icon><RefreshIcon /></template></ff-button>
+                    <FormRow v-model="input.name" :error="errors.name">
+                        <template #default>Project Name</template>
+                        <template #description>
+                            Please note, currently, project names cannot be changed once a project is created
+                        </template>
+                        <template #append>
+                            <ff-button kind="secondary" @click="refreshName"><template #icon><RefreshIcon /></template></ff-button>
                         </template>
                     </FormRow>
-                    <span class="block text-xs ml-4 italic text-gray-500 m-0 max-w-sm">Please note, currently, project names cannot be changed once a project is created</span>
                 </div>
                 <div v-if="this.errors.projectTypes" class="text-red-400 text-xs">{{errors.projectTypes}}</div>
                 <!-- Project Type -->
-                <div v-else class="flex flex-wrap gap-1 items-stretch">
-                    <label class="w-full block text-sm font-medium text-gray-700 mb-1">Project Type</label>
-                    <ff-tile-selection v-model="input.projectType" >
-                        <ff-tile-selection-option v-for="(projType, index) in projectTypes" :key="index"
-                                                  :label="projType.name" :description="projType.description"
-                                                  :price="projType.properties?.billingDescription?.split('/')[0]"
-                                                  :price-interval="projType.properties?.billingDescription?.split('/')[1]"
-                                                  :value="projType.id"/>
+                <div v-else class="flex flex-wrap items-stretch">
+                    <label class="w-full block text-sm font-medium text-gray-700">Choose your Project Type</label>
+                    <div v-if="subscription?.customer?.balance < 0" class="text-sm text-blue-600 italic">
+                        You have a credit balance of {{ formatCurrency(Math.abs(subscription.customer.balance)) }} that will be applied to this project
+                    </div>
+                    <ff-tile-selection v-model="input.projectType" class="mt-5">
+                        <ff-tile-selection-option
+                            v-for="(projType, index) in projectTypes" :key="index"
+                            :label="projType.name" :description="projType.description"
+                            :price="projType.properties?.billingDescription?.split('/')[0]"
+                            :price-interval="projType.properties?.billingDescription?.split('/')[1]"
+                            :value="projType.id"
+                        />
                     </ff-tile-selection>
                 </div>
                 <!-- Stack -->
                 <!-- <FormRow :options="stacks" :error="errors.stack" v-model="input.stack" id="stack">Stack</FormRow> -->
                 <div class="flex flex-wrap gap-1 items-stretch">
-                    <label class="w-full block text-sm font-medium text-gray-700 mb-1">Stack</label>
+                    <label class="w-full block text-sm font-medium text-gray-700 mb-1">Choose your Stack</label>
                     <label v-if="!input.projectType" class="text-sm text-gray-400">Please select a Project Type first.</label>
                     <label v-if="errors.stack" class="text-sm text-gray-400">{{ errors.stack }}</label>
                     <ff-tile-selection v-if="input.projectType" v-model="input.stack" >

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -76,7 +76,7 @@
                 </template>
 
                 <div v-if="features.billing && input.projectType">
-                    <div v-if="selectedProjectType?.cost > 0 || subscription?.customer?.balance > 0" class="pb-4 mb-4 border-b border-gray-300">
+                    <div v-if="selectedProjectType?.cost > 0 || subscription?.customer?.balance > 0" class="pb-4 mb-4 border-b border-gray-300" data-el="charges-table">
                         <h1 class="text-lg font-medium mb-2 border-b border-gray-700">Charges</h1>
                         <div v-if="subscription?.customer?.balance" class="text-sm text-blue-600 italic">
                             You have a credit balance of {{ formatCurrency(Math.abs(subscription.customer.balance)) }} that will be applied to this project

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -76,7 +76,7 @@
                 </template>
 
                 <div v-if="features.billing && input.projectType">
-                    <div class="pb-4 mb-4 border-b border-gray-300">
+                    <div v-if="selectedProjectType?.cost > 0 || subscription?.customer?.balance > 0" class="pb-4 mb-4 border-b border-gray-300">
                         <h1 class="text-lg font-medium mb-2 border-b border-gray-700">Charges</h1>
                         <div v-if="subscription?.customer?.balance" class="text-sm text-blue-600 italic">
                             You have a credit balance of {{ formatCurrency(Math.abs(subscription.customer.balance)) }} that will be applied to this project

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -78,19 +78,19 @@
                 <div v-if="features.billing && input.projectType">
                     <div v-if="selectedProjectType?.cost > 0 || subscription?.customer?.balance > 0" class="pb-4 mb-4 border-b border-gray-300" data-el="charges-table">
                         <h1 class="text-lg font-medium mb-2 border-b border-gray-700">Charges</h1>
-                        <div v-if="subscription?.customer?.balance" class="text-sm text-blue-600 italic">
+                        <div v-if="subscription?.customer?.balance" class="text-sm text-blue-600 italic" data-el="credit-balance-banner">
                             You have a credit balance of {{ formatCurrency(Math.abs(subscription.customer.balance)) }} that will be applied to this project
                         </div>
                         <div class="grid grid gap-x-1 gap-y-4 text-sm text-sm mt-4 ml-4" style="grid-template-columns: 1fr 75px auto">
                             <template v-if="selectedProjectType?.cost">
-                                <div>1 x {{ selectedProjectType.name }}</div>
-                                <div class="text-right">{{ formatCurrency(selectedProjectType.cost) }} </div>
-                                <div v-if="selectedProjectType?.interval" class="text-left">/{{ selectedProjectType.interval }} </div>
+                                <div data-el="selected-project-type-name">1 x {{ selectedProjectType.name }}</div>
+                                <div data-el="selected-project-type-cost" class="text-right">{{ formatCurrency(selectedProjectType.cost) }} </div>
+                                <div v-if="selectedProjectType?.interval" data-el="selected-project-type-interval" class="text-left">/{{ selectedProjectType.interval }} </div>
                                 <div v-else />
                             </template>
                             <template v-if="subscription?.customer?.balance">
-                                <div>Credit Balance</div>
-                                <div class="text-right">{{ formatCurrency(subscription?.customer?.balance) }}</div>
+                                <div data-el="credit-balance-row">Credit Balance</div>
+                                <div data-el="credit-balance-amount" class="text-right">{{ formatCurrency(subscription?.customer?.balance) }}</div>
                                 <div />
                             </template>
                         </div>
@@ -106,7 +106,7 @@
                     </FormRow>
                 </div>
 
-                <ff-button :disabled="!createEnabled" @click="createProject" data-action="create-project">Create Project</ff-button>
+                <ff-button :disabled="!createEnabled" data-action="create-project" @click="createProject">Create Project</ff-button>
             </form>
         </div>
     </main>

--- a/test/e2e/frontend/cypress/support/commands.js
+++ b/test/e2e/frontend/cypress/support/commands.js
@@ -71,33 +71,6 @@ Cypress.Commands.add('home', (username, password) => {
     cy.url().should('include', '/overview')
 })
 
-// Navigate to the home page, and given we are logged in,
-// wait until all API calls have completed before moving on
-// however members do not wait for @getTeamMembers or @getTeamProjects
-Cypress.Commands.add('overview', (username, password) => {
-    /** @type {import('cypress')} */
-    cy.intercept('/api/*/user').as('getUser')
-    cy.intercept('/api/*/settings').as('getSettings')
-    cy.intercept('/api/*/user/teams').as('getTeams')
-    cy.intercept('/api/*/teams/*').as('getTeam')
-    cy.intercept('/api/*/teams/*/user').as('getTeamRole')
-    cy.intercept('/api/*/user/invitations').as('getInvitations')
-
-    cy.intercept('/api/*/admin/stats').as('getAdminStats')
-    cy.intercept('/api/*/admin/license').as('getAdminLicense')
-
-    cy.visit('/team/ateam/overview')
-
-    cy.wait('@getUser')
-    cy.wait('@getSettings')
-    cy.wait('@getTeam')
-    cy.wait('@getTeams')
-    cy.wait('@getTeamRole')
-    cy.wait('@getInvitations')
-
-    cy.url().should('include', '/overview')
-})
-
 // resets T+Cs.
 // Should be called AFTER cy.login(admin, adminPass)
 Cypress.Commands.add('resetTermsAndCondition', () => {

--- a/test/e2e/frontend/cypress/tests/project.spec.js
+++ b/test/e2e/frontend/cypress/tests/project.spec.js
@@ -85,6 +85,78 @@ describe('FlowForge - Projects', () => {
     })
 })
 
+describe('FlowForge - Projects - With Billing', () => {
+    beforeEach(() => {
+        cy.enableBilling()
+    })
+
+    it('can create a project that will charge the user', () => {
+        cy.login('alice', 'aaPassword')
+        cy.home()
+
+        cy.request('GET', 'api/v1/teams').then((response) => {
+            const team = response.body.teams[0]
+
+            cy.visit(`/team/${team.slug}/projects/create`)
+
+            cy.get('[data-el="charges-table"]').should('not.exist')
+
+            cy.contains('type1').click()
+
+            cy.get('[data-el="charges-table"]').should('exist')
+
+            cy.get('[data-el="selected-project-type-name"]').contains('type1')
+            cy.get('[data-el="selected-project-type-cost"]').contains('$15.00')
+            cy.get('[data-el="selected-project-type-interval"]').contains('/mo')
+
+            cy.get('[data-el="form-row-description"]').contains('$15.00 now').contains('$15.00/month')
+
+            cy.get('[data-action="create-project"]').should('be.disabled')
+
+            cy.get('[id="billing-confirmation"][data-el="form-row-title"]').click()
+
+            cy.get('[data-action="create-project"]').should('not.be.disabled').click()
+        })
+    })
+
+    it('considers any credit balance the team may have when creating a project', () => {
+        cy.applyBillingCreditToTeam(1001)
+        cy.login('alice', 'aaPassword')
+        cy.home()
+
+        cy.request('GET', 'api/v1/teams').then((response) => {
+            const team = response.body.teams[0]
+
+            cy.visit(`/team/${team.slug}/projects/create`)
+
+            cy.wait('@getTeamBilling')
+
+            cy.get('[data-el="charges-table"]').should('not.exist')
+
+            cy.contains('type1').click()
+
+            cy.get('[data-el="charges-table"]').should('exist')
+
+            cy.get('[data-el="credit-balance-banner"]').should('exist').contains('$10.01')
+
+            cy.get('[data-el="selected-project-type-name"]').contains('type1')
+            cy.get('[data-el="selected-project-type-cost"]').contains('$15.00')
+            cy.get('[data-el="selected-project-type-interval"]').contains('/mo')
+
+            cy.get('[data-el="credit-balance-row"]').should('exist')
+            cy.get('[data-el="credit-balance-amount"]').contains('$10.01')
+
+            cy.get('[data-el="form-row-description"]').contains('$4.99 now').contains('$15.00/month')
+
+            cy.get('[data-action="create-project"]').should('be.disabled')
+
+            cy.get('[id="billing-confirmation"][data-el="form-row-title"]').click()
+
+            cy.get('[data-action="create-project"]').should('not.be.disabled').click()
+        })
+    })
+})
+
 describe('FlowForge stores audit logs for a project', () => {
     beforeEach(() => {
         cy.login('alice', 'aaPassword')


### PR DESCRIPTION
## Description

- Adds a charges section at the bottom of the create project page to clarify the new charges
- Specifically includes the current and monthly cost when confirming the charges*
- Takes into account and credit balance the customer may have on their account (from a free trial or prorated refund).

<img width="500" alt="Screenshot 2023-01-13 at 15 09 40" src="https://user-images.githubusercontent.com/507155/212341039-5fbdba3a-4486-4375-98cf-6920e67d0a89.png">
<img width="500" alt="Screenshot 2023-01-13 at 15 08 55" src="https://user-images.githubusercontent.com/507155/212341047-1f0e6dea-aba5-4841-b743-ede0e8050756.png">

\* One caveat, the "now" price, isn't always 100% precise as it can't take into account pro-ration, but it's always larger than the amount actually charged (.e.g. if 50% of the way though the month, it'll still say the full amount e.g. $15 now, but stripe actually only charges $7.50)

## Related Issue(s)

Closes #1550
Part of #1471 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated - this does not have test coverage as there's currently no support for E2E tests with Billing set up
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

