### PR TITLE
Change Project Stack without Affecting Billing

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -1,5 +1,3 @@
-const { KEY_BILLING_STATE } = require('../db/models/ProjectSettings')
-
 class SubscriptionHandler {
     constructor (app) {
         this._app = app
@@ -51,9 +49,9 @@ class SubscriptionHandler {
 
         if (skipBilling) {
             const BILLING_STATES = this._app.db.models.ProjectSettings.BILLING_STATES
-            if (await project.getSetting(KEY_BILLING_STATE) === BILLING_STATES.UNKNOWN) {
+            if (await this._app.billing.getProjectBillingState(project) === BILLING_STATES.UNKNOWN) {
                 this._app.log.info('Billing state of project is unknown, but remove attempt that skips billing made, assuming it is currently billed')
-                await project.updateSetting(KEY_BILLING_STATE, BILLING_STATES.BILLED)
+                await this._app.billing.setProjectBillingState(project, BILLING_STATES.BILLED)
             }
 
             this._app.log.info(`Skipped removing project '${project.id}' from subscription - skip billing flag set'`)

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -1,4 +1,4 @@
-const { KEY_BILLING_STATE } = require('../../../db/models/ProjectSettings')
+const { KEY_BILLING_STATE } = require('../db/models/ProjectSettings')
 
 class SubscriptionHandler {
     constructor (app) {
@@ -80,7 +80,7 @@ module.exports = {
         }
         this._subscriptionHandler = new SubscriptionHandler(app)
         this._isBillingEnabled = () => {
-            return app.license.active() && app.billing
+            return app.license.active() && !!app.billing
         }
     },
     /**

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -40,7 +40,7 @@ class SubscriptionHandler {
      * @param {*} project
      * @param {*} options
      */
-    async removeProject (project, { skipBilling = false }) {
+    async removeProject (project, { skipBilling = false } = {}) {
         const subscription = await this.requireSubscription(project.Team)
         if (subscription.isCanceled()) {
             this._app.log.warn(`Skipped removing project '${project.id}' from subscription for canceled subscription '${subscription.subscription}'`)

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -119,6 +119,11 @@ module.exports.init = async function (app) {
             return session
         },
         addProject: async (team, project) => {
+            if (await project.getSetting(KEY_BILLING_STATE) === BILLING_STATES.BILLED) {
+                app.log.info(`Project ${project.id} is already marked billed, skipping adding it to Subscription for team ${team.hashid}`)
+                return
+            }
+
             let projectProduct = app.config.billing.stripe.project_product
             let projectPrice = app.config.billing.stripe.project_price
             const projectType = await project.getProjectType()
@@ -187,6 +192,11 @@ module.exports.init = async function (app) {
             }
         },
         removeProject: async (team, project) => {
+            if (await project.getSetting(KEY_BILLING_STATE) === BILLING_STATES.NOT_BILLED) {
+                app.log.info(`Project ${project.id} is already marked non-billed, skipping removing from Subscription for team ${team.hashid}`)
+                return
+            }
+
             let projectProduct = app.config.billing.stripe.project_product
             const projectType = await project.getProjectType()
             if (projectType) {

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -30,7 +30,8 @@ describe('Projects API - with billing enabled', function () {
         sandbox.stub(app.log, 'info')
         sandbox.stub(app.log, 'warn')
         sandbox.stub(app.log, 'error')
-        sandbox.stub(app.billing)
+        sandbox.stub(app.billing, 'addProject')
+        sandbox.stub(app.billing, 'removeProject')
 
         await login('alice', 'aaPassword')
     })

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -13,7 +13,6 @@ describe('Projects API - with billing enabled', function () {
     const TestObjects = { tokens: {} }
 
     let app
-    let stripe
 
     async function login (username, password) {
         const response = await app.inject({
@@ -26,28 +25,7 @@ describe('Projects API - with billing enabled', function () {
         TestObjects.tokens[username] = response.cookies[0].value
     }
 
-    async function getLog () {
-        const logs = await app.db.models.AuditLog.forEntity()
-        logs.log.should.have.length(1)
-        return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
-    }
-
-    function setupStripe (mock) {
-        require.cache[require.resolve('stripe')] = {
-            exports: function (apiKey) {
-                return mock
-            }
-        }
-        stripe = mock
-    }
-
     beforeEach(async function () {
-        setupStripe({
-            customers: {
-                createBalanceTransaction: sinon.stub().resolves({ status: 'ok' })
-            }
-        })
-
         app = await setup()
         sandbox.stub(app.log, 'info')
         sandbox.stub(app.log, 'warn')
@@ -63,7 +41,7 @@ describe('Projects API - with billing enabled', function () {
         sandbox.restore()
     })
 
-    describe.only('Update Project', function () {
+    describe('Update Project', function () {
         describe('Change project type', function () {
             it('Removes and re-adds the project to billing', async function () {
                 const project = app.project

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -1,0 +1,155 @@
+const FF_UTIL = require('flowforge-test-utils')
+const should = require('should')
+const sinon = require('sinon')
+const sleep = require('util').promisify(setTimeout)
+const setup = require('../../setup')
+
+const { START_DELAY, STOP_DELAY } = FF_UTIL.require('forge/containers/stub/index.js')
+const { KEY_BILLING_STATE } = FF_UTIL.require('forge/db/models/ProjectSettings')
+
+describe('Projects API - with billing enabled', function () {
+    const sandbox = sinon.createSandbox()
+
+    const TestObjects = { tokens: {} }
+
+    let app
+    let stripe
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    async function getLog () {
+        const logs = await app.db.models.AuditLog.forEntity()
+        logs.log.should.have.length(1)
+        return (await app.db.views.AuditLog.auditLog({ log: logs.log })).log[0]
+    }
+
+    function setupStripe (mock) {
+        require.cache[require.resolve('stripe')] = {
+            exports: function (apiKey) {
+                return mock
+            }
+        }
+        stripe = mock
+    }
+
+    beforeEach(async function () {
+        setupStripe({
+            customers: {
+                createBalanceTransaction: sinon.stub().resolves({ status: 'ok' })
+            }
+        })
+
+        app = await setup()
+        sandbox.stub(app.log, 'info')
+        sandbox.stub(app.log, 'warn')
+        sandbox.stub(app.log, 'error')
+        sandbox.stub(app.billing)
+
+        await login('alice', 'aaPassword')
+    })
+
+    afterEach(async function () {
+        await app.close()
+        delete require.cache[require.resolve('stripe')]
+        sandbox.restore()
+    })
+
+    describe.only('Update Project', function () {
+        describe('Change project type', function () {
+            it('Removes and re-adds the project to billing', async function () {
+                const project = app.project
+
+                // Create a new project type
+                const projectTypeProperties = {
+                    name: 'projectType-new',
+                    description: 'This is a new project type',
+                    active: true,
+                    properties: { bar: 'foo' }
+                }
+                const projectType = await app.db.models.ProjectType.create(projectTypeProperties)
+
+                // Create a new stack
+                const stackProperties = {
+                    name: 'stack-new',
+                    active: true,
+                    properties: { nodered: '9.9.9' }
+                }
+                const stack = await app.db.models.ProjectStack.create(stackProperties)
+                await stack.setProjectType(projectType)
+
+                // Put project in running state
+                await app.containers.start(project)
+                app.billing.addProject.resetHistory()
+
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${app.project.id}`,
+                    payload: {
+                        projectType: projectType.id,
+                        stack: stack.id
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                response.statusCode.should.equal(200)
+
+                await sleep(START_DELAY + STOP_DELAY + 50)
+
+                should.equal(app.billing.removeProject.calledOnce, true)
+                should.equal(app.billing.addProject.calledOnce, true)
+            })
+        })
+
+        describe('Change project stack', function () {
+            it('Skips removing the project from billing when changing only stack but marks billing state as billed', async function () {
+                const BILLING_STATES = app.db.models.ProjectSettings.BILLING_STATES
+
+                const project = app.project
+
+                // Create a new stack
+                const stackProperties = {
+                    name: 'stack-new',
+                    active: true,
+                    properties: { nodered: '9.9.9' }
+                }
+                const stack = await app.db.models.ProjectStack.create(stackProperties)
+                await stack.setProjectType(app.projectType)
+
+                // Put project in running state
+                await app.containers.start(project)
+                app.billing.addProject.resetHistory()
+
+                should(await project.getSetting(KEY_BILLING_STATE)).equal(BILLING_STATES.UNKNOWN)
+
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/projects/${app.project.id}`,
+                    payload: {
+                        stack: stack.id
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                response.statusCode.should.equal(200)
+
+                await sleep(STOP_DELAY + 50)
+
+                should(await project.getSetting(KEY_BILLING_STATE)).equal(BILLING_STATES.BILLED)
+
+                await sleep(START_DELAY + 50)
+
+                should.equal(app.billing.removeProject.calledOnce, false) // skipped
+                should.equal(app.billing.addProject.calledOnce, true)
+            })
+        })
+    })
+})

--- a/test/unit/forge/ee/routes/billing/index_spec.js
+++ b/test/unit/forge/ee/routes/billing/index_spec.js
@@ -37,6 +37,8 @@ describe('Stripe Callbacks', function () {
         sandbox.stub(app.log, 'warn')
         sandbox.stub(app.log, 'error')
         sandbox.stub(app.billing)
+
+        await app.project.destroy() // clean up test project
     })
 
     afterEach(async function () {

--- a/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
+++ b/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
@@ -10,8 +10,7 @@ describe('Library Storage API', function () {
 
     beforeEach(async function () {
         app = await setup()
-        project = await app.db.models.Project.create({ name: 'project1', type: '', url: '' })
-        await app.team.addProject(project)
+        project = app.project
         tokens = await project.refreshAuthTokens()
         project2 = await app.db.models.Project.create({ name: 'project2', type: '', url: '' })
         await app.team.addProject(project2)

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -37,20 +37,45 @@ module.exports = async function (config = {}) {
     template.setOwner(userAlice)
     await template.save()
 
+    const projectTypeProperties = {
+        name: 'projectType1',
+        description: 'default project type',
+        active: true,
+        properties: { foo: 'bar' },
+        order: 1
+    }
+    const projectType = await forge.db.models.ProjectType.create(projectTypeProperties)
+
     const stackProperties = {
         name: 'stack1',
         active: true,
         properties: { nodered: '2.2.2' }
     }
     const stack = await forge.db.models.ProjectStack.create(stackProperties)
+    await stack.setProjectType(forge.projectType)
 
     const subscription = 'sub_1234567890'
     const customer = 'cus_1234567890'
     await forge.db.controllers.Subscription.createSubscription(team1, subscription, customer)
 
+    const project = await forge.db.models.Project.create({ name: 'project1', type: '', url: '' })
+    await team1.addProject(project)
+    await project.setProjectStack(stack)
+    await project.setProjectTemplate(template)
+    await project.setProjectType(projectType)
+    await project.reload({
+        include: [
+            { model: forge.db.models.Team },
+            { model: forge.db.models.ProjectStack },
+            { model: forge.db.models.ProjectType }
+        ]
+    })
+
     forge.user = userAlice
     forge.team = team1
     forge.stack = stack
+    forge.projectType = projectType
+    forge.project = project
 
     return forge
 }

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -41,7 +41,7 @@ module.exports = async function (config = {}) {
         name: 'projectType1',
         description: 'default project type',
         active: true,
-        properties: { foo: 'bar' },
+        properties: { foo: 'bar', billingPriceId: 'price_123', billingProductId: 'prod_123' },
         order: 1
     }
     const projectType = await forge.db.models.ProjectType.create(projectTypeProperties)


### PR DESCRIPTION
**Merge target is** [refactor-project-put-method](https://github.com/flowforge/flowforge/tree/refactor-project-put-method), do not merge until after https://github.com/flowforge/flowforge/pull/1634 is merged.

## Description

Updates the project update logic to skip adding and removing a project from billing when changing only the project stack.

Stacks are not connected to billing, thus the removal and addition was simply extra un-needed noise in Stripe and customers emails.

## Related Issue(s)

Closes https://github.com/flowforge/flowforge/issues/1598

Follow up to https://github.com/flowforge/flowforge/pull/1619

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass

