### PR TITLE
Improve polling on project overview

### DIFF
--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -121,7 +121,7 @@ export default {
             type: Boolean
         }
     },
-    emits: ['project-start', 'project-delete', 'project-suspend', 'project-restart'],
+    emits: ['project-start', 'project-delete', 'project-suspend', 'project-restart', 'project-overview-exit', 'project-overview-enter'],
     computed: {
         ...mapState('account', ['teamMembership']),
         options: function () {
@@ -151,6 +151,12 @@ export default {
             return this.projectRunning
         }
 
+    },
+    mounted () {
+        this.$emit('project-overview-enter')
+    },
+    unmounted () {
+        this.$emit('project-overview-exit')
     },
     methods: {
         loadItems: async function (projectId, cursor) {


### PR DESCRIPTION

## Description

This builds on the already merged PRs 
* https://github.com/flowforge/flowforge/pull/1539
* https://github.com/flowforge/flowforge-nr-launcher/pull/94

Additional improvements made...
- dont wipe out users settings changes when project is (re)starting
- dont refresh view if overview is not "in view"
- ensure timer/flags are cleaned up after failed "restart"

## Related Issue(s)

#1232

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

