### PR TITLE
Add "Last Seen" device badge

### DIFF
--- a/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
@@ -10,7 +10,7 @@ import { ExclamationCircleIcon } from '@heroicons/vue/outline'
 
 export default {
     name: 'ProjectStatusBadge',
-    props: ['lastSeenAt'],
+    props: ['lastSeenAt', 'lastSeenSince'],
     computed: {
         since: function () {
             if (this.lastSeenAt) {
@@ -25,25 +25,22 @@ export default {
             }
         },
         status: function () {
+            // re-uses the status from last known status in order to get respective colour styling
             if (this.since < 0) {
-                return 'never'
-            } else if (this.since < 1) {
+                return 'never' // green
+            } else if (this.since < 1.5) {
                 return 'running'
+            } else if (this.since < 3) {
+                return 'safe' // yellow
             } else {
-                return 'error'
+                return 'error' // red
             }
         },
         label: function () {
             if (this.since < 0) {
                 return 'never'
-            } else if (this.since < 1) {
-                return 'less than a minute ago'
-            } else if (this.since < 2) {
-                return `${Math.floor(this.since)} minute ago`
-            } else if (this.since < 60) {
-                return `${Math.floor(this.since)} minutes ago`
             } else {
-                return 'over an hour ago'
+                return this.lastSeenSince
             }
         }
     },

--- a/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import { ExclamationIcon, ExclamationCircleIcon, PlayIcon, StopIcon, DotsCircleHorizontalIcon, SupportIcon, CloudDownloadIcon, CloudUploadIcon } from '@heroicons/vue/outline'
+import { ExclamationCircleIcon } from '@heroicons/vue/outline'
 
 export default {
     name: 'ProjectStatusBadge',

--- a/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
@@ -1,0 +1,54 @@
+<template>
+    <div class="forge-badge" :class="'forge-status-' + status">
+        <ExclamationCircleIcon v-if="status === 'error'" class="w-4 h-4" />
+        <span class="ml-1">{{ label }}</span>
+    </div>
+</template>
+
+<script>
+import { ExclamationIcon, ExclamationCircleIcon, PlayIcon, StopIcon, DotsCircleHorizontalIcon, SupportIcon, CloudDownloadIcon, CloudUploadIcon } from '@heroicons/vue/outline'
+
+export default {
+    name: 'ProjectStatusBadge',
+    props: ['lastSeenAt'],
+    computed: {
+        since: function () {
+            if (this.lastSeenAt) {
+                const now = new Date()
+                const lastSeen = new Date(this.lastSeenAt)
+
+                const mins = ((now.getTime() - lastSeen.getTime()) / 1000) / 60
+
+                return mins
+            } else {
+                return -1
+            }
+        },
+        status: function () {
+            if (this.since < 0) {
+                return 'never'
+            } else if (this.since < 1) {
+                return 'running'
+            } else {
+                return 'error'
+            }
+        },
+        label: function () {
+            if (this.since < 0) {
+                return 'never'
+            } else if (this.since < 1) {
+                return 'less than a minute ago'
+            } else if (this.since < 2) {
+                return `${Math.floor(this.since)} minute ago`
+            } else if (this.since < 60) {
+                return `${Math.floor(this.since)} minutes ago`
+            } else {
+                return 'over an hour ago'
+            }
+        }
+    },
+    components: {
+        ExclamationCircleIcon
+    }
+}
+</script>

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -89,11 +89,6 @@ const ProjectLink = {
     props: ['project']
 }
 
-const LastSeen = {
-    template: '<span><span v-if="lastSeenSince">{{lastSeenSince}}</span><span v-else class="italic text-gray-500">never</span></span>',
-    props: ['lastSeenSince']
-}
-
 export default {
     name: 'TeamDevices',
     mixins: [permissionsMixin],

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -59,6 +59,7 @@ import deviceApi from '@/api/devices'
 
 import SectionTopMenu from '@/components/SectionTopMenu'
 import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
+import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
 
 import { ChipIcon, PlusSmIcon } from '@heroicons/vue/outline'
 
@@ -216,8 +217,8 @@ export default {
         columns: function () {
             return [
                 { label: 'Device', class: ['w-64'], key: 'name', sortable: true, component: { is: markRaw(DeviceLink) } },
-                { label: 'Status', class: ['w-20'], key: 'status', sortable: true, component: { is: markRaw(ProjectStatusBadge) } },
-                { label: 'Last Seen', class: ['w-64'], key: 'last seen', sortable: true, component: { is: markRaw(LastSeen) } },
+                { label: 'Last Seen', class: ['w-32'], key: 'lastSeenAt', sortable: true, component: { is: markRaw(DeviceLastSeenBadge) } },
+                { label: 'Last Known Status', class: ['w-32'], key: 'status', sortable: true, component: { is: markRaw(ProjectStatusBadge) } },
                 { label: 'Project', class: ['w-64'], key: 'project', sortable: true, component: { is: markRaw(ProjectLink) } }
             ]
         }

--- a/frontend/src/utils/daysSince.js
+++ b/frontend/src/utils/daysSince.js
@@ -4,9 +4,6 @@ export default function (dateString) {
     if (!dateString) {
         return ''
     }
-    if (!dateString) {
-        return ''
-    }
 
     return elapsedTime(Date.now(), dateString) + ' ago'
 }

--- a/frontend/src/utils/elapsedTime.js
+++ b/frontend/src/utils/elapsedTime.js
@@ -11,7 +11,12 @@ const periodSeconds = {
 }
 
 function dateDiff (to, from) {
+    if (typeof from === 'string') {
+        from = (new Date(from)).getTime()
+    }
+
     let delta = Math.abs(to - from) / 1000
+
     const res = {}
 
     for (const key in periodSeconds) {


### PR DESCRIPTION
## Description

- Adds a new device status badge that shows a clearer picture of device status & connectivity.
- Change column header to "Last Known Status"

<img width="1728" alt="Screenshot 2023-02-07 at 22 34 52" src="https://user-images.githubusercontent.com/99246719/217382185-9c30f06f-0584-457b-8592-0b682f3c3b9c.png">

**Categorisation:**

As implemented currently, shows as green if last seen within the last minute, otherwise red. Will likely want to add more text-based labels to cover more time periods beyond 1 hr ago.

| ~Last Seen~ | ~Colour~ |
| - | - |
| never | colourless |
| < 1 min | green |
| > 1 min | red |

updated table to: https://github.com/flowforge/flowforge/pull/1679#issuecomment-1423218275

## Related Issue(s)

Closes #1599

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass