### PR TITLE
devtool: Add --repl flag to start app in interactive node shell

### DIFF
--- a/forge/app.js
+++ b/forge/app.js
@@ -19,6 +19,11 @@ const forge = require('./forge')
         process.exit(1)
     }
 
+    // Check for repl arg. We could use parseArgs from node:util if on >=16.17.0,
+    // but risk someone is on older 16.x without it. So for now, just look for
+    // this one flag
+    const enableRepl = process.argv.includes('--repl')
+
     try {
         const server = await forge()
 
@@ -60,6 +65,11 @@ const forge = require('./forge')
                 server.log.info('* FlowForge is now running and can be accessed at: *')
                 server.log.info(`*   ${server.config.base_url.padEnd(47, ' ')}*`)
                 server.log.info('****************************************************')
+            }
+            if (enableRepl) {
+                const repl = require('repl')
+                const replServer = repl.start('FF => ')
+                replServer.context.app = server
             }
         })
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
     "description": "An open source low-code development platform",
     "scripts": {
         "start": "node forge/app.js",
+        "repl": "node forge/app.js --repl",
         "build": "webpack -c ./config/webpack.config.js",
         "serve": "npm-run-all --parallel build-watch start-watch",
+        "serve-repl": "npm-run-all --parallel build-watch start-watch-repl",
         "serve:test-env": "node ./test/e2e/frontend/test_environment.js",
         "start-watch": "cross-env NODE_ENV=development nodemon -w forge -w ee/forge -i forge/containers/localfs_root forge/app.js",
+        "start-watch-repl": "cross-env NODE_ENV=development nodemon -w forge -w ee/forge -i forge/containers/localfs_root forge/app.js --repl",
         "build-watch": "webpack --mode=development -c ./config/webpack.config.js --watch",
         "lint": "eslint -c .eslintrc \"forge/**/*.js\" \"frontend/**/*.js\" \"frontend/**/*.vue\" \"test/**/*.js\" --ignore-pattern \"frontend/dist/**\"",
         "lint:fix": "eslint -c .eslintrc \"forge/**/*.js\" \"frontend/**/*.js\" \"frontend/**/*.vue\" \"test/**/*.js\" --ignore-pattern \"frontend/dist/**\" --fix",


### PR DESCRIPTION
This adds support for starting FlowForge with an interactive shell, much like the standard node repl.

Within the node shell, `app` is the FlowForge application instance.

```
[2023-01-26T10:34:51.877Z] INFO: ****************************************************
[2023-01-26T10:34:51.878Z] INFO: * FlowForge is now running and can be accessed at: *
[2023-01-26T10:34:51.878Z] INFO: *   http://localhost:3000                          *
[2023-01-26T10:34:51.878Z] INFO: ****************************************************
[2023-01-26T10:34:51.925Z] INFO: Connected to SMTP server
[2023-01-26T10:34:52.023Z] INFO: Connected to comms broker
[2023-01-26T10:34:52.485Z] DEBUG: [localfs] Restarting projects
[2023-01-26T10:34:52.485Z] DEBUG: [localfs] Checking project status
[2023-01-26T10:34:52.509Z] DEBUG: [localfs] Project 1e7bb9d0-36e5-40dd-888f-6927a635bc5b port 7880
[2023-01-26T10:34:52.510Z] DEBUG: [localfs] Project ac8e4995-cb47-42ec-a9a4-71c42366c7f3 port 7881

FF => const projects = await app.db.models.Project.findAll()
undefined
FF => projects[0].name
'fantastic-shelduck-8877'
FF =>
```

It can be run in any of the following ways:

 - `node forge/app.js --repl`
 - `npm run repl`
 - `npm run serve-repl`

