### PR TITLE
Fix logic to disable housekeeper

### DIFF
--- a/forge/housekeeper/index.js
+++ b/forge/housekeeper/index.js
@@ -34,7 +34,7 @@ module.exports = fp(async function (app, _opts, next) {
         // Allow the housekeeper to be disabled - this allows the tests
         // to run without fear the housekeeper may fire off a task at the same
         // time.
-        if (!app.config.housekeeper) {
+        if (app.config.housekeeper === false) {
             return
         }
 


### PR DESCRIPTION
## Description

Team Trials added the ability to disable the housekeeper thread so that the tests can run without fear of the housekeeper running stuff unexpectedly. The logic was a little aggressive and needs this fix to ensure it only gets disabled when intended.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

