### PR TITLE
Move "Danger" settings into the "General" tab

### DIFF
--- a/docs/user/changestack.md
+++ b/docs/user/changestack.md
@@ -16,10 +16,9 @@ new version available.
 To change a project's stack:
 
 1. Go to the project's page and select **Settings** in the sidebar.
-2. Select the **Danger** section in the side menu
-3. Click the **Change Project Stack** button
-4. You will be prompted to select the new stack for the project.
-5. Click **Change Stack**
+2. Click the **Change Project Stack** button
+3. You will be prompted to select the new stack for the project.
+4. Click **Change Stack**
 
 Your project will now be restart on the new stack.
 

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -4,11 +4,44 @@ The Project Settings allow you to customize many aspects of your Node-RED runtim
 
 Project Settings are split into a number of sections:
 
+ - [General](#general)
  - [Environment](#environment)
  - [Editor](#editor)
  - [Security](#security)
  - [Palette](#palette)
- - [Danger](#danger)
+
+## General
+
+This section includes a number of actions you can take on the project:
+
+### Change Stack
+
+The Project Stack determines the version of Node-RED being used. If a new stack
+is available, you can use this option to updated your project.
+
+### Copy Project
+
+This allows you to create a copy of the project in your team. Alternatively, you
+can use it to export certain parts of your project into an existing project.
+
+For example, you may want to have separate 'Development' and 'Production' projects
+using different Environment Variables to point the flows at different external
+resources. You can then use the 'Export into existing project' to copy over just the
+flows when you want to update your Production instance.
+
+### Import Project
+
+This allows you to take existing Node-RED flow and credential files and import them
+into your project.
+
+### Suspend Project
+
+This stops the project entirely.
+
+### Delete Project
+
+If you're really sure you don't want the project anymore, this allows you to delete
+it. You cannot undo deleting a project.
 
 ## Environment
 
@@ -41,36 +74,3 @@ FlowForge.
 
 This allows you to manage what extra nodes are installed inside Node-RED, as well
 as any restrictions you want to apply to the Palette Manager within Node-RED.
-
-## Danger
-
-This section includes a number of actions you can take on the project:
-
-### Change Stack
-
-The Project Stack determines the version of Node-RED being used. If a new stack
-is available, you can use this option to updated your project.
-
-### Copy Project
-
-This allows you to create a copy of the project in your team. Alternatively, you
-can use it to export certain parts of your project into an existing project.
-
-For example, you may want to have separate 'Development' and 'Production' projects
-using different Environment Variables to point the flows at different external
-resources. You can then use the 'Export into existing project' to copy over just the
-flows when you want to update your Production instance.
-
-### Import Project
-
-This allows you to take existing Node-RED flow and credential files and import them
-into your project.
-
-### Suspend Project
-
-This stops the project entirely.
-
-### Delete Project
-
-If you're really sure you don't want the project anymore, this allows you to delete
-it. You cannot undo deleting a project.

--- a/frontend/src/pages/project/Settings/General.vue
+++ b/frontend/src/pages/project/Settings/General.vue
@@ -1,4 +1,5 @@
 <template>
+    <FormHeading class="mb-6">Project Details</FormHeading>
     <div class="space-y-6">
         <FormRow v-model="input.projectId" type="uneditable" id="projectId" inputClass="font-mono">
             Project ID
@@ -23,12 +24,14 @@
         <FormRow v-model="input.templateName" type="uneditable">
             Template
         </FormRow>
-
+        <DangerSettings :project="project"/>
     </div>
 </template>
 
 <script>
 import FormRow from '@/components/FormRow'
+import FormHeading from '@/components/FormHeading'
+import DangerSettings from './Danger.vue'
 
 export default {
     name: 'ProjectSettings',
@@ -81,7 +84,9 @@ export default {
         }
     },
     components: {
-        FormRow
+        FormRow,
+        FormHeading,
+        DangerSettings
     }
 }
 </script>

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -43,7 +43,6 @@ export default {
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
                 this.sideNavigation.push({ name: 'Security', path: './security' })
                 this.sideNavigation.push({ name: 'Palette', path: './palette' })
-                this.sideNavigation.push({ name: 'Danger', path: './danger' })
             }
         }
     }

--- a/test/e2e/frontend/cypress/tests/project.spec.js
+++ b/test/e2e/frontend/cypress/tests/project.spec.js
@@ -104,7 +104,7 @@ describe('FlowForge - Projects', () => {
             .then((response) => {
                 cy.intercept('GET', '/api/*/projects/*').as('getProject')
                 const project = response.body
-                cy.visit(`/project/${project.id}/settings/danger`)
+                cy.visit(`/project/${project.id}/settings`)
                 cy.wait('@getProject')
 
                 cy.get('[data-el="delete-project"]').should('not.be.visible')
@@ -141,7 +141,6 @@ describe('FlowForge - Projects', () => {
         cy.wait('@getProject')
 
         cy.get('[data-nav="project-settings"]').click()
-        cy.get('[data-nav="danger"]').click()
         cy.get('[data-nav="change-project-settings"]').click()
 
         cy.intercept('PUT', '/api/*/projects/*').as('updateProject')
@@ -178,7 +177,6 @@ describe('FlowForge - Projects', () => {
 
         // Put it back how it was
         cy.get('[data-nav="project-settings"]').click()
-        cy.get('[data-nav="danger"]').click()
         cy.get('[data-nav="change-project-settings"]').click()
 
         cy.get('[data-el="change-project"]').within(($form) => {
@@ -223,7 +221,6 @@ describe('FlowForge - Projects', () => {
         cy.wait('@getProject')
 
         cy.get('[data-nav="project-settings"]').click()
-        cy.get('[data-nav="danger"]').click()
         cy.get('[data-nav="copy-project"]').click()
 
         // Does not use same name


### PR DESCRIPTION
## Description

Removed the "Danger" tab, and used the same page/component and embedded that into the "General" settings.

https://user-images.githubusercontent.com/99246719/216029702-822e732f-5611-42f6-b07a-ca58df0c7030.mov

## Related Issue(s)

Arose from discussion around https://github.com/flowforge/flowforge/pull/1610 where the "Danger" tab had grown beyond just dangerous things to change.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [x] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

