### PR TITLE
Team slug check

### DIFF
--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -76,8 +76,8 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const slug = request.body.slug.toLowerCase()
-        // Handle reserved names
-        if (slug === 'create') {
+        const reservedNames = ['create']
+        if (reservedNames.includes(slug)) {
             reply.code(409).send({ code: 'invalid_slug', error: 'Slug not available' })
             return
         }

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -76,11 +76,16 @@ module.exports = async function (app) {
         }
     }, async (request, reply) => {
         const slug = request.body.slug.toLowerCase()
+        // Handle reserved names
+        if (slug === 'create') {
+            reply.code(409).send({ code: 'invalid_slug', error: 'Slug not available' })
+            return
+        }
         const existingCount = await app.db.models.Team.count({ where: { slug } })
         if (existingCount === 0) {
             reply.send({ status: 'okay' })
         } else {
-            reply.code(409).send({ code: 'slug_unavailable', error: 'Slug unavailable' })
+            reply.code(409).send({ code: 'invalid_slug', error: 'Slug not available' })
         }
     })
 

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -63,6 +63,27 @@ module.exports = async function (app) {
         }
     })
 
+    app.post('/check-slug', {
+        preHandler: app.needsPermission('team:create'),
+        schema: {
+            body: {
+                type: 'object',
+                required: ['slug'],
+                properties: {
+                    slug: { type: 'string' }
+                }
+            }
+        }
+    }, async (request, reply) => {
+        const slug = request.body.slug.toLowerCase()
+        const existingCount = await app.db.models.Team.count({ where: { slug } })
+        if (existingCount === 0) {
+            reply.send({ status: 'okay' })
+        } else {
+            reply.code(409).send({ code: 'slug_unavailable', error: 'Slug unavailable' })
+        }
+    })
+
     async function getTeamDetails (request, reply, team) {
         const result = app.db.views.Team.team(team)
         if (app.license.active() && app.billing) {

--- a/frontend/src/api/teams.js
+++ b/frontend/src/api/teams.js
@@ -12,6 +12,12 @@ const getTeams = async (cursor, limit, query) => {
     })
 }
 
+const checkSlug = async (slug) => {
+    return client.post('/api/v1/teams/check-slug', { slug }).then(res => {
+        return res.data
+    })
+}
 export default {
-    getTeams
+    getTeams,
+    checkSlug
 }

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -263,5 +263,16 @@ describe('Team API', function () {
             })
             response.statusCode.should.equal(409)
         })
+        it('reports if slug is reserved', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/teams/check-slug',
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    slug: 'create'
+                }
+            })
+            response.statusCode.should.equal(409)
+        })
     })
 })

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -239,4 +239,29 @@ describe('Team API', function () {
     describe('Get team audit-log', async function () {
         // GET /api/v1/teams/:teamId/audit-log
     })
+
+    describe('Check slug availability', async function () {
+        it('reports if slug is available', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/teams/check-slug',
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    slug: 'new-slug'
+                }
+            })
+            response.statusCode.should.equal(200)
+        })
+        it('reports if slug is unavailable', async function () {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/teams/check-slug',
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    slug: 'ateam'
+                }
+            })
+            response.statusCode.should.equal(409)
+        })
+    })
 })


### PR DESCRIPTION
## Description

This adds an endpoint `POST /api/v1/teams/check-slug` that can be used to validate if a team slug is available for use or not.

Available returns status 200 `{status: 'okay'}`.
Unavailable returns status 409 `{ code: 'invalid_slug', error: 'Slug not available' }`

The Create Team and Update Team pages have been updated to use this endpoint and feedback to the user before they try using the slug.

## Related Issue(s)

#1609 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

