### PR TITLE
docs: Add 1.3 update notes

### DIFF
--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -9,6 +9,16 @@ for each version you are upgrading across.
 Note that we do not support downgrading FlowForge to previous levels once an upgrade
 has been performed.
 
+### Upgrading to 1.3
+
+Details of how to upgrade can be found for each deployment model:
+
+- [LocalFS](../install/local/README.md#upgrade)
+- [Docker](../install/docker/README.md#upgrade)
+- [Kubernetes](../install/kubernetes/README.md#upgrade)
+
+To enable the Team Library and FlowForge-based Authentication of HTTP routes each
+project will need to be updated to the [latest Stack](../user/changestack.md).
 
 ### Upgrading to 1.2
 


### PR DESCRIPTION
## Description

Adds notes on upgrading to 1.3 - in particular that Team Library and FF Auth requires a project stack update.

@hardillb we need to review our stack creation docs as well - I think the k8s docs can be simplified as we now publish suitable container images ourselves.