### PR TITLE
Add admin view of user details and teams

### DIFF
--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -161,4 +161,20 @@ module.exports = async function (app) {
             reply.code(400).send(resp)
         }
     })
+
+    /**
+     * Get the teams of the current logged in user
+     * @name /api/v1/user/teams
+     * @static
+     * @memberof forge.routes.api.user
+     */
+    app.get('/:userId/teams', async (request, reply) => {
+        const teams = await app.db.models.Team.forUser(request.user)
+        const result = await app.db.views.Team.userTeamList(teams)
+        reply.send({
+            meta: {}, // For future pagination
+            count: result.length,
+            teams: result
+        })
+    })
 }

--- a/frontend/src/api/users.js
+++ b/frontend/src/api/users.js
@@ -24,6 +24,21 @@ const updateUser = async (userId, options) => {
     })
 }
 
+const getUser = async (userId) => {
+    return client.get(`/api/v1/users/${userId}`).then(res => {
+        return res.data
+    })
+}
+const getUserTeams = async (userId, cursor, limit, query) => {
+    const url = paginateUrl(`/api/v1/users/${userId}/teams`, cursor, limit, query)
+    return client.get(url).then(res => {
+        res.data.teams = res.data.teams.map(r => {
+            r.link = { name: 'Team', params: { team_slug: r.slug } }
+            return r
+        })
+        return res.data
+    })
+}
 /**
  * Calls api routes in users.js
  * See [routes/api/users.js](../../../forge/routes/api/users.js)
@@ -32,5 +47,7 @@ export default {
     create,
     getUsers,
     deleteUser,
-    updateUser
+    updateUser,
+    getUser,
+    getUserTeams
 }

--- a/frontend/src/pages/admin/Users/General.vue
+++ b/frontend/src/pages/admin/Users/General.vue
@@ -12,6 +12,7 @@
             loading-message="Loading Users"
             @load-more="loadItems"
             no-data-message="No Users Found"
+            :rows-selectable="true" @row-selected="showUser"
         >
             <template v-slot:actions>
                 <ff-button to="./create">
@@ -22,7 +23,7 @@
                 </ff-button>
             </template>
             <template v-slot:context-menu="{row}">
-                <ff-list-item label="Edit User" @click="showEditUserDialog(row)"></ff-list-item>
+                <ff-list-item label="Edit User" @click.stop="showEditUserDialog(row)"></ff-list-item>
             </template>
         </ff-data-table>
         <AdminUserEditDialog @userUpdated="userUpdated" @userDeleted="userDeleted" ref="adminUserEditDialog"/>
@@ -117,6 +118,12 @@ export default {
                 this.users.push(v)
             })
             this.loading = false
+        },
+        showUser (user) {
+            this.$router.push({
+                name: 'Admin User Details',
+                params: { id: user.id }
+            })
         }
     },
     components: {

--- a/frontend/src/pages/admin/Users/UserDetails.vue
+++ b/frontend/src/pages/admin/Users/UserDetails.vue
@@ -5,24 +5,43 @@
                 <router-link class="ff-link font-bold" :to="{path: '/admin/users'}">Users</router-link>
                 <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
                 <ChevronRightIcon class="ff-icon" />
-                <span>{{ user.username }}</span>
+                <span>{{user.username}}</span>
             </div>
+        </div>
+        <div>
+            <ff-button @click="showEditUserDialog()" data-action="editUser">Edit</ff-button>
         </div>
     </div>
     <div>
+        <div class="flex items-center mb-4">
+            <div class="mr-3"><img :src="user.avatar" class="h-14 v-14 rounded-md"/></div>
+            <div class="flex flex-col">
+                <div class="text-xl font-bold">{{ user.name }}</div>
+                <div class="text-l text-gray-400">{{ user.username }}</div>
+            </div>
+            <div class="ml-3 space-x-1">
+                <span v-if="user.admin" class="forge-badge forge-status-running">admin</span>
+                <span v-if="user.suspended" class="forge-badge forge-status-error">suspended</span>
+            </div>
+        </div>
         <div class="mb-4">
-            <FormRow v-model="user.username" type="uneditable">
-                <template #default>Username</template>
-            </FormRow>
-            <FormRow v-model="user.name" type="uneditable">
-                <template #default>Name</template>
-            </FormRow>
-            <FormRow v-model="user.email" type="uneditable">
-                <template #default>Email</template>
-            </FormRow>
-            <FormRow v-model="user.createdAt" type="uneditable">
-                <template #default>Created</template>
-            </FormRow>
+            <table class="table-fixed w-full mb-2">
+                <tr class="border-b">
+                    <td class="w-1/4 font-medium py-2">Email</td>
+                    <td class="flex">
+                        {{user.email}}
+                        <div class="ml-3 space-x-1">
+                            <span v-if="user.sso_enabled" class="forge-badge forge-status-safe">sso-enabled</span>
+                            <span v-else-if="user.email_verified" class="forge-badge forge-status-running">verified</span>
+                            <span v-else class="forge-badge forge-status-error">unverified</span>
+                        </div>
+                    </td>
+                </tr>
+                <tr class="border-b">
+                    <td class="w-1/4 font-medium py-2">Registered At</td>
+                    <td class="py-1">{{user.createdAt}}</td>
+                </tr>
+            </table>
         </div>
         <FormHeading>Teams</FormHeading>
         <ff-data-table
@@ -35,6 +54,7 @@
             data-el="teams-table"
         />
     </div>
+    <AdminUserEditDialog @userUpdated="userUpdated" @userDeleted="userDeleted" ref="adminUserEditDialog"/>
 </template>
 
 <script>
@@ -42,8 +62,9 @@
 import usersApi from '@/api/users'
 import { ChevronRightIcon } from '@heroicons/vue/solid'
 
-import FormRow from '@/components/FormRow'
 import FormHeading from '@/components/FormHeading'
+
+import AdminUserEditDialog from './dialogs/AdminUserEditDialog'
 
 import { mapState } from 'vuex'
 import TeamCell from '@/components/tables/cells/TeamCell'
@@ -98,10 +119,19 @@ export default {
                     hash: this.$router.currentRoute.value.hash
                 })
             }
+        },
+        showEditUserDialog (user) {
+            this.$refs.adminUserEditDialog.show(this.user)
+        },
+        userUpdated (user) {
+            this.loadUser()
+        },
+        userDeleted (userId) {
+            this.$router.push({ path: '/admin/users' })
         }
     },
     components: {
-        FormRow,
+        AdminUserEditDialog,
         FormHeading,
         ChevronRightIcon
     }

--- a/frontend/src/pages/admin/Users/UserDetails.vue
+++ b/frontend/src/pages/admin/Users/UserDetails.vue
@@ -1,0 +1,106 @@
+<template>
+    <div class="flex flex-col sm:flex-row mb-8">
+        <div class="flex-grow">
+            <div class="text-gray-800 text-xl">
+                <router-link class="ff-link font-bold" :to="{path: '/admin/users'}">Users</router-link>
+                <!-- <nav-item :icon="icons.breadcrumbSeparator" label="sss"></nav-item> -->
+                <ChevronRightIcon class="ff-icon" />
+                <span>{{ user.username }}</span>
+            </div>
+        </div>
+    </div>
+    <div>
+        <div class="mb-4">
+            <FormRow v-model="user.username" type="uneditable">
+                <template #default>Username</template>
+            </FormRow>
+            <FormRow v-model="user.name" type="uneditable">
+                <template #default>Name</template>
+            </FormRow>
+            <FormRow v-model="user.email" type="uneditable">
+                <template #default>Email</template>
+            </FormRow>
+            <FormRow v-model="user.createdAt" type="uneditable">
+                <template #default>Created</template>
+            </FormRow>
+        </div>
+        <FormHeading>Teams</FormHeading>
+        <ff-data-table
+            :columns="columns"
+            :rows="teams"
+            :rows-selectable="true"
+            :loading="loadingTeams"
+            loading-message="Loading Teams"
+            no-data-message="No Teams Found"
+            data-el="teams-table"
+        />
+    </div>
+</template>
+
+<script>
+
+import usersApi from '@/api/users'
+import { ChevronRightIcon } from '@heroicons/vue/solid'
+
+import FormRow from '@/components/FormRow'
+import FormHeading from '@/components/FormHeading'
+
+import { mapState } from 'vuex'
+import TeamCell from '@/components/tables/cells/TeamCell'
+import TeamTypeCell from '@/components/tables/cells/TeamTypeCell'
+import { markRaw } from 'vue'
+
+export default {
+    name: 'AdminUserDetails',
+    data () {
+        return {
+            user: null,
+            teams: null,
+            loadingTeams: false,
+            loading: false,
+            columns: [
+                { label: 'Name', class: ['w-full'], component: { is: markRaw(TeamCell) }, sortable: true },
+                { label: 'Type', key: 'type', component: { is: markRaw(TeamTypeCell) }, sortable: true },
+                { label: 'Members', class: ['w-54', 'text-center'], key: 'memberCount', sortable: true },
+                { label: 'Projects', class: ['w-54', 'text-center'], key: 'projectCount', sortable: true }
+            ]
+        }
+    },
+    async created () {
+        return this.loadUser()
+    },
+    computed: {
+        ...mapState('account', ['features'])
+    },
+    watch: {
+    },
+    methods: {
+        async loadUser () {
+            this.loading = true
+            this.loadingTeams = true
+            try {
+                this.user = await usersApi.getUser(this.$route.params.id)
+                this.loading = false
+                usersApi.getUserTeams(this.$route.params.id).then((result) => {
+                    this.teams = result.teams
+                }).finally(() => {
+                    this.loadingTeams = false
+                })
+            } catch (err) {
+                this.$router.push({
+                    name: 'PageNotFound',
+                    params: { pathMatch: this.$router.currentRoute.value.path.substring(1).split('/') },
+                    // preserve existing query and hash if any
+                    query: this.$router.currentRoute.value.query,
+                    hash: this.$router.currentRoute.value.hash
+                })
+            }
+        }
+    },
+    components: {
+        FormRow,
+        FormHeading,
+        ChevronRightIcon
+    }
+}
+</script>

--- a/frontend/src/pages/admin/Users/UserDetails.vue
+++ b/frontend/src/pages/admin/Users/UserDetails.vue
@@ -48,6 +48,7 @@ import FormHeading from '@/components/FormHeading'
 import { mapState } from 'vuex'
 import TeamCell from '@/components/tables/cells/TeamCell'
 import TeamTypeCell from '@/components/tables/cells/TeamTypeCell'
+import UserRoleCell from '@/components/tables/cells/UserRoleCell'
 import { markRaw } from 'vue'
 
 export default {
@@ -60,6 +61,7 @@ export default {
             loading: false,
             columns: [
                 { label: 'Name', class: ['w-full'], component: { is: markRaw(TeamCell) }, sortable: true },
+                { label: 'Role', component: { is: markRaw(UserRoleCell) }, sortable: true },
                 { label: 'Type', key: 'type', component: { is: markRaw(TeamTypeCell) }, sortable: true },
                 { label: 'Members', class: ['w-54', 'text-center'], key: 'memberCount', sortable: true },
                 { label: 'Projects', class: ['w-54', 'text-center'], key: 'projectCount', sortable: true }
@@ -83,6 +85,7 @@ export default {
                 this.loading = false
                 usersApi.getUserTeams(this.$route.params.id).then((result) => {
                     this.teams = result.teams
+                    console.log(this.teams)
                 }).finally(() => {
                     this.loadingTeams = false
                 })

--- a/frontend/src/pages/admin/routes.js
+++ b/frontend/src/pages/admin/routes.js
@@ -10,6 +10,7 @@ import AdminSettingsSSOEdit from '@/pages/admin/Settings/SSO/createEditProvider.
 import AdminUsers from '@/pages/admin/Users/index.vue'
 import AdminUsersGeneral from '@/pages/admin/Users/General.vue'
 import AdminUsersInvitations from '@/pages/admin/Users/Invitations.vue'
+import AdminUserDetails from '@/pages/admin/Users/UserDetails.vue'
 import AdminTeams from '@/pages/admin/Teams.vue'
 import AdminProjectTypes from '@/pages/admin/ProjectTypes/index.vue'
 import AdminStacks from '@/pages/admin/Stacks/index.vue'
@@ -85,6 +86,14 @@ export default [
                     { path: 'general', component: AdminUsersGeneral, name: 'AdminUsersGeneral' },
                     { path: 'invitations', component: AdminUsersInvitations }
                 ]
+            },
+            {
+                name: 'Admin User Details',
+                path: 'users/:id',
+                component: AdminUserDetails,
+                meta: {
+                    title: 'Admin - User'
+                }
             },
             {
                 path: 'teams',


### PR DESCRIPTION
## Description

Quick iteration to solve #1573 

An admin can click on an entry in the Users table (Admin Settings -> Users) to get to a new User Details view. This lists the basic info about the user and a table of the teams they are in. This is the missing link we have needed to address the related issue.

<img width="898" alt="image" src="https://user-images.githubusercontent.com/51083/217628741-ed56d648-4d9c-4bc3-94ec-830dc2642c0c.png">

- Edit button reuses the same edit dialog we have.
- Using badges to show certainly boolean states - admin/sso/verified/suspended. Reuses the classes for project state... for a quick iteration, that's fine, but may want to be something else.

## Related Issue(s)

#1573 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

