### PR TITLE
Add configurable banner on Create Account page (rework)

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -1,6 +1,7 @@
 module.exports.init = async function (app) {
     // Set the billing feature flag
     app.config.features.register('billing', true, true)
+    app.config.features.register('createAccountBanner', app.config.billing.createAccountBanner, true)
 
     const stripe = require('stripe')(app.config.billing.stripe.key)
 

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -1,7 +1,6 @@
 module.exports.init = async function (app) {
     // Set the billing feature flag
     app.config.features.register('billing', true, true)
-    app.config.features.register('createAccountBanner', app.config.billing.createAccountBanner, true)
 
     const stripe = require('stripe')(app.config.billing.stripe.key)
 

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -35,13 +35,17 @@ module.exports = async function (app) {
             }
             reply.send(response)
         } else {
-            reply.send({
+            const publicSettings = {
                 features: app.config.features.getPublicFeatures(),
                 'user:signup': app.settings.get('user:signup') && app.postoffice.enabled(),
                 'user:reset-password': app.settings.get('user:reset-password') && app.postoffice.enabled(),
                 'user:tcs-required': app.settings.get('user:tcs-required') && app.postoffice.enabled(),
                 'user:tcs-url': app.settings.get('user:tcs-url')
-            })
+            }
+            if (app.config.branding) {
+                publicSettings.branding = app.config.branding
+            }
+            reply.send(publicSettings)
         }
     })
 

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -2,7 +2,8 @@
     <ff-layout-box class="ff-signup">
         <div v-if="!emailSent && !ssoCreated" class="max-w-md">
             <h2>Sign Up</h2>
-            <div>
+            <p v-if="settings.features.createAccountBanner" class="-mt-6 pb-4 text-gray-400">{{ settings.features.createAccountBanner }}</p>
+            <div class="pb-4">
                 <label>Username</label>
                 <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
                 <label class="ff-error-inline">{{ errors.username }}</label>

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -2,7 +2,7 @@
     <ff-layout-box class="ff-signup">
         <div v-if="!emailSent && !ssoCreated" class="max-w-md">
             <h2>Sign Up</h2>
-            <p v-if="settings.features.createAccountBanner" class="-mt-6 pb-4 text-gray-400">{{ settings.features.createAccountBanner }}</p>
+            <p v-if="settings.branding?.account?.signUpTopBanner" class="-mt-6 pb-4 text-gray-400">{{ settings.branding?.account?.signUpTopBanner }}</p>
             <div class="pb-4">
                 <label>Username</label>
                 <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script>
-import { markRaw } from 'vue'
 import teamApi from '@/api/team'
 
 import { ChevronRightIcon } from '@heroicons/vue/solid'


### PR DESCRIPTION
## Description

This is an alternative approach (compared with #1589)  for how we can inject custom text into the Create Account page.

This takes a slightly broader approach and considers that we may want to introduce other bits of customisable text in the future.

Whilst the immediate need is related to billing, and my original suggestion was to put this under the billing config, in hindsight there is nothing inherently related to billing in wanting to add text to the create account page.

This proposes we add a new `branding` section in `flowforge.yml` under which we can organise any bits of customisable text.

For #1581, this PR adds support for the following:

```yaml
branding:
  account:
    signUpTopBanner: Free donuts for all
```

The entire `branding` object is passed to the UI via the `/settings` object. It currently only includes it in the unauthenticated request to `/settings` (as we only need it for the create user page), but a future iteration will want to make that smarter. We may even want to move it to a separate api end point to load these customisations... but that's for another day.

The choice of `signUpTopBanner` was based on the discussion in https://github.com/flowforge/website/issues/339 where I can see us wanting `signUpSideBanner` fairly soon...




## Related Issue(s)

 - #1589  

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

