### PR TITLE
Validate internal links that include #

### DIFF
--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -64,7 +64,7 @@ This release introduces an MQTT Broker into the FlowForge platform used to commu
 between devices and the core platform.
 
 For LocalFS users, they will need to manually setup the broker and ensure it is
-properly configured. The documentation for this is available [here](../local/README.md#mosquitto)
+properly configured. The documentation for this is available [here](../install/local/README.md#mosquitto)
 
 #### LocalFS Users
 


### PR DESCRIPTION
## Description

The link checking script was ignoring links to other pages with a `#` in them. The PR fixes that.

It does not validate the anchor is valid within the page, but at least checks the right file exists.

It also handles the case where a src link of `foo/bar#anchor` can be resolved by the existence of any one of `foo/bar/README.md`, `foo/bar/index.md` or `foo/bar.md`.

This also fixes one broken link these updates helped to reveal.

