### PR TITLE
Fix front end tests

### DIFF
--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -1,4 +1,4 @@
-name: UI E2E (Cypress) Tests
+name: UI Tests
 
 on:
   push:
@@ -25,9 +25,9 @@ jobs:
       - name: Install Dependencies
         run: npm install
       # and run all Cypress tests
-      - name: Run front-end unit tests
+      - name: Run UI Unit Tests
         run: npm run test:unit:frontend
-      - name: Cypress run
+      - name: Run UI E2E (Cypress) Tests
         uses: cypress-io/github-action@v4
         with:
           install: false

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'frontend/**'
       - 'test/e2e/frontend/**'
+      - 'test/unit/frontend/**'
       - 'package.json'
   pull_request:
     paths:
       - 'frontend/**'
       - 'test/e2e/frontend/**'
+      - 'test/unit/frontend/**'
       - 'package.json'
 
 jobs:
@@ -23,6 +25,8 @@ jobs:
       - name: Install Dependencies
         run: npm install
       # and run all Cypress tests
+      - name: Run front-end unit tests
+        run: npm run test:unit:frontend
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script>
-import { markRaw } from 'vue'
 import teamApi from '@/api/team'
 
 import { ChevronRightIcon } from '@heroicons/vue/solid'

--- a/test/unit/frontend/api/team.spec.js
+++ b/test/unit/frontend/api/team.spec.js
@@ -172,7 +172,8 @@ describe('Team API', async () => {
         const teamid = 'teamid'
         const cursor = 10
         const limit = 5
-        TeamAPI.default.getTeamAuditLog(teamid, cursor, limit)
+        const params = { event: 'foo' }
+        TeamAPI.default.getTeamAuditLog(teamid, params, cursor, limit)
         expect(mockPaginateUrl).toHaveBeenCalledOnce()
         expect(mockPaginateUrl).toHaveBeenCalledWith(`/api/v1/teams/${teamid}/audit-log`, cursor, limit)
     })


### PR DESCRIPTION
Noticed a recent PR broke one of the frontend unit tests (`npm run test:unit:frontend`). The PR had only modified frontend files and the current GitHub Action setup meant those particular tests were not run against it automatically.

This PR fixes the test failure and also ensures any front-end change triggers the front-end unit tests and not just the e2e tests.

As it stands, this does mean we'll run those particular tests multiple times - but we should look at removing them from main build/test actions and leave them to the UI test actions.