### PR TITLE
Improve Shared Library api for platform access

### DIFF
--- a/forge/ee/db/models/StorageSharedLibrary.js
+++ b/forge/ee/db/models/StorageSharedLibrary.js
@@ -30,25 +30,35 @@ module.exports = {
                     })
                 },
                 byType: async (team, type) => {
-                    return this.findAll({
-                        where: { TeamId: team, type }
-                    })
+                    const where = {
+                        TeamId: team
+                    }
+                    if (type) {
+                        where.type = type
+                    }
+                    return this.findAll({ where })
                 },
                 byName: async (team, type, name) => {
-                    return this.findOne({
-                        where: { TeamId: team, type, name }
-                    })
+                    const where = {
+                        name,
+                        TeamId: team
+                    }
+                    if (type) {
+                        where.type = type
+                    }
+                    return this.findOne({ where })
                 },
                 byPath: async (team, type, name) => {
-                    return this.findAll({
-                        where: {
-                            TeamId: team,
-                            type,
-                            name: {
-                                [Op.like]: `${name}%`
-                            }
+                    const where = {
+                        TeamId: team,
+                        name: {
+                            [Op.like]: `${name}%`
                         }
-                    })
+                    }
+                    if (type) {
+                        where.type = type
+                    }
+                    return this.findAll({ where })
                 }
             }
         }

--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -9,6 +9,8 @@ module.exports = async function (app) {
     if (app.config.billing) {
         await app.register(require('./billing'), { prefix: '/ee/billing', logLevel: app.config.logging.http })
     }
+    await app.register(require('./sharedLibrary'), { logLevel: app.config.logging.http })
+
+    // Important: keep SSO last to avoid its error handling polluting other routes.
     await app.register(require('./sso'), { logLevel: app.config.logging.http })
-    await app.register(require('./sharedLibrary'), { prefix: '/storage', logLevel: app.config.logging.http })
 }

