### PR TITLE
Add configurable banner on Create Account page

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -1,6 +1,7 @@
 module.exports.init = async function (app) {
     // Set the billing feature flag
     app.config.features.register('billing', true, true)
+    app.config.features.register('createAccountBanner', app.config.billing.createAccountBanner, true)
 
     const stripe = require('stripe')(app.config.billing.stripe.key)
 

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -2,7 +2,8 @@
     <ff-layout-box class="ff-signup">
         <div v-if="!emailSent && !ssoCreated" class="max-w-md">
             <h2>Sign Up</h2>
-            <div>
+            <p v-if="settings.features.createAccountBanner" class="-mt-6 pb-4 text-gray-400">{{ settings.features.createAccountBanner }}</p>
+            <div class="pb-4">
                 <label>Username</label>
                 <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
                 <label class="ff-error-inline">{{ errors.username }}</label>

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script>
-import { markRaw } from 'vue'
 import teamApi from '@/api/team'
 
 import { ChevronRightIcon } from '@heroicons/vue/solid'


### PR DESCRIPTION
## Description

Introduces a new config option in the `flowforge.yml`:

```
billing:
    createAccountBanner: <text goes here>
```

This text, if configured, will then appear int he "Create Account" box:

<img width="811" alt="Screenshot 2023-01-18 at 17 13 27" src="https://user-images.githubusercontent.com/99246719/213249123-be11e6ad-06df-4f6e-a216-cf1cdbf8acf2.png">


No "billing" configuration included in the FF docs at the moment, so I have no added anything into `/docs/install/configuration.md`

## Related Issue(s)

Closes #1581

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

