### PR TITLE
doc: Add Azure to SSO providers

### DIFF
--- a/docs/admin/sso/README.md
+++ b/docs/admin/sso/README.md
@@ -89,6 +89,7 @@ by ticking the `active` checkbox and clicking `Update configuration`.
 The following is a non-exhaustive list of the providers that are known to work
 with FlowForge SAML SSO.
 
+ - Azure AD
  - [Google Workspace](#google-workspace)
  - [OneLogin](#onelogin)
 


### PR DESCRIPTION
## Description

While this is not an exhaustive description around adding SSO with Azure AD as provider, it does list the fact it's supported.