--- a/forge/ee/routes/sharedLibrary/index.js
+++ b/forge/ee/routes/sharedLibrary/index.js
@@ -1,135 +1,123 @@
+const { registerPermissions } = require('../../../lib/permissions')
+const { Roles } = require('../../../lib/roles.js')
+
 module.exports = async function (app) {
+    registerPermissions({
+        'library:entry:create': { description: 'Create entries in a team library', role: Roles.Member },
+        'library:entry:list': { description: 'List entries in a team library', role: Roles.Member }
+    })
+
     app.addHook('preHandler', app.verifySession)
     app.addHook('preHandler', async (request, response) => {
         // The request has a valid token, but need to check the token is allowed
-        // to access the project
+        // to access the library
 
-        const id = request.params.projectId
-        // Check if the project exists first
-        const project = await app.db.models.Project.byId(id)
-        if (project && request.session.ownerType === 'project' && request.session.ownerId === id) {
-            request.project = project
-            // Project exists and the auth token is for this project
-            return
+        // For initial shared library implementation, this will be the teamId
+        const id = request.params.libraryId
+        const team = await app.db.models.Team.byId(id)
+        if (team) {
+            request.team = team
+            // If this is a project session token, verify the project is in the team
+            if (request.session.ownerType === 'project') {
+                const project = await app.db.models.Project.byId(request.session.ownerId)
+                if (project.Team.hashid === id) {
+                    // Project exists and the auth token is for this project
+                    return
+                }
+            } else if (!request.session.ownerType) {
+                // This is a logged-in user. Get their teamMembership so the needsPermission
+                // checks in the routes will evaluate properly
+                request.teamMembership = await request.session.User.getTeamMembership(request.team.id)
+                if (request.teamMembership) {
+                    return
+                }
+            }
         }
         response.status(404).send({ code: 'not_found', error: 'Not Found' })
     })
 
-    app.post('/:projectId/shared-library/:libraryId/:type',
-        {
-            schema: {
-                body: {
-                    type: 'object',
-                    required: ['name', 'body'],
-                    properties: {
-                        name: { type: 'string' },
-                        meta: { type: 'object' },
-                        body: {
-                            anyOf: [
-                                { type: 'string' },
-                                { type: 'object' }
-                            ]
-                        }
-                    }
-                },
-                params: {
-                    // type: { type: 'string', enum: [ 'flows', 'functions', 'templates' ] },
-                    id: { type: 'string' }
-                }
+    app.post('/storage/library/:libraryId/*', {
+        preHandler: async (request, reply) => {
+            if (request.teamMembership) {
+                return app.needsPermission('library:entry:create')(request, reply)
             }
-        },
-        async (request, response) => {
-            const id = request.params.libraryId
-            const type = request.params.type
-            let body = request.body.body
-            const name = request.body.name
-            const meta = request.body.meta
-
-            if (id !== request.project.Team.hashid) {
-                response.status(404).send({ code: 'not_found', error: 'Not Found' })
-                return
-            }
-
-            if (typeof body === 'object') {
-                body = JSON.stringify(body)
-            }
-
-            const direct = await app.db.models.StorageSharedLibrary.byName(request.project.Team.id, type, name)
-
-            if (direct) {
-                direct.body = body
-                direct.meta = JSON.stringify(meta)
-                await direct.save()
-            } else {
-                await app.db.models.StorageSharedLibrary.create({
-                    name: request.body.name,
-                    type,
-                    meta: JSON.stringify(meta),
-                    body,
-                    TeamId: request.project.Team.id
-                })
-            }
-
-            response.status(201).send()
         }
-    )
+    }, async (request, response) => {
+        const type = request.body.type
+        let body = request.body.body
+        const name = request.params['*']
+        const meta = request.body.meta
 
-    app.get('/:projectId/shared-library/:libraryId/:type',
-        {
-            schema: {
-                query: {
-                    name: { type: 'string' }
-                },
-                params: {
-                    // type: { type: 'string', enum: [ 'flows', 'functions', 'templates' ]},
-                    id: { type: 'string' }
-                }
+        if (!type) {
+            response.code(400).send({ code: 'invalid_request', error: 'Missing type parameter' })
+            return
+        }
+
+        if (typeof body === 'object') {
+            body = JSON.stringify(body)
+        }
+
+        const direct = await app.db.models.StorageSharedLibrary.byName(request.team.id, type, name)
+
+        if (direct) {
+            direct.body = body
+            direct.meta = JSON.stringify(meta)
+            await direct.save()
+        } else {
+            await app.db.models.StorageSharedLibrary.create({
+                name,
+                type,
+                meta: JSON.stringify(meta),
+                body,
+                TeamId: request.team.id
+            })
+        }
+
+        response.status(201).send()
+    })
+
+    app.get('/storage/library/:libraryId/*', {
+        preHandler: async (request, reply) => {
+            if (request.teamMembership) {
+                return app.needsPermission('library:entry:list')(request, reply)
             }
-        },
-        async (request, response) => {
-            const id = request.params.libraryId
-            const type = request.params.type
-            let name = request.query.name
+        }
+    }, async (request, response) => {
+        const type = request.query.type
+        let name = request.params['*']
 
-            // For now, we only have a single shared library - the default team library
-            // It's id is the hashid of the team. We need to verify that is proper here
-            // and then translate it to the real team id.
+        // For now, we only have a single shared library - the default team library
+        // It's id is the hashid of the team. We need to verify that is proper here
+        // and then translate it to the real team id.
+        let reply = []
 
-            if (id !== request.project.Team.hashid) {
-                response.status(404).send({ code: 'not_found', error: 'Not Found' })
-                return
+        // Try to get the exact name
+        const direct = await app.db.models.StorageSharedLibrary.byName(request.team.id, type, name)
+        if (direct) {
+            if (type === 'flows') {
+                reply = JSON.parse(direct.body)
+            } else {
+                reply = direct.body
             }
-
-            let reply = []
-
-            // Try to get the exact name
-            const direct = await app.db.models.StorageSharedLibrary.byName(request.project.Team.id, type, name)
-            if (direct) {
-                if (type === 'flows') {
-                    reply = JSON.parse(direct.body)
+        } else {
+            // No entry with that exact name. Check to see if its a partial
+            // path name
+            if (name.length > 0 && name[name.length - 1] !== '/') {
+                name += '/'
+            }
+            const subPaths = new Set()
+            const entries = await app.db.models.StorageSharedLibrary.byPath(request.team.id, type, name)
+            entries.forEach(entry => {
+                const shortName = entry.name.substring(name.length)
+                const pathParts = shortName.split('/')
+                if (pathParts.length === 1) {
+                    reply.push({ fn: shortName, ...JSON.parse(entry.meta), type: entry.type })
                 } else {
-                    reply = direct.body
+                    subPaths.add(pathParts[0])
                 }
-            } else {
-                // No entry with that exact name. Check to see if its a partial
-                // path name
-                if (name.length > 0 && name[name.length - 1] !== '/') {
-                    name += '/'
-                }
-                const subPaths = new Set()
-                const entries = await app.db.models.StorageSharedLibrary.byPath(request.project.Team.id, type, name)
-                entries.forEach(entry => {
-                    const shortName = entry.name.substring(name.length)
-                    const pathParts = shortName.split('/')
-                    if (pathParts.length === 1) {
-                        reply.push({ fn: shortName, ...JSON.parse(entry.meta) })
-                    } else {
-                        subPaths.add(pathParts[0])
-                    }
-                })
-                reply.push(...subPaths)
-            }
-            response.send(reply)
+            })
+            reply.push(...subPaths)
         }
-    )
+        response.send(reply)
+    })
 }


### PR DESCRIPTION
## Description

This changes the platform API used by the shared team library.

The first version of the API implemented by #1529 was implemented to match the default library routes used by storage. These routes had been implemented based on how they are driven by the Node-RED Library api. However on further examination, the api design didn't make it easy to use to provide a front-end for the library in the platform (#1368).

This PR changes the API to make it more usable - even if we don't ship #1368 in this release, we want to make sure the API is stable.

There will be a companion API for the storage plugin that must be merged in parallel. 

 - `GET /storage/library/:teamId/path/to/entry` - get an entry from the library.
 - `POST /storage/library/:teamId/path/to/entry` - add an entry to the library

The `GET` route can optionally filter the results to a particular type. For example, to just get `flows` add `?type=flows`.

The response of the `GET` depends on whether the path resolves to a 'directory' or a 'file'.

In the case of a 'file', the contents is returned.

In the case of a directory, an array is returned. The elements of that array are either:
 - a string - representing a sub directory
 - an object - representing a file. The object properties provide meta-data about the file, including `type`, `fn` (filename... a legacy node-red-ism in choice of property name) as well as any type-specific meta-data.

I'll save writing up the details of the `POST` endpoint for now as that is only intended to be drive by the storage plugin.

The endpoints can be accessed by either:
 - a Project token for a project in the team library being accessed
 - a login session token for a user who is a Member of the team being accessed


## Related Issue(s)

Part of
 - #237 

Companion PR to update the storage plugin to match
 - https://github.com/flowforge/flowforge-nr-storage/pull/28

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

