### PR TITLE
Change PostHog config: apihost to apiurl

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -112,7 +112,7 @@ For more information about this feature, see [here](/docs/admin/telemetry.md)
 Option        | Description
 --------------|------------
 `telemetry.enabled` | Enables the anonymous usage telemetry of the platform. Default: `true`
-`telemetry.frontend.posthog.apihost` | The API host for PostHog, either 'https://app.posthog.com' or 'https://eu.posthog.com'. Default: `https://app.posthog.com`
+`telemetry.frontend.posthog.apiurl` | The API URL for PostHog, either 'https://app.posthog.com' or 'https://eu.posthog.com'. Default: `https://app.posthog.com`
 `telemetry.frontend.posthog.apikey` | The API key provided to you from your own PostHog account. Default: `null`
 `telemetry.frontend.posthog.capture_pageview` | FlowForge is designed as to provide custom posthog `$pageview` events that provide more detail on navigation than the default, and suit a single page application better. As such, we recommend setting this to false in order to prevent duplicate `pageleave`/`pageview` events firing. Default: `true`
 

--- a/forge/routes/ui/index.js
+++ b/forge/routes/ui/index.js
@@ -42,7 +42,7 @@ module.exports = async function (app) {
             }
 
             if (telemetry.frontend.posthog?.apikey) {
-                const apihost = telemetry.frontend.posthog.apihost || 'https://app.posthog.com'
+                const apihost = telemetry.frontend.posthog.apiurl || 'https://app.posthog.com'
                 const apikey = telemetry.frontend.posthog.apikey
                 const options = {
                     api_host: apihost


### PR DESCRIPTION
## Description

Change `apihost` to `apiurl` given that the parameter requires the `https://` too.

## Related Issue(s)

https://github.com/flowforge/flowforge/pull/1649

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [-] Upgrade instructions
    - [x] Configuration details
    - [-] Concepts
 - [x] Changes `flowforge.yml`?
    - [x] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [x] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

