### PR TITLE
Identify User at registration, rather than on return to app

### DIFF
--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -19,6 +19,11 @@ const logout = () => {
 }
 
 const registerUser = async (options) => {
+    window.posthog?.identify(options.username, {
+        name: options.name,
+        username: options.username,
+        email: options.email
+    })
     return client.post('/account/register', options).then(res => res.data)
 }
 


### PR DESCRIPTION
## Description

Our PostHog data showing anonymous users filling out the form, and signing up. We then get new users appear when they login, having following the relevant link in their e-mail.

PostHog is struggling to map these sessions to the same person, for reasons I am trying to understand, but I have been assured from PostHog dev team:

> This is our team’s highest priority right now, we plan on testing a new algorithm next week (on our own data), but it’s too early on to commit on an ETA

The only proposal I have at the moment, is that we call the $identify _before_ they navigate away to interact with their email address, i.e. exactly at the point they register. This assures that they still have the same anon ID from their original Website session.

This is also meaning that the user is then classified as two PostHog Persons, the second of which has inaccurate referral data, because it believe they came directly to PostHog from the e-mail, the original referal data form their anon ID cookie is lost.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

