### PR TITLE
Refactor project put method to a single route

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -14,6 +14,7 @@ const forgeUtils = require('../../db/utils')
 
 module.exports = {
     START_DELAY: 500,
+    STOP_DELAY: 250,
     /**
      * Initialises this driver
      *
@@ -134,7 +135,7 @@ module.exports = {
                 setTimeout(() => {
                     list[project.id].state = 'suspended'
                     resolve()
-                }, 250)
+                }, module.exports.STOP_DELAY)
             })
         } else {
             throw new Error(`${project.id} not found`)

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -4,7 +4,7 @@ const ProjectActions = require('./projectActions')
 const ProjectDevices = require('./projectDevices')
 const ProjectSnapshots = require('./projectSnapshots')
 
-const { KEY_HOSTNAME } = require('../../db/models/ProjectSettings')
+const { KEY_HOSTNAME, KEY_SETTINGS } = require('../../db/models/ProjectSettings')
 const { isFQDN } = require('../../lib/validate')
 
 /**
@@ -272,7 +272,7 @@ module.exports = async function (app) {
             })
             await settings.save()
 
-            const sourceProjectSettings = await sourceProject.getSetting('settings') || { env: [] }
+            const sourceProjectSettings = await sourceProject.getSetting(KEY_SETTINGS) || { env: [] }
             const sourceProjectEnvVars = sourceProjectSettings.env || []
             const newProjectSettings = { ...sourceProjectSettings }
             newProjectSettings.env = []
@@ -286,10 +286,10 @@ module.exports = async function (app) {
                 })
             }
             newProjectSettings.header = { title: name }
-            await project.updateSetting('settings', newProjectSettings)
+            await project.updateSetting(KEY_SETTINGS, newProjectSettings)
         } else {
             const newProjectSettings = { header: { title: name } }
-            await project.updateSetting('settings', newProjectSettings)
+            await project.updateSetting(KEY_SETTINGS, newProjectSettings)
             await project.updateSetting('credentialSecret', generateCredentialSecret())
         }
 
@@ -360,103 +360,10 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
-        // Updating a projects definition
-        if (request.body.changeProjectDefinition === true) {
-            if (!request.body.projectType) {
-                reply.code(400).send({ code: 'invalid_request', error: 'Invalid project type' })
-                return
-            }
-            if (!request.body.stack) {
-                reply.code(400).send({ code: 'invalid_request', error: 'Invalid stack' })
-                return
-            }
-            const newProjectType = await app.db.models.ProjectType.byId(request.body.projectType)
-            if (!newProjectType) {
-                reply.code(400).send({ code: 'invalid_project_type', error: 'Invalid project type' })
-                return
-            }
-            const stack = await app.db.models.ProjectStack.byId(request.body.stack)
-            if (!stack) {
-                reply.code(400).send({ code: 'invalid_stack', error: 'Invalid stack' })
-                return
-            }
-            app.log.info(`Updating project ${request.project.id} to type: '${newProjectType.hashid}',  stack: '${stack.hashid}'`)
-            const { resumeProject, targetState } = await suspendProject()
-            const t = await app.db.sequelize.transaction() // start a transaction
-            let typeChanged = false
-            let stackChanged = false
-            try {
-                if (request.project.ProjectType?.id !== newProjectType.id) {
-                    await request.project.setProjectType(newProjectType, { transaction: t })
-                    typeChanged = true
-                }
-                if (request.project.ProjectStack?.id !== stack.id) {
-                    await request.project.setProjectStack(stack, { transaction: t })
-                    stackChanged = true
-                }
-                await t.commit() // all good, commit the transaction
-            } catch (error) {
-                await t.rollback() // rollback the transaction.
-                reply.code(500).send({ code: 'unexpected_error', error: error.message })
-                return
-            }
-            if (typeChanged) {
-                await app.auditLog.Project.project.type.changed(request.session.User, null, request.project, newProjectType)
-            }
-            if (stackChanged) {
-                await app.auditLog.Project.project.stack.changed(request.session.User, null, request.project, stack)
-            }
-            await unSuspendProject(resumeProject, targetState)
-            reply.send({})
-
-        // Changing only the stack - used for stack upgrades
-        } else if (request.body.stack) {
-            if (request.body.stack !== request.project.ProjectStack?.id) {
-                const stack = await app.db.models.ProjectStack.byId(request.body.stack)
-                if (!stack) {
-                    reply.code(400).send({ code: 'invalid_stack', error: 'Invalid stack' })
-                    return
-                }
-                app.log.info(`Updating project ${request.project.id} to use stack ${stack.hashid}`)
-
-                // TODO: better inflight state needed
-                app.db.controllers.Project.setInflightState(request.project, 'starting')
-
-                // With the project stopped, respond to the request so the UI
-                // can refresh to show 'progress'. We may want to move this even earlier.
-                reply.send({})
-
-                const { resumeProject, targetState } = await suspendProject()
-                await request.project.setProjectStack(stack)
-                await request.project.save()
-                await app.auditLog.Project.project.stack.changed(request.session.User, null, request.project, stack)
-                await unSuspendProject(resumeProject, targetState)
-            }
-
-        // Setting the project type for the first time (legacy)
-        } else if (request.body.projectType) {
-            if (request.project.ProjectType) {
-                reply.code(400).send({ code: 'invalid_request', error: 'Cannot change project type' })
-                return
-            }
-            const existingStackProjectType = request.project.ProjectStack.ProjectTypeId
-            const newProjectType = await app.db.models.ProjectType.byId(request.body.projectType)
-            if (!newProjectType) {
-                reply.code(400).send({ code: 'invalid_project_type', error: 'Invalid project type' })
-                return
-            }
-            if (existingStackProjectType && newProjectType.id !== existingStackProjectType) {
-                reply.code(400).send({ code: 'invalid_request', error: 'Mismatch between stack project type and new project type' })
-                return
-            }
-
-            await request.project.setProjectType(newProjectType)
-
-            reply.code(200).send({})
-
         // Export this one project over another
-        } else if (request.body.sourceProject) {
+        if (request.body.sourceProject) {
             const sourceProject = await app.db.models.Project.byId(request.body.sourceProject.id)
+            const targetProject = request.project
             const options = request.body.sourceProject.options
             if (!sourceProject) {
                 reply.code(404).send('Source Project not found')
@@ -465,205 +372,227 @@ module.exports = async function (app) {
                 reply.code(403).send('Source Project and Target not in same team')
             }
 
-            reply.send({})
+            // Early return, status is loaded async
+            reply.code(200).send({})
 
-            const { resumeProject, targetState } = await suspendProject()
+            exportProjectToExistingProject(sourceProject, targetProject, options) // runs async
 
-            const sourceSettingsString = ((await app.db.models.StorageSettings.byProject(sourceProject.id))?.settings) || '{}'
-            const sourceSettings = JSON.parse(sourceSettingsString)
-            let targetStorageSettings = await app.db.models.StorageSettings.byProject(request.project.id)
-            const targetSettingString = targetStorageSettings?.settings || '{}'
-            const targetSettings = JSON.parse(targetSettingString)
+            return
+        }
 
-            targetSettings.nodes = sourceSettings.nodes
-            if (targetStorageSettings) {
-                targetStorageSettings.settings = JSON.stringify(targetSettings)
+        /// Validation of changes
+        const changesToPersist = {}
+
+        // Name
+        const reqName = request.body.name?.trim()
+        const reqSafeName = reqName?.toLowerCase()
+        const projectName = request.project.name?.trim()
+        if (reqName && projectName !== reqName) {
+            if (bannedNameList.includes(reqSafeName)) {
+                reply.status(409).type('application/json').send({ code: 'invalid_project_name', error: 'name not allowed' })
+                return
+            }
+            if (await app.db.models.Project.isNameUsed(reqSafeName)) {
+                reply.status(409).type('application/json').send({ code: 'invalid_project_name', error: 'name in use' })
+                return
+            }
+
+            changesToPersist.name = { from: projectName, to: reqName }
+        }
+
+        // Hostname
+        const newHostname = request.body.hostname?.toLowerCase().replace(/\.$/, '') // trim trailing .
+        const oldHostname = await request.project.getSetting(KEY_HOSTNAME)
+        if (newHostname && newHostname !== oldHostname) {
+            if (!isFQDN(newHostname)) {
+                reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is not an FQDN' })
+                return
+            }
+
+            const hostnameInUse = await app.db.models.ProjectSettings.isHostnameUsed(newHostname)
+            const hostnameMatchesDomain = (app.config.domain && newHostname.endsWith(app.config.domain.toLowerCase()))
+            if (hostnameInUse || hostnameMatchesDomain) {
+                reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is already in use' })
+                return
+            }
+
+            changesToPersist.hostname = { from: oldHostname, to: newHostname }
+        }
+
+        // Settings
+        if (request.body.settings) {
+            let bodySettings
+            if (request.allSettingsEdit) {
+                // store all body settings if user is owner
+                bodySettings = request.body.settings
             } else {
-                targetStorageSettings = await app.db.models.StorageSettings.create({
-                    settings: JSON.stringify(targetSettings),
-                    ProjectId: request.project.id
-                })
-            }
-            await targetStorageSettings.save()
-
-            if (options.flows) {
-                let sourceFlow = await app.db.models.StorageFlow.byProject(sourceProject.id)
-                let targetFlow = await app.db.models.StorageFlow.byProject(request.project.id)
-                if (!sourceFlow) {
-                    sourceFlow = {
-                        flow: '[]'
-                    }
-                }
-                if (targetFlow) {
-                    targetFlow.flow = sourceFlow.flow
-                } else {
-                    targetFlow = await app.db.models.StorageFlow.create({
-                        flow: sourceFlow.flow,
-                        ProjectId: request.project.id
-                    })
-                }
-                await targetFlow.save()
-            }
-            if (options.credentials) {
-                // To copy over the credentials, we have to:
-                //  - get the source credentials + credentialSecret
-                //  - get the target credentials + credentialSecret
-                //  - decrypt credentials from src and re-encrypt the
-                //  - credentials using the target key for target StorageCredentials
-                const origCredentials = await app.db.models.StorageCredentials.byProject(sourceProject.id)
-                if (origCredentials) {
-                    let trgCredentialSecret = await request.project.getSetting('credentialSecret')
-                    if (trgCredentialSecret == null) {
-                        trgCredentialSecret = targetSettings?._credentialSecret || generateCredentialSecret()
-                        request.project.updateSetting('credentialSecret', trgCredentialSecret)
-                        delete targetSettings._credentialSecret
-                    }
-                    const srcCredentials = JSON.parse(origCredentials.credentials)
-                    const srcCredentialSecret = await sourceProject.getSetting('credentialSecret') || sourceSettings._credentialSecret
-                    let targetCreds = await app.db.models.StorageCredentials.byProject(request.project.id)
-                    if (targetCreds && srcCredentials) {
-                        targetCreds.credentials = JSON.stringify(app.db.controllers.Project.exportCredentials(srcCredentials, srcCredentialSecret, trgCredentialSecret))
-                        await targetCreds.save()
-                    } else if (srcCredentials) {
-                        targetCreds = await app.db.models.StorageCredentials.create({
-                            credentials: JSON.stringify(app.db.controllers.Project.exportCredentials(srcCredentials, srcCredentialSecret, trgCredentialSecret)),
-                            ProjectId: request.project.id
-                        })
-                        await targetCreds.save()
-                    }
+                // only store settings.env if user is member
+                bodySettings = {
+                    env: request.body.settings.env
                 }
             }
-            if (options.template) {
-                request.project.ProjectTemplateId = sourceProject.ProjectTemplateId
-                await request.project.save()
-                await request.project.reload()
-            }
-            // Get the source project settings - ignore hostname
-            const sourceProjectSettings = await sourceProject.getSetting('settings') || { env: [] }
-            // Get the target project settings
-            let targetProjectSettings = await request.project.getSetting('settings') || { env: [] }
-            const targetProjectEnvVars = targetProjectSettings.env
+            const newSettings = app.db.controllers.ProjectTemplate.validateSettings(bodySettings, request.project.ProjectTemplate)
+            // Merge the settings into the existing values
+            const currentProjectSettings = await request.project.getSetting(KEY_SETTINGS) || {}
+            const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)
 
-            let updateSettings = false
+            changesToPersist.settings = { from: currentProjectSettings, to: updatedSettings }
+        }
 
-            if (options.settings) {
-                // The target project needs to pickup the source project settings
-                targetProjectSettings = sourceProjectSettings
-                if (!options.envVars) {
-                    // Need to keep the existing env vars
-                    targetProjectSettings.env = targetProjectEnvVars
-                }
-                updateSettings = true
-            }
-            if (options.envVars) {
-                targetProjectSettings.env = mergeEnvVars(options, sourceProjectSettings.env, targetProjectEnvVars)
-                updateSettings = true
-            }
-            if (updateSettings) {
-                await request.project.updateSetting('settings', targetProjectSettings)
+        // Project Type
+        if (request.body.projectType) {
+            const newProjectType = await app.db.models.ProjectType.byId(request.body.projectType)
+            if (!newProjectType) {
+                reply.code(400).send({ code: 'invalid_project_type', error: 'Invalid project type' })
+                return
             }
 
-            await unSuspendProject(resumeProject, targetState)
-
-        // Updating a project settings
-        } else {
-            const reqName = request.body.name?.trim()
-            const reqSafeName = reqName?.toLowerCase()
-            const projectName = request.project.name?.trim()
-            const updates = new app.auditLog.formatters.UpdatesCollection()
-
-            let changed = false
-            if (reqName && projectName !== reqName) {
-                if (bannedNameList.includes(reqSafeName)) {
-                    reply.status(409).type('application/json').send({ code: 'invalid_project_name', error: 'name not allowed' })
+            // Setting of project type for first time only (legacy)
+            if (!request.project.ProjectType) {
+                const existingStackProjectType = request.project.ProjectStack.ProjectTypeId
+                if (existingStackProjectType && newProjectType.id !== existingStackProjectType) {
+                    reply.code(400).send({ code: 'invalid_request', error: 'Mismatch between stack project type and new project type' })
                     return
                 }
-                if (await app.db.models.Project.isNameUsed(reqSafeName)) {
-                    reply.status(409).type('application/json').send({ code: 'invalid_project_name', error: 'name in use' })
-                    return
+            } else {
+                // Must specify stack if changing project
+                const newStack = request.body.stack
+                if (!newStack) {
+                    reply.code(400).send({ code: 'invalid_request', error: 'Stack must be set when changing project type' })
                 }
-                request.project.name = reqName
-                changed = true
-                updates.push('name', projectName, reqName)
             }
 
-            const newHostname = request.body.hostname?.toLowerCase().replace(/\.$/, '') // trim trailing .
-            const oldHostname = await request.project.getSetting('hostname')
-            if (newHostname && newHostname !== oldHostname) {
-                if (!isFQDN(newHostname)) {
-                    reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is not an FQDN' })
-                    return
-                }
+            changesToPersist.projectType = { from: request.project.projectType, to: newProjectType }
+        }
 
-                const hostnameInUse = await app.db.models.ProjectSettings.isHostnameUsed(newHostname)
-                const hostnameMatchesDomain = (app.config.domain && newHostname.endsWith(app.config.domain.toLowerCase()))
-                if (hostnameInUse || hostnameMatchesDomain) {
-                    reply.status(409).type('application/json').send({ code: 'invalid_hostname', error: 'Hostname is already in use' })
-                    return
-                }
-
-                await request.project.updateSetting(KEY_HOSTNAME, newHostname)
-                await request.project.reload({
-                    include: [
-                        { model: app.db.models.ProjectSettings }
-                    ]
-                })
-                changed = true
-                updates.push('hostname', newHostname, oldHostname)
+        // Project Stack
+        if (request.body.stack) {
+            const stack = await app.db.models.ProjectStack.byId(request.body.stack)
+            if (!stack) {
+                reply.code(400).send({ code: 'invalid_stack', error: 'Invalid stack' })
+                return
             }
 
-            if (request.body.settings) {
-                let bodySettings
+            changesToPersist.stack = { from: request.project.stack, to: stack }
+        }
+
+        /// Persist the changes
+        const updates = new app.auditLog.formatters.UpdatesCollection()
+        const transaction = await app.db.sequelize.transaction() // start a transaction
+        const changesToProjectDefinition = changesToPersist.stack || changesToPersist.projectType
+        let returnedEarly = false
+        try {
+            let resumeProject, targetState
+            if (changesToProjectDefinition) {
+                // Early return and complete the rest async
+                app.db.controllers.Project.setInflightState(request.project, 'starting') // TODO: better inflight state needed
+                reply.code(200).send({})
+                returnedEarly = true
+
+                const result = await suspendProject()
+                resumeProject = result.resumeProject
+                targetState = result.targetState
+            }
+
+            if (changesToPersist.name) {
+                request.project.name = changesToPersist.name.to
+                await request.project.save({ transaction })
+
+                updates.push('name', changesToPersist.name.from, changesToPersist.name.to)
+            }
+
+            if (changesToPersist.hostname) {
+                await request.project.updateSetting(KEY_HOSTNAME, changesToPersist.hostname.to, { transaction })
+
+                updates.push('hostname', changesToPersist.hostname.from, changesToPersist.hostname.to)
+            }
+
+            if (changesToPersist.settings) {
+                await request.project.updateSetting(KEY_SETTINGS, changesToPersist.settings.to, { transaction })
+
                 if (request.allSettingsEdit) {
-                    // store all body settings if user is owner
-                    bodySettings = request.body.settings
+                    updates.pushDifferences(changesToPersist.settings.from, changesToPersist.settings.to)
                 } else {
-                    // only store settings.env if user is member
-                    bodySettings = {
-                        env: request.body.settings.env
-                    }
-                }
-                const newSettings = app.db.controllers.ProjectTemplate.validateSettings(bodySettings, request.project.ProjectTemplate)
-                // Merge the settings into the existing values
-                const currentProjectSettings = await request.project.getSetting('settings') || {}
-                const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)
-                await request.project.updateSetting('settings', updatedSettings)
-                changed = true
-                if (request.allSettingsEdit) {
-                    updates.pushDifferences(currentProjectSettings, updatedSettings)
-                } else {
-                    updates.pushDifferences({ env: currentProjectSettings.env }, { env: newSettings.env })
+                    updates.pushDifferences({ env: changesToPersist.settings.from.env }, { env: changesToPersist.settings.to.env })
                 }
             }
-            if (changed) {
-                await request.project.save()
+
+            if (changesToPersist.stack || changesToPersist.projectType) {
+                if (changesToPersist.projectType) {
+                    app.log.info(`Updating project ${request.project.id} to type: '${changesToPersist.projectType.to.hashid}',  stack: '${changesToPersist.stack.to.hashid}'`)
+                } else {
+                    app.log.info(`Updating project ${request.project.id} to use stack ${changesToPersist.stack.to.hashid}`)
+                }
+
+                if (changesToPersist.projectType.to) {
+                    await request.project.setProjectType(changesToPersist.projectType.to, { transaction })
+                }
+
+                if (changesToPersist.stack.to) {
+                    await request.project.setProjectStack(changesToPersist.stack.to, { transaction })
+                }
+            }
+
+            await transaction.commit() // all good, commit the transaction
+
+            // Log the updates
+            if (updates.length > 0) {
                 await app.auditLog.Project.project.settings.updated(request.session.User.id, null, request.project, updates)
             }
-            const project = await app.db.views.Project.project(request.project)
-            let result
-            if (request.teamMembership.role >= Roles.Owner) {
-                result = project
-            } else {
-                // exclude template object in response when not owner
-                result = {
-                    createdAt: project.createdAt,
-                    id: project.id,
-                    name: project.name,
-                    links: project.links,
-                    projectType: project.projectType,
-                    stack: project.stack,
-                    team: project.team,
-                    updatedAt: project.updatedAt,
-                    url: project.url,
-                    settings: {
-                        env: project.settings?.env
-                    }
+            if (changesToPersist.projectType) {
+                await app.auditLog.Project.project.type.changed(request.session.User, null, request.project, changesToPersist.projectType.to)
+            }
+            if (changesToPersist.stack) {
+                await app.auditLog.Project.project.stack.changed(request.session.User, null, request.project, changesToPersist.stack.to)
+            }
+
+            // Awaken the project
+            if (changesToProjectDefinition) {
+                await unSuspendProject(resumeProject, targetState)
+            }
+        } catch (error) {
+            await transaction.rollback() // rollback the transaction.
+            app.log.error('Error while updating project:')
+            app.log.error(error)
+            if (!returnedEarly) {
+                reply.code(500).send({ code: 'unexpected_error', error: error.message })
+            }
+            return
+        }
+
+        if (returnedEarly) {
+            // No further response needed
+            return
+        }
+
+        // Result
+        const project = await app.db.models.Project.byId(request.project.id) // Reload project entirely
+        const projectView = await app.db.views.Project.project(request.project)
+        let result
+        if (request.teamMembership.role >= Roles.Owner) {
+            result = projectView
+        } else {
+            // exclude template object in response when not owner
+            result = {
+                createdAt: projectView.createdAt,
+                id: projectView.id,
+                name: projectView.name,
+                links: projectView.links,
+                projectType: projectView.projectType,
+                stack: projectView.stack,
+                team: projectView.team,
+                updatedAt: projectView.updatedAt,
+                url: projectView.url,
+                settings: {
+                    env: projectView.settings?.env
                 }
             }
-            result.meta = await app.containers.details(request.project) || { state: 'unknown' }
-            result.team = await app.db.views.Team.teamSummary(request.project.Team)
-            reply.send(result)
         }
+
+        result.meta = await app.containers.details(project) || { state: 'unknown' }
+        result.team = await app.db.views.Team.teamSummary(project.Team)
+
+        reply.send(result)
 
         async function unSuspendProject (resumeProject, targetState) {
             if (resumeProject) {
@@ -682,16 +611,124 @@ module.exports = async function (app) {
             }
         }
 
-        async function suspendProject () {
+        async function suspendProject (project = request.project) {
             let resumeProject = false
-            const targetState = request.project.state
-            if (request.project.state !== 'suspended') {
+            const targetState = project.state
+            if (project.state !== 'suspended') {
                 resumeProject = true
-                app.log.info(`Stopping project ${request.project.id}`)
-                await app.containers.stop(request.project)
-                await app.auditLog.Project.project.suspended(request.session.User, null, request.project)
+                app.log.info(`Stopping project ${project.id}`)
+                await app.containers.stop(project)
+                await app.auditLog.Project.project.suspended(request.session.User, null, project)
             }
             return { resumeProject, targetState }
+        }
+
+        async function exportProjectToExistingProject (sourceProject, targetProject, options) {
+            const { resumeProject, targetState } = await suspendProject(targetProject)
+
+            // Nodes
+            const sourceSettingsString = ((await app.db.models.StorageSettings.byProject(sourceProject.id))?.settings) || '{}'
+            const sourceSettings = JSON.parse(sourceSettingsString)
+
+            let targetStorageSettings = await app.db.models.StorageSettings.byProject(targetProject.id)
+            const targetSettingString = targetStorageSettings?.settings || '{}'
+            const targetSettings = JSON.parse(targetSettingString)
+
+            targetSettings.nodes = sourceSettings.nodes
+            if (targetStorageSettings) {
+                targetStorageSettings.settings = JSON.stringify(targetSettings)
+            } else {
+                targetStorageSettings = await app.db.models.StorageSettings.create({
+                    settings: JSON.stringify(targetSettings),
+                    ProjectId: targetProject.id
+                })
+            }
+            await targetStorageSettings.save()
+
+            // Flows
+            if (options.flows) {
+                let sourceFlow = await app.db.models.StorageFlow.byProject(sourceProject.id)
+                let targetFlow = await app.db.models.StorageFlow.byProject(targetProject.id)
+                if (!sourceFlow) {
+                    sourceFlow = {
+                        flow: '[]'
+                    }
+                }
+                if (targetFlow) {
+                    targetFlow.flow = sourceFlow.flow
+                } else {
+                    targetFlow = await app.db.models.StorageFlow.create({
+                        flow: sourceFlow.flow,
+                        ProjectId: targetProject.id
+                    })
+                }
+                await targetFlow.save()
+            }
+
+            // Credentials
+            if (options.credentials) {
+                /*
+                    To copy over the credentials, we have to:
+                    - get the source credentials + credentialSecret
+                    - get the target credentials + credentialSecret
+                    - decrypt credentials from src and re-encrypt the
+                    - credentials using the target key for target StorageCredentials
+                */
+                const origCredentials = await app.db.models.StorageCredentials.byProject(sourceProject.id)
+                if (origCredentials) {
+                    let trgCredentialSecret = await targetProject.getSetting('credentialSecret')
+                    if (trgCredentialSecret == null) {
+                        trgCredentialSecret = targetSettings?._credentialSecret || generateCredentialSecret()
+                        targetProject.updateSetting('credentialSecret', trgCredentialSecret)
+                        delete targetSettings._credentialSecret
+                    }
+                    const srcCredentials = JSON.parse(origCredentials.credentials)
+                    const srcCredentialSecret = await sourceProject.getSetting('credentialSecret') || sourceSettings._credentialSecret
+                    let targetCreds = await app.db.models.StorageCredentials.byProject(targetProject.id)
+                    if (targetCreds && srcCredentials) {
+                        targetCreds.credentials = JSON.stringify(app.db.controllers.Project.exportCredentials(srcCredentials, srcCredentialSecret, trgCredentialSecret))
+                        await targetCreds.save()
+                    } else if (srcCredentials) {
+                        targetCreds = await app.db.models.StorageCredentials.create({
+                            credentials: JSON.stringify(app.db.controllers.Project.exportCredentials(srcCredentials, srcCredentialSecret, trgCredentialSecret)),
+                            ProjectId: targetProject.id
+                        })
+                        await targetCreds.save()
+                    }
+                }
+            }
+
+            // Template
+            if (options.template) {
+                targetProject.ProjectTemplateId = sourceProject.ProjectTemplateId
+                await targetProject.save()
+                await targetProject.reload()
+            }
+
+            // Settings
+            let updateSettings = false
+            const sourceProjectSettings = await sourceProject.getSetting(KEY_SETTINGS) || { env: [] }
+            let targetProjectSettings = await targetProject.getSetting(KEY_SETTINGS) || { env: [] }
+            const targetProjectEnvVars = targetProjectSettings.env
+            if (options.settings) {
+                targetProjectSettings = sourceProjectSettings
+                if (!options.envVars) {
+                    // Need to keep the existing env vars
+                    targetProjectSettings.env = targetProjectEnvVars
+                }
+                updateSettings = true
+            }
+
+            if (options.envVars) {
+                targetProjectSettings.env = mergeEnvVars(options, sourceProjectSettings.env, targetProjectEnvVars)
+                updateSettings = true
+            }
+
+            if (updateSettings) {
+                await targetProject.updateSetting(KEY_SETTINGS, targetProjectSettings)
+            }
+
+            await unSuspendProject(resumeProject, targetState)
         }
     })
 

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -571,6 +571,15 @@ module.exports = async function (app) {
             return
         }
 
