### PR TITLE
Disable free team credit if team trials is enabled

### DIFF
--- a/forge/ee/db/controllers/Subscription.js
+++ b/forge/ee/db/controllers/Subscription.js
@@ -39,7 +39,11 @@ module.exports = {
         return null
     },
 
-    freeTrialsEnabled: function (app) {
+    freeTrialCreditEnabled: function (app) {
+        // Team trial mode overrides team credit
+        if (app.settings.get('user:team:trial-mode')) {
+            return false
+        }
         const creditAmount = app.config.billing?.stripe?.new_customer_free_credit
         if (!creditAmount) {
             return false
@@ -55,7 +59,7 @@ module.exports = {
 
     // Users are only eligible for the free trial if they're not part of any team
     // newTeamAlreadyCreated is required during subscription creation as the team is created before the subscription
-    userEligibleForFreeTrial: async function (app, user, newTeamAlreadyCreated = false) {
+    userEligibleForFreeTrialCredit: async function (app, user, newTeamAlreadyCreated = false) {
         const teamCount = await user.teamCount()
 
         return teamCount <= (newTeamAlreadyCreated ? 1 : 0)

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -123,9 +123,9 @@ module.exports.init = async function (app) {
             }
 
             // Set the flag to enable a free trial
-            if (app.db.controllers.Subscription.freeTrialsEnabled() && user) {
+            if (app.db.controllers.Subscription.freeTrialCreditEnabled() && user) {
                 const newTeamAlreadyCreated = true // team is created before this step
-                const eligibleForTrial = await app.db.controllers.Subscription.userEligibleForFreeTrial(user, newTeamAlreadyCreated)
+                const eligibleForTrial = await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user, newTeamAlreadyCreated)
 
                 if (eligibleForTrial) {
                     app.log.info(`User ${user.name} (${user.username}) is eligible for a free trial, set the flag in the subscription metadata.`)

--- a/forge/ee/routes/billing/index.js
+++ b/forge/ee/routes/billing/index.js
@@ -192,7 +192,7 @@ module.exports = async function (app) {
                     return
                 }
 
-                if (!app.db.controllers.Subscription.freeTrialsEnabled()) {
+                if (!app.db.controllers.Subscription.freeTrialCreditEnabled()) {
                     app.log.error(`Received a new subscription with the trial flag set for ${team.hashid}, but trials are not configured.`)
                     return
                 }

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -28,8 +28,8 @@ module.exports = async function (app) {
         const user = request.session.User
 
         const response = await app.db.views.User.userProfile(user)
-        if (app.license.active() && app.billing && app.db.controllers.Subscription.freeTrialsEnabled()) {
-            response.free_trial_available = await app.db.controllers.Subscription.userEligibleForFreeTrial(user)
+        if (app.license.active() && app.billing && app.db.controllers.Subscription.freeTrialCreditEnabled()) {
+            response.free_trial_available = await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user)
         }
 
         reply.send(response)

--- a/test/unit/forge/ee/db/controllers/Subscription_spec.js
+++ b/test/unit/forge/ee/db/controllers/Subscription_spec.js
@@ -64,38 +64,44 @@ describe('Subscription controller', function () {
         })
     })
 
-    describe('freeTrialsEnabled', function () {
+    describe('freeTrialCreditEnabled', function () {
         it('returns true if new_customer_free_credit is set to an amount above zero', async function () {
             app.config.billing.stripe.new_customer_free_credit = 1
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), true)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), true)
 
             app.config.billing.stripe.new_customer_free_credit = 100
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), true)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), true)
 
             app.config.billing.stripe.new_customer_free_credit = 1000
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), true)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), true)
         })
 
         it('returns false if new_customer_free_credit is unset or less than or equal to zero', async function () {
             delete app.config.billing.stripe.new_customer_free_credit
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), false)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), false)
 
             app.config.billing.stripe.new_customer_free_credit = null
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), false)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), false)
 
             app.config.billing.stripe.new_customer_free_credit = 0
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), false)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), false)
 
             app.config.billing.stripe.new_customer_free_credit = -1000
