### PR TITLE
Add delete route for shared library api

### DIFF
--- a/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
+++ b/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
@@ -51,6 +51,20 @@ describe('Library Storage API', function () {
             })).json()
         }
 
+        async function deleteFromLibrary (libraryURL, name, type) {
+            let query = ''
+            if (type) {
+                query = `?type=${type}`
+            }
+            return (await app.inject({
+                method: 'DELETE',
+                url: `${libraryURL}${name}${query}`,
+                headers: {
+                    authorization: `Bearer ${tokens.token}`
+                }
+            })).json()
+        }
+
         async function shouldRejectGet (url, token) {
             const response = await app.inject({
                 method: 'GET',
@@ -228,6 +242,104 @@ describe('Library Storage API', function () {
             // Now try to create an entry that clashes with the directory test/foo
             const response2 = await addToLibrary(libraryURL, 'test/foo', 'functions')
             response2.statusCode.should.equal(400)
+        })
+
+        it('Deletes an individual entry', async function () {
+            const libraryURL = `/storage/library/${app.team.hashid}/`
+            /*
+              Library file structure:
+                ├── bar3 (flows)
+                └── test
+                    └── foo
+                    |   ├── bar (flows)
+                    |   └── bar2 (flows)
+                    └── funcs
+                        └── bar4 (funcs)
+            */
+            await addToLibrary(libraryURL, 'test/foo/bar', 'flows')
+            await addToLibrary(libraryURL, 'test/foo/bar2', 'flows')
+            await addToLibrary(libraryURL, 'bar3', 'flows')
+            await addToLibrary(libraryURL, 'test/funcs/bar4', 'functions')
+
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(4)
+
+            const result = await deleteFromLibrary(libraryURL, 'test/foo/bar')
+            result.should.have.property('status', 'okay')
+            result.should.have.property('deleteCount', 1)
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(3)
+        })
+
+        it('Deletes a folder - all types', async function () {
+            const libraryURL = `/storage/library/${app.team.hashid}/`
+            /*
+              Library file structure:
+                ├── bar3 (flows)
+                └── test
+                    └── foo
+                    |   ├── bar (flows)
+                    |   └── bar2 (flows)
+                    └── funcs
+                        └── bar4 (funcs)
+            */
+            await addToLibrary(libraryURL, 'test/foo/bar', 'flows')
+            await addToLibrary(libraryURL, 'test/foo/bar2', 'flows')
+            await addToLibrary(libraryURL, 'bar3', 'flows')
+            await addToLibrary(libraryURL, 'test/funcs/bar4', 'functions')
+
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(4)
+
+            const result = await deleteFromLibrary(libraryURL, 'test')
+            result.should.have.property('status', 'okay')
+            result.should.have.property('deleteCount', 3)
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(1)
+        })
+        it('Deletes a folder - specific type', async function () {
+            const libraryURL = `/storage/library/${app.team.hashid}/`
+            /*
+              Library file structure:
+                ├── bar3 (flows)
+                └── test
+                    └── foo
+                    |   ├── bar (flows)
+                    |   └── bar2 (flows)
+                    └── funcs
+                        └── bar4 (funcs)
+            */
+            await addToLibrary(libraryURL, 'test/foo/bar', 'flows')
+            await addToLibrary(libraryURL, 'test/foo/bar2', 'flows')
+            await addToLibrary(libraryURL, 'bar3', 'flows')
+            await addToLibrary(libraryURL, 'test/funcs/bar4', 'functions')
+
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(4)
+
+            const result = await deleteFromLibrary(libraryURL, 'test', 'flows')
+            result.should.have.property('status', 'okay')
+            result.should.have.property('deleteCount', 2)
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(2)
+        })
+
+        it('Delete returns 404 if path not matched', async function () {
+            const libraryURL = `/storage/library/${app.team.hashid}/`
+            /*
+              Library file structure:
+                ├── bar3 (flows)
+                └── test
+                    └── foo
+                    |   ├── bar (flows)
+                    |   └── bar2 (flows)
+                    └── funcs
+                        └── bar4 (funcs)
+            */
+            await addToLibrary(libraryURL, 'test/foo/bar', 'flows')
+            await addToLibrary(libraryURL, 'test/foo/bar2', 'flows')
+            await addToLibrary(libraryURL, 'bar3', 'flows')
+            await addToLibrary(libraryURL, 'test/funcs/bar4', 'functions')
+
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(4)
+
+            const result = await deleteFromLibrary(libraryURL, 'test/fo')
+            result.should.have.property('code', 'not_found')
+            ;(await app.db.models.StorageSharedLibrary.count()).should.equal(4)
         })
     })
 })


### PR DESCRIPTION
## Description

Adds support for deleting entries from the Shared Team Library

 - `DELETE /storage/library/:libraryId/:path`

Response:

 - `{ "status": "okay", "deleteCount": <how many things were deleted> }`

If `path` matches a single entry (ie a 'file') the file is deleted (`deleteCount: 1`)
If `path` matches a folder, all entries beneath that folder are deleted. (`deleteCount: n`)
If `path` doesn't match anything, it 404s.

An optional `type=<type>` parameter can be included to restrict the operation to library entries of a particular type. Whilst this isn't necessarily needed by the UI, it is consistent with the `GET` api that Node-RED requires to be able to filter by type.



## Related Issue(s)

#1597 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

