### PR TITLE
Team Trial UX improvements

### DIFF
--- a/forge/ee/lib/billing/emailTemplates/TrialTeamCreated.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamCreated.js
@@ -7,46 +7,52 @@
 module.exports = {
     subject: 'Welcome to your free FlowForge trial',
     text:
-`Hello {{{username}}}
+`Hello {{{username}}},
 
-Welcome to your FlowForge trial. We've created a team called '{{{teamName}}}' just
-for you.
+Welcome to FlowForge. We hope you enjoy your free trial for your first
+{{{trialDuration}}} days with us.
 
-Your trial will last for {{{trialDuration}}} days and you'll be able to create
-a {{{trialProjectTypeName}}} project for free.
+To get started using FlowForge, log in to your new team, '{{{teamName}}}' 
+and create your first Node-RED Project.
 
-Once the trial ends, you can setup billing details on your team to keep the project
-running. But do not worry - we'll let you know when the trial is nearing its end so you
-can choose what to do nearer the time.
+You can also invite other users to join your team to collaborate on your projects.
 
-If you want to do more with your team during the trial, you will need to setup
-billing details. You will still get your one {{{trialProjectTypeName}}} project
-for free during the trial and we will only add it to your billing subscription
-once the trial ends. Again, we'll email to let you know what is happening so
-you can cancel at any time.
+Your {{{trialDuration}}} day trial allows you to create a {{{trialProjectTypeName}}} project
+for free. Once the trial ends, you will need to add your credit card details to
+keep the project running. But don't worry - we'll remind you when the trial is
+nearing its end.
+
+If you want to do more with your team during the trial, you can add your credit
+card details at any time and create more projects.  Again, we'll email to remind
+you what is happening with the trial.
+
+We hope you enjoy the FlowForge experience.
 
 Cheers!
 
 Your friendly FlowForge Team
 `,
     html:
-`<p>Hello {{{username}}}</p>
+`<p>Hello {{{username}}},</p>
 
-<p>Welcome to your FlowForge trial. We've created a team called '{{{teamName}}}' just
-for you.</p>
+<p>Welcome to FlowForge. We hope you enjoy your free trial for your first
+{{{trialDuration}}} days with us.</p>
 
-<p>Your trial will last for {{{trialDuration}}} days and you'll be able to create
-a {{{trialProjectTypeName}}} project for free.</p>
+<p>To get started using FlowForge, log in to your new team, '{{{teamName}}}' 
+and create your first Node-RED Project.</p>
 
-<p>Once the trial ends, you can setup billing details on your team to keep the project
-running. But do not worry - we'll let you know when the trial is nearing its end so you
-can choose what to do nearer the time.</p>
+<p>You can also invite other users to join your team to collaborate on your projects.</p>
 
-<p>If you want to do more with your team during the trial, you will need to setup
-billing details. You will still get your one {{{trialProjectTypeName}}} project
-for free during the trial and we will only add it to your billing subscription
-once the trial ends. Again, we'll email to let you know what is happening so
-you can cancel at any time.</p>
+<p>Your {{{trialDuration}}} day trial allows you to create a {{{trialProjectTypeName}}} project
+for free. Once the trial ends, you will need to add your credit card details to
+keep the project running. But don't worry - we'll remind you when the trial is
+nearing its end.</p>
+
+<p>If you want to do more with your team during the trial, you can add your credit
+card details at any time and create more projects.  Again, we'll email to remind
+you what is happening with the trial.</p>
+
+<p>We hope you enjoy the FlowForge experience.</p>
 
 <p>Cheers!</p>
 

--- a/forge/ee/lib/billing/emailTemplates/TrialTeamEnded.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamEnded.js
@@ -8,7 +8,7 @@
 module.exports = {
     subject: 'Your FlowForge trial has ended',
     text:
-`Hello {{{username}}}
+`Hello {{{username}}},
 
 Your FlowForge trial has now ended on '{{teamName}}'.
 {{#if trialProjectName}}
@@ -27,7 +27,7 @@ Cheers!
 Your friendly FlowForge Team
 `,
     html:
-`<p>Hello {{{username}}}</p>
+`<p>Hello {{{username}}},</p>
 
 <p>Your FlowForge trial has now ended on '{{teamName}}'.</p>
 {{#if trialProjectName}}

--- a/forge/ee/lib/billing/emailTemplates/TrialTeamReminder.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamReminder.js
@@ -7,7 +7,7 @@
 module.exports = {
     subject: 'Your FlowForge trial ends soon',
     text:
-`Hello {{{username}}}
+`Hello {{{username}}},
 
 Just to let you know, your free trial on team '{{{teamName}}}' ends in {{{endingInDuration}}}.
 
@@ -31,7 +31,7 @@ Cheers!
 Your friendly FlowForge Team
 `,
     html:
-`<p>Hello {{{username}}}</p>
+`<p>Hello {{{username}}},</p>
 
 <p>Just to let you know, your free trial on team '{{{teamName}}}' ends in {{{endingInDuration}}}.</p>
 

--- a/forge/ee/lib/billing/emailTemplates/TrialTeamSuspended.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamSuspended.js
@@ -7,7 +7,7 @@
 module.exports = {
     subject: 'Your FlowForge trial has ended',
     text:
-`Hello {{{username}}}
+`Hello {{{username}}},
 
 Your FlowForge trial has now ended. We hope you've enjoyed your time with us.
 
@@ -23,7 +23,7 @@ Cheers!
 Your friendly FlowForge Team
 `,
     html:
-`<p>Hello {{{username}}}</p>
+`<p>Hello {{{username}}},</p>
 
 <p>Your FlowForge trial has now ended. We hope you've enjoyed your time with us.</p>
 

--- a/frontend/src/components/banners/TeamTrial.vue
+++ b/frontend/src/components/banners/TeamTrial.vue
@@ -1,8 +1,10 @@
 <template>
     <div
         v-if="team.billing?.trial"
-        class="ff-banner ff-banner-warning"
+        class="ff-banner"
         :class="{
+            'ff-banner-warning': !team.billing?.active,
+            'ff-banner-info': team.billing?.active,
             'cursor-pointer': linkToBilling
         }"
         data-el="banner-team-trial"

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -25,6 +25,7 @@
             <label class="ff-error-inline">{{ errors.general }}</label>
             <div class="ff-actions">
                 <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
+                <ff-button kind="tertiary" to="/" data-action="sign-up">Already registered? Log in here</ff-button>
             </div>
         </div>
         <div v-else-if="emailSent">

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -11,6 +11,11 @@
         </SideNavigationTeamOptions>
     </Teleport>
     <main>
+        <Teleport v-if="mounted" to="#platform-banner">
+            <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-project-as-admin">You are viewing this project as an Administrator</div>
+            <SubscriptionExpiredBanner :team="team" />
+            <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
+        </Teleport>
         <SectionTopMenu>
             <template #hero>
                 <div class="flex-grow space-x-6 items-center inline-flex">
@@ -41,6 +46,8 @@ import { Roles } from '@core/lib/roles'
 import NavItem from '@/components/NavItem'
 import SectionTopMenu from '@/components/SectionTopMenu'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions'
+import SubscriptionExpiredBanner from '@/components/banners/SubscriptionExpired.vue'
+import TeamTrialBanner from '@/components/banners/TeamTrial.vue'
 
 // icons
 import { ChipIcon, CogIcon } from '@heroicons/vue/solid'
@@ -50,7 +57,9 @@ export default {
     components: {
         NavItem,
         SectionTopMenu,
-        SideNavigationTeamOptions
+        SideNavigationTeamOptions,
+        SubscriptionExpiredBanner,
+        TeamTrialBanner
     },
     data: function () {
         const navigation = [

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -32,14 +32,20 @@
             </div>
         </div>
         <div v-else class="ff-no-data ff-no-data-large">
-            Billing has not yet been configured for this team. Before proceeding further, you must continue to Stripe and complete this.
+            <div v-if="trialMode">
+                You are currently in a free trial. During the trial you can only create one project in the team. To unlock other features you will need
+                to configure your billing details.
+            </div>
+            <div v-else>
+                Billing has not yet been configured for this team. Before proceeding further, you must continue to Stripe and complete this.
+            </div>
             <div v-if="coupon">
                 <div class="my-3 text-sm">Will apply coupon code <strong>{{ coupon }}</strong> at checkout</div>
             </div>
             <div v-else-if="errors.coupon">
                 <div class="my-3 text-red-400">{{ errors.coupon }}</div>
             </div>
-            <div class="mt-3">
+            <div class="mt-6">
                 <ff-button data-action="setup-payment-details" class="mx-auto mt-3" @click="setupBilling()">
                     <template #icon-right><ExternalLinkIcon /></template>
                     Setup Payment Details

--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -173,7 +173,6 @@ export default {
                     total_price: 0
                 })
             }
-            console.log(this.team.billing)
         }
         this.loading = false
     },


### PR DESCRIPTION
## Description

UX improvements based on initial feedback of Team Trial feature #1611 

 - Add log-in link on sign up page

<img width="221" alt="image" src="https://user-images.githubusercontent.com/51083/217302841-50dff0bd-03da-468a-9912-92416e73b196.png">

- Updated wording of Trial Team Created email:
```
Hello {{{username}}},

Welcome to FlowForge. We hope you enjoy your free trial for your first
{{{trialDuration}}} days with us.

To get started using FlowForge, log in to your new team, '{{{teamName}}}' 
and create your first Node-RED Project.

You can also invite other users to join your team to collaborate on your projects.

Your {{{trialDuration}}} day trial allows you to create a {{{trialProjectTypeName}}} project
for free. Once the trial ends, you will need to add your credit card details to
keep the project running. But don't worry - we'll remind you when the trial is
nearing its end.

If you want to do more with your team during the trial, you can add your credit
card details at any time and create more projects.  Again, we'll email to remind
you what is happening with the trial.

We hope you enjoy the FlowForge experience.

Cheers!

Your friendly FlowForge Team
```

- Add trial banner to Device pages

- Change trial banner style to 'info' once billing has been setup.
   - this uses the existing 'banner-info' class. Are we happy with this shade of blue?

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/51083/217309891-df73cde1-5d6a-4c61-a720-fa64a9074b7a.png">

 - When in trial mode, but with billing setup, the billing details page now lists the trial end date, the trial project and a footnote about the trial project being added to the subscription at the end of the trial

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/51083/217315656-b7aae5c2-8d92-406e-897d-5defa7e2b029.png">


- When in trial mode, but **without** billing setup, the billing details page now explains the situation

> You are currently in a free trial. During the trial you can only create one project in the team. To unlock other features you will need to configure your billing details.

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/51083/217318766-b11cfef2-83fb-4ece-8d2d-4b6d5848dc24.png">



## Related Issue(s)

#1578 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