-            should.equal(app.db.controllers.Subscription.freeTrialsEnabled(), false)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), false)
+        })
+
+        it('returns false if configured, but team trial mode is enabled', async function () {
+            app.config.billing.stripe.new_customer_free_credit = 1
+            app.settings.set('user:team:trial-mode', true)
+            should.equal(app.db.controllers.Subscription.freeTrialCreditEnabled(), false)
         })
     })
 
-    describe('userEligibleForFreeTrial', function () {
+    describe('userEligibleForFreeTrialCredit', function () {
         it('returns true if the user has no teams', async function () {
             const newUser = await app.db.models.User.create({ admin: true, username: 'new', name: 'New', email: 'new@example.com', email_verified: true, password: 'aaPassword' })
 
-            const eligible = await app.db.controllers.Subscription.userEligibleForFreeTrial(newUser)
+            const eligible = await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(newUser)
             should.equal(eligible, true)
         })
 
@@ -103,7 +109,7 @@ describe('Subscription controller', function () {
             const user = await app.db.models.User.byEmail('alice@example.com')
             should.equal(await user.teamCount() > 0, true)
 
-            const eligible = await app.db.controllers.Subscription.userEligibleForFreeTrial(user)
+            const eligible = await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user)
             should.equal(eligible, false)
         })
 
@@ -112,7 +118,7 @@ describe('Subscription controller', function () {
             should.equal(await user.teamCount() === 1, true)
 
             const newTeamAlreadyCreated = true
-            const eligible = await app.db.controllers.Subscription.userEligibleForFreeTrial(user, newTeamAlreadyCreated)
+            const eligible = await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user, newTeamAlreadyCreated)
             should.equal(eligible, true)
         })
     })

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -128,7 +128,7 @@ describe('Billing', function () {
                     const newTeam = await app.db.models.Team.create({ name: 'new-team', TeamTypeId: defaultTeamType.id })
                     const user = await app.db.models.User.create({ admin: true, username: 'new', name: 'New User', email: 'new@example.com', email_verified: true, password: 'aaPassword' })
                     await newTeam.addUser(user, { through: { role: Roles.Owner } })
-                    should.equal(await app.db.controllers.Subscription.userEligibleForFreeTrial(user, true), true)
+                    should.equal(await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user, true), true)
 
                     const result = await app.billing.createSubscriptionSession(newTeam, null, user)
 
@@ -142,7 +142,7 @@ describe('Billing', function () {
                     const secondTeam = await app.db.models.Team.create({ name: 'new-team', TeamTypeId: defaultTeamType.id })
                     const userAlice = await app.db.models.User.byEmail('alice@example.com')
                     await secondTeam.addUser(userAlice, { through: { role: Roles.Owner } })
-                    should.equal(await app.db.controllers.Subscription.userEligibleForFreeTrial(userAlice, true), false)
+                    should.equal(await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(userAlice, true), false)
 
                     const result = await app.billing.createSubscriptionSession(secondTeam, null, userAlice)
 
@@ -172,7 +172,7 @@ describe('Billing', function () {
                 const newTeam = await app.db.models.Team.create({ name: 'new-team', TeamTypeId: defaultTeamType.id })
                 const user = await app.db.models.User.create({ admin: true, username: 'new', name: 'New User', email: 'new@example.com', email_verified: true, password: 'aaPassword' })
                 await newTeam.addUser(user, { through: { role: Roles.Owner } })
-                should.equal(await app.db.controllers.Subscription.userEligibleForFreeTrial(user, true), true)
+                should.equal(await app.db.controllers.Subscription.userEligibleForFreeTrialCredit(user, true), true)
 
                 const result = await app.billing.createSubscriptionSession(newTeam, null, user)
 


### PR DESCRIPTION
## Description

We enabled free team credit in 1.3 as a first iteration to trials.

In 1.4 we are introducing proper team trials.

We do not want to apply both free credit *and* team trial to the same account. This PR disables free team credit if team trials is enabled.

It also renames a couple of the internal helper functions to clarify they are related to the free **credit** rather than team trial.

## Related Issue(s)

 - #1578 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

