### PR TITLE
Team Library - File Preview

### DIFF
--- a/docs/user/shared-library.md
+++ b/docs/user/shared-library.md
@@ -1,10 +1,10 @@
-# Shared Team Library
+# Shared Team Library
 
-Node-RED allows you to import and export flows to a local library. This is helpful
+Node-RED allows you to import and export **flows** and **functions** to a local library. This is helpful
 for saving pieces of flow that you want to reuse.
 
 With FlowForge Premium, each project also has access to a Team Library that makes
-it very easy to share flows between the projects without having to manually copy
+it very easy to share flows and functions between the projects without having to manually copy
 them around.
 
 For example, you may have a standard set of flows that you want each project to
@@ -34,3 +34,8 @@ To import flows within the Node-RED editor:
 
 ![](./images/shared-lib-import.png)
 
+### Viewing Team Library
+
+It is possible to explore your Team Library within FlowForge by clicking "Library" in your Team options.
+
+You can inspect the contents of any `.json` flow file, or `.js` function file here too.

--- a/frontend/src/components/CodePreviewer.vue
+++ b/frontend/src/components/CodePreviewer.vue
@@ -17,7 +17,6 @@ export default {
     },
     computed: {
         strippedSnippet: function () {
-            console.log(this.snippet)
             return this.snippet
         }
     }

--- a/frontend/src/components/CodePreviewer.vue
+++ b/frontend/src/components/CodePreviewer.vue
@@ -1,0 +1,29 @@
+<template>
+    <pre class="ff-code-previewer">
+        <code>
+            {{ strippedSnippet }}
+        </code>
+    </pre>
+</template>
+
+<script>
+export default {
+    name: 'ff-code-previewer',
+    props: {
+        snippet: {
+            required: true,
+            type: [Object, Array, String]
+        }
+    },
+    computed: {
+        strippedSnippet: function () {
+            console.log(this.snippet)
+            return this.snippet
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@/stylesheets/components/code-previewer.scss";
+</style>

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -5,10 +5,13 @@
             <p>The contents of your Team Library are available across any of your projects in FlowForge.</p>
             <p>You can read more about <a href="https://nodered.org/docs/user-guide/editor/workspace/import-export" target="_blank">Import & Exporting Flows</a> in the Node-RED documentation</p>
         </template>
+        <template v-slot:tools>
+            <ff-button v-if="contents" @click="copyToClipboard()">Copy to Clipboard</ff-button>
+        </template>
     </SectionTopMenu>
     <div class="ff-breadcrumbs">
         <span v-for="(crumb, $index) in breadcrumbs" :key="$index" class="flex">
-            <a @click="goToFolder(crumb, $index)">{{ crumb.name }}</a>
+            <label @click="goToFolder(crumb, $index)">{{ crumb.name }}</label>
             <ChevronRightIcon class="ff-icon"></ChevronRightIcon>
         </span>
     </div>
@@ -21,11 +24,12 @@
                 </ff-data-table-row>
             </template>
         </ff-data-table>
-        <ff-code-previewer v-else :snippet="contents"></ff-code-previewer>
+        <ff-code-previewer v-else :snippet="contents" ref="code-preview"></ff-code-previewer>
     </div>
 </template>
 
 <script>
+import Alert from '@/services/alerts'
 import teamApi from '@/api/team'
 
 import { ChevronRightIcon } from '@heroicons/vue/solid'
@@ -113,6 +117,10 @@ export default {
                 // folders first, then names
                 return folderSort || nameSort
             })
+        },
+        copyToClipboard () {
+            navigator.clipboard.writeText(JSON.stringify(this.contents))
+            Alert.emit('Copied to Clipboard.', 'confirmation')
         }
     },
     components: {

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -102,7 +102,7 @@ export default {
                 return {
                     type,
                     name,
-                    path: parent.path ? parent.path + '/' + name + '/' : name + '/'
+                    path: parent.path ? (parent.path + name + '/') : name + '/'
                 }
             }).sort((a, b) => {
                 const typeOrder = ['folder', 'flows', 'functions']

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -103,14 +103,14 @@ label {
     align-items: center;
     margin-top: 12px;
     margin-bottom: 12px;
-    a {
+    label {
         color: $ff-blue-600;
+        cursor: pointer;
         &:hover {
-            cursor: pointer;
             text-decoration: underline;
         }
     }
-    span:last-child a {
+    span:last-child label {
         pointer-events: none;
         color: black;
     }

--- a/frontend/src/stylesheets/components/code-previewer.scss
+++ b/frontend/src/stylesheets/components/code-previewer.scss
@@ -1,0 +1,11 @@
+@import '~@flowforge/forge-ui-components/dist/scss/forge-colors.scss';
+
+.ff-code-previewer {
+    background-color: white;
+    border: 1px solid $ff-grey-300;
+    border-radius: 6px;
+    padding: 12px;
+    code {
+        border: none;
+    }
+}


### PR DESCRIPTION
## Description

Implements Option 1 detailed in #1657 so that users can view the contents of function & flow files. Also adds the option to copy contents to clipboard as a basic extraction - chose this over Download, as felt it was likely to be more useful?

https://user-images.githubusercontent.com/99246719/217235335-fa3076c0-6eac-4d0a-9cfc-e2a2cbe9444f.mov

## Related Issue(s)

Closes #1657

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [x] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

