### PR TITLE
Ensure device billing counts are updated during trial mode

### DIFF
--- a/forge/ee/db/controllers/Subscription.js
+++ b/forge/ee/db/controllers/Subscription.js
@@ -8,6 +8,11 @@ module.exports = {
             existingSub.subscription = subscription
             existingSub.status = app.db.models.Subscription.STATUS.ACTIVE
             await existingSub.save()
+
+            // This *could* be a trial team that has devices in it. In which case,
+            // we need to reconcile the subscription device count in case device billing
+            // is enabled.
+            await app.billing.updateTeamDeviceCount(team)
             return existingSub
         } else {
             // Create the subscription

--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -23,6 +23,9 @@ module.exports.init = function (app) {
                 await sendTrialEmail(subscription.Team, 'TrialTeamEnded', {
                     trialProjectName
                 })
+                // Ensure device count is updated (if device billing enabled)
+                await subscription.Team.reload({ include: [app.db.models.TeamType] })
+                await app.billing.updateTeamDeviceCount(subscription.Team)
             } else {
                 // Stripe not configured - suspend the lot
                 await suspendAllProjects(subscription.Team)


### PR DESCRIPTION
## Description

This ensures that when a Trial Team setups up billing, or the trial ends, any devices created during the trial are properly added to their team subscription on stripe (if device billing is enabled).

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/51083/217584817-3ba0e5ad-9586-44e0-bb64-06cd8f454ee7.png">


## Related Issue(s)

#1578 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

