### PR TITLE
Fix resync maintenance release task

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,5 +24,5 @@ jobs:
         if: ${{ endsWith(github.ref, '.0') }}
         run: |
           git checkout maintenance
-          git reset --hard main
+          git reset --hard origin/main
           git push --force origin maintenance


### PR DESCRIPTION
The task to resync `main` to `maintenance` failed in the 1.3.0 release.

This PR fixes the error by being explicit on what branch we want the `maintenance` branch to be reset to.

This doesn't appear to be necessary when running the commands locally, but there must be something about how `actions/checkout` leaves things that makes this necessary when running in a GH Action.

I have reproduced the error in a private repo on my personal GH account and verified this fixes it there.