+        // Bust sequelize caching on project settings
+        if (changesToPersist.hostname || changesToPersist.settings) {
+            await request.project.reload({
+                include: [
+                    { model: app.db.models.ProjectSettings }
+                ]
+            })
+        }
+
         // Result
         const project = await app.db.models.Project.byId(request.project.id) // Reload project entirely
         const projectView = await app.db.views.Project.project(request.project)

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -793,9 +793,17 @@ describe('Project API', function () {
 
                 response.statusCode.should.equal(200)
 
-                // Project is stopped and restarted async and returns early
-                // Wait for at least 250ms+500ms (stop/start time as set in stub driver)
-                await sleep(800)
+                // Project is stopped and restarted async
+                // Wait for time stub driver takes to stop project
+                await sleep(STOP_DELAY)
+                await project.reload()
+
+                // Project has been stopped but is presented as "starting"
+                project.state.should.equal('suspended')
+                app.db.controllers.Project.getInflightState(project).should.equal('starting')
+
+                // Wait for at least start delay as set in stub driver
+                await sleep(START_DELAY + 100)
 
                 await project.reload({
                     include: [
@@ -804,6 +812,11 @@ describe('Project API', function () {
                     ]
                 })
 
+                // Project is re-running
+                project.state.should.equal('running')
+                should(app.db.controllers.Project.getInflightState(project)).equal(undefined)
+
+                // Type and stack updated
                 project.ProjectType.id.should.equal(projectType.id)
                 project.ProjectStack.id.should.equal(stack.id)
 
@@ -847,9 +860,17 @@ describe('Project API', function () {
 
                 response.statusCode.should.equal(200)
 
-                // Project is stopped and restarted async and returns early
-                // Wait for at least 250ms+500ms (stop/start time as set in stub driver)
-                await sleep(800)
+                // Project is stopped and restarted async
+                // Wait for time stub driver takes to stop project
+                await sleep(STOP_DELAY)
+                await project.reload()
+
+                // Project has been stopped but is presented as "starting"
+                project.state.should.equal('suspended')
+                app.db.controllers.Project.getInflightState(project).should.equal('starting')
+
+                // Wait for at least start delay as set in stub driver
+                await sleep(START_DELAY + 100)
 
                 await project.reload({
                     include: [
@@ -858,6 +879,11 @@ describe('Project API', function () {
                     ]
                 })
 
+                // Project is re-running
+                project.state.should.equal('running')
+                should(app.db.controllers.Project.getInflightState(project)).equal(undefined)
+
+                // Stack has been updated
                 project.ProjectType.id.should.equal(projectType.id)
                 project.ProjectStack.id.should.equal(stack.id)
 

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -5,7 +5,8 @@ const crypto = require('crypto')
 const sleep = require('util').promisify(setTimeout)
 const setup = require('../setup')
 
-const { KEY_HOSTNAME } = require('../../../../../forge/db/models/ProjectSettings')
+const { KEY_HOSTNAME } = FF_UTIL.require('forge/db/models/ProjectSettings')
+const { START_DELAY, STOP_DELAY } = FF_UTIL.require('forge/containers/stub/index.js')
 
 function encryptCredentials (key, plain) {
     const initVector = crypto.randomBytes(16)
@@ -1026,7 +1027,7 @@ describe('Project API', function () {
                     cookies: { sid: TestObjects.tokens.alice }
                 })
                 response.statusCode.should.equal(200)
-                await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+                await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wait (stop/start time as set in stub driver)
                 const newAccessToken = (await newProject.refreshAuthTokens()).token
                 const runtimeSettings = (await app.inject({
                     method: 'GET',
@@ -1091,7 +1092,7 @@ describe('Project API', function () {
                         cookies: { sid: TestObjects.tokens.alice }
                     })
                     response.statusCode.should.equal(200)
-                    await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+                    await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wai (stop/start time as set in stub driver)
                     const newAccessToken = (await newProject.refreshAuthTokens()).token
                     const runtimeSettings = (await app.inject({
                         method: 'GET',
@@ -1171,7 +1172,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+
             const newSettings = await TestObjects.project1.getSetting('settings')
             newSettings.should.have.property('codeEditor', 'ace') // should be changed
             newSettings.should.have.property('httpAdminRoot', '/test-red') // should be unchanged
@@ -1226,7 +1227,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+
             const newSettings = await TestObjects.project1.getSetting('settings')
             newSettings.should.have.property('codeEditor', 'monaco') // should be unchanged
             newSettings.should.have.property('httpAdminRoot', '/test-red') // should be unchanged
@@ -1266,7 +1267,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.bob }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+
             const newSettings = await TestObjects.project1.getSetting('settings')
             newSettings.should.have.property('codeEditor', 'monaco') // should be unchanged
             newSettings.should.have.property('httpAdminRoot', '/test-red') // should be unchanged
@@ -1416,7 +1417,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+            await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wait (stop/start time as set in stub driver)
 
             const newAccessToken = (await newProject.refreshAuthTokens()).token
             const newFlows = await getProjectInfo(newProject.id, newAccessToken, 'flows')
@@ -1499,7 +1500,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+            await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wait (stop/start time as set in stub driver)
             const newAccessToken = (await newProject.refreshAuthTokens()).token
             const runtimeSettings = (await app.inject({
                 method: 'GET',
@@ -1569,7 +1570,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+            await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wait (stop/start time as set in stub driver)
             const newAccessToken = (await newProject.refreshAuthTokens()).token
             const runtimeSettings = (await app.inject({
                 method: 'GET',
@@ -1628,7 +1629,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+            await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wait (stop/start time as set in stub driver)
             const newAccessToken = (await newProject.refreshAuthTokens()).token
             const newCreds = await getProjectInfo(newProject.id, newAccessToken, 'credentials')
             Object.keys(newCreds).should.have.length(0)
@@ -1674,7 +1675,7 @@ describe('Project API', function () {
                 cookies: { sid: TestObjects.tokens.alice }
             })
             response.statusCode.should.equal(200)
-            await sleep(850) // "Update a project" returns early so it is necessary to wait at least 250ms+500ms (stop/start time as set in stub driver)
+            await sleep(STOP_DELAY + START_DELAY + 50) // "Update a project" returns early so it is necessary to wait (stop/start time as set in stub driver)
             const newAccessToken = (await newProject.refreshAuthTokens()).token
             // Flows should be empty
             const newFlows = await getProjectInfo(newProject.id, newAccessToken, 'flows')


### PR DESCRIPTION
## Description

Refactors the unwieldy Project update endpoint to have a single implementation for _updating_ a project. 

Three key objectives:
 - Easier to maintain code
 - Clearer overview of what is legacy
 - Improved failure state handling (transactions) - previously errors would leave projects in a half updated state

There are two subtle API changes as a result, the rest of the API behaves the same as previously (including the legacy setting of stack and type):
 - The `changeProjectDefinition` flag is no longer needed to change a projects time
 - Changing a projects type now returns early and completes the reboot of the project async

## Related Issue(s)

Replaces https://github.com/flowforge/flowforge/pull/1623
Follow up to https://github.com/flowforge/flowforge/pull/1631

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass

