### PR TITLE
Allow AuditLog paginated api to also filter on event and username

### DIFF
--- a/forge/db/models/AuditLog.js
+++ b/forge/db/models/AuditLog.js
@@ -49,9 +49,12 @@ module.exports = {
                 forEntity: async (where = {}, pagination = {}) => {
                     const limit = parseInt(pagination.limit) || 1000
                     if (pagination.cursor) {
+                        // As we aren't using the default cursor behaviour (Op.gt)
+                        // set the appropriate clause and delete cursor so that
+                        // buildPaginationSearchClause doesn't do it for us
                         where.id = { [Op.lt]: M.AuditLog.decodeHashid(pagination.cursor) }
+                        delete pagination.cursor
                     }
-
                     const { count, rows } = await this.findAndCountAll({
                         where: buildPaginationSearchClause(
                             pagination,

--- a/forge/db/models/AuditLog.js
+++ b/forge/db/models/AuditLog.js
@@ -53,7 +53,17 @@ module.exports = {
                     }
 
                     const { count, rows } = await this.findAndCountAll({
-                        where: buildPaginationSearchClause(pagination, where, ['AuditLog.event']),
+                        where: buildPaginationSearchClause(
+                            pagination,
+                            where,
+                            // These are the columns that are searched using the `query` query param
+                            ['AuditLog.event', 'AuditLog.body', 'User.username', 'User.name'],
+                            // These map additional query params to specific columns to allow filtering
+                            {
+                                event: 'AuditLog.event',
+                                username: 'User.username'
+                            }
+                        ),
                         order: [['createdAt', 'DESC']],
                         include: {
                             model: M.User,

--- a/forge/routes/api/index.js
+++ b/forge/routes/api/index.js
@@ -20,15 +20,9 @@ const ProjectType = require('./projectType.js')
 module.exports = async function (app) {
     app.addHook('preHandler', app.verifySession)
     app.decorate('getPaginationOptions', (request, defaults) => {
-        const result = { ...defaults }
-        if (request.query.limit !== undefined) {
-            result.limit = request.query.limit
-        }
-        if (request.query.cursor !== undefined) {
-            result.cursor = request.query.cursor
-        }
-        if (request.query.query !== undefined) {
-            result.query = request.query.query.trim()
+        const result = { ...defaults, ...request.query }
+        if (result.query) {
+            result.query = result.query.trim()
         }
         return result
     })


### PR DESCRIPTION
Fixes #1489 

## Description

This PR adds the ability to search the audit log entries.

It also enhances the pagination & search api design to include filtering.

 - Search: case-insensitive pattern matching against nominated properties of the model
 - Filter: require specific properties to have a specific value (or be in a set of values)

For this PR, the new filter capability has been added to the AuditLog endpoints. The available filters are `event` and `username`.

The search applies to the `AuditLog.event`, `AuditLog.body`, `User.username`, `User.name` fields.


Examples:

**Return all of the latest audit log entries**

http://localhost:3000/api/v1/admin/audit-log

**Return any audit log entry that mentions 'account'**

http://localhost:3000/api/v1/admin/audit-log?query=account

**Return any audit log entry for the event 'account.logout'**

http://localhost:3000/api/v1/admin/audit-log?event=account.logout

**Return any audit log entry for the events 'account.logout' or 'account.login'**

http://localhost:3000/api/v1/admin/audit-log?event=account.logout&event=account.login

**Return any audit log event for when username 'nick' logged in**

http://localhost:3000/api/v1/admin/audit-log?username=nick&event=account.login


## Related Issue(s)

 - #1489 
 - #1448

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

