### PR TITLE
license: Allow custom expiration date

### DIFF
--- a/forge/licensing/license-generator.js
+++ b/forge/licensing/license-generator.js
@@ -75,7 +75,17 @@ const promptly = require('promptly')
             }
         })
 
-        const expiry = validFrom + (366 * 24 * 60 * 60) - 1
+        const defaultExpire = new Date(new Date().setFullYear(new Date().getFullYear() + 1)).toISOString().substring(0, 10)
+        const expiry = await promptly.prompt(`Expire at [${defaultExpire}]: `, {
+            default: defaultExpire,
+            validator: (value) => {
+                const date = new Date(value)
+                if (isNaN(date.getTime())) {
+                    throw new Error('Invalid expire time')
+                }
+                return Math.floor(date.getTime() / 1000)
+            }
+        })
 
         const licenseDetails = {
             iss: 'FlowForge Inc.', // DO NOT CHANGE


### PR DESCRIPTION
When providing a trial license or providing a license for a contract not expiring one year from today, one needs to generate two licenses.

This change fixes that.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

