### PR TITLE
Limit Postgres to 3GB memory

### DIFF
--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -14,6 +14,7 @@ on:
       - 'test/unit/**'
       - 'test/system/**'
       - 'package.json'
+      - '.github/workflows/test-postgresql.yml'
 
 jobs:
   runner-job:

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -29,6 +29,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          -m 3GB
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432


### PR DESCRIPTION
## Description

A test to see if this fixes the OOM errors when testing against PostgreSQL

GH Action runners should have 7GB of RAM (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

Limiting the PostgreSQL container to 3GB should leave enough to run the tests

## Related Issue(s)

<!-- What issue does this PR relate to? -->
The PostgresSQL tests now fail more often than they pass, always with a OOM error in NodeJS, this started before Christmas, but a re-run would normally pass.

If the PostgreSQL tests can run consistently then it somewhat defeats the point of running them.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [-] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

