### PR TITLE
chore: Fix newline escaping in backport action

### DIFF
--- a/.github/scripts/backport.sh
+++ b/.github/scripts/backport.sh
@@ -59,7 +59,7 @@ Backport of $PR_URL
 ---
 EOT
 
-echo $PR_BODY >> $PR_BRANCH".txt"
+echo $PR_BODY | sed -e 's/\\r\\n/\r\n/g' >> $PR_BRANCH".txt"
 
 gh pr create --title "$PR_TITLE (backport #$PR)" -F $PR_BRANCH".txt" -H $PR_BRANCH -B $TARGET_BRANCH
 


### PR DESCRIPTION
## Description

The backport script is generating PR descriptions with escaped newlines. My previous attempt at fixing it (#1585) worked locally, but didn't work in the repo.

I've now reproduced in a private repo and confirmed this is the complete fix.

