### PR TITLE
Backend for stack restart API

### DIFF
--- a/forge/auditLog/project.js
+++ b/forge/auditLog/project.js
@@ -39,6 +39,9 @@ module.exports = {
             stack: {
                 async changed (actionedBy, error, project, stack) {
                     await log('project.stack.changed', actionedBy, project?.id, generateBody({ error, project, stack }))
+                },
+                async restart (actionedBy, error, project) {
+                    await log('project.stack.restart', actionedBy, project?.id, generateBody({ error, project }))
                 }
             },
             settings: {

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -60,7 +60,8 @@ const iconMap = {
         'platform.stack.created',
         'platform.stack.deleted',
         'platform.stack.updated',
-        'project.stack.changed'
+        'project.stack.changed',
+        'project.stack.restart'
     ],
     login: [
         'account.login',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -294,6 +294,11 @@
         <span v-if="!error && entry.body?.project">The stack for Project '{{ entry.body.project?.name }}' has been changed to Stack '{{ entry.body.stack?.name }}'</span>
         <span v-else-if="!error">Project data not found in audit entry.</span>
     </template>
+    <template v-else-if="entry.event === 'project.stack.restart'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span v-if="!error && entry.body?.project">The stack for Project '{{ entry.body.project?.name }}' has been restarted</span>
+        <span v-else-if="!error">Project data not found in audit entry.</span>
+    </template>
     <template v-else-if="entry.event === 'project.settings.updated'">
         <label>{{ AuditEvents[entry.event] }}</label>
         <span v-if="!error && entry.body?.project">Project '{{ entry.body.project?.name }}' has had the following changes made to its settings: <AuditEntryUpdates :updates="entry.body.updates" /></span>


### PR DESCRIPTION
## Description

Add API endpoint `/projects/<project id>/actions/restartStack`

This suspends and then restarts the project.

Useful for upgrading bare pod to Deployment (when https://github.com/flowforge/flowforge-driver-k8s/pull/71 is merged)

## Related Issue(s)


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

