### PR TITLE
Store project billing state when adding/removing subscription

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -1,4 +1,3 @@
-
 class SubscriptionHandler {
     constructor (app) {
         this._app = app
@@ -59,6 +58,7 @@ module.exports = {
             try {
                 await this._app.billing.addProject(project.Team, project)
             } catch (err) {
+                this._app.log.error(`Problem adding project to subscription: ${err}`)
                 throw new Error('Problem adding project to subscription')
             }
         }
@@ -85,6 +85,7 @@ module.exports = {
                     try {
                         await this._app.billing.removeProject(project.Team, project)
                     } catch (err) {
+                        this._app.log.error(`Problem removing project from subscription: ${err}`)
                         throw new Error('Problem removing project from subscription')
                     }
                 }
@@ -131,6 +132,7 @@ module.exports = {
                 try {
                     await this._app.billing.removeProject(project.Team, project)
                 } catch (err) {
+                    this._app.log.error(`Problem removing project from subscription: ${err}`)
                     throw new Error('Problem with removing project from subscription')
                 }
             } else {
@@ -163,6 +165,7 @@ module.exports = {
                     try {
                         await this._app.billing.removeProject(project.Team, project)
                     } catch (err) {
+                        this._app.log.error(`Problem removing project from subscription: ${err}`)
                         throw new Error('Problem with removing project from subscription')
                     }
                 } else {

--- a/forge/db/models/ProjectSettings.js
+++ b/forge/db/models/ProjectSettings.js
@@ -11,10 +11,19 @@ const SettingTypes = {
 
 const KEY_SETTINGS = 'settings'
 const KEY_HOSTNAME = 'hostname'
+const KEY_BILLING_STATE = 'billingState'
+
+const BILLING_STATES = {
+    UNKNOWN: undefined,
+    NOT_BILLED: 'not_billed',
+    BILLED: 'billed'
+}
+Object.freeze(BILLING_STATES)
 
 module.exports = {
     KEY_SETTINGS,
     KEY_HOSTNAME,
+    KEY_BILLING_STATE,
     name: 'ProjectSettings',
     schema: {
         ProjectId: { type: DataTypes.UUID, unique: 'pk_settings' },
@@ -47,6 +56,7 @@ module.exports = {
     finders: function (M) {
         return {
             static: {
+                BILLING_STATES,
                 isHostnameUsed: async (hostname) => {
                     const count = await this.count({
                         where: { key: KEY_HOSTNAME, value: hostname.toLowerCase() }


### PR DESCRIPTION
## Description

Stores the project's billing state whenever it is added to or removed from the billing subscription. 

## Related Issue(s)

Fixes #1616

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
