### PR TITLE
Add email to the Person object for PostHog <> Hubspot mapping

### DIFF
--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -24,9 +24,11 @@ const registerUser = async (options) => {
 
 const getUser = () => {
     return client.get('/api/v1/user/').then((res) => {
+        console.log(res.data)
         window.posthog?.identify(res.data.username, {
             name: res.data.name,
-            username: res.data.username
+            username: res.data.username,
+            email: res.data.email
         })
         return res.data
     })

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -24,7 +24,6 @@ const registerUser = async (options) => {
 
 const getUser = () => {
     return client.get('/api/v1/user/').then((res) => {
-        console.log(res.data)
         window.posthog?.identify(res.data.username, {
             name: res.data.name,
             username: res.data.username,


### PR DESCRIPTION
## Description

As part of the CTA tracking & marketing request, we want to include the email address when creating a PostHog person in our identification process so that we can map that to HubSpot.

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1510

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

