### PR TITLE
Add updatedAt to library entry meta data

### DIFF
--- a/forge/ee/routes/sharedLibrary/index.js
+++ b/forge/ee/routes/sharedLibrary/index.js
@@ -135,7 +135,7 @@ module.exports = async function (app) {
                 const shortName = entry.name.substring(name.length)
                 const pathParts = shortName.split('/')
                 if (pathParts.length === 1) {
-                    reply.push({ fn: shortName, ...JSON.parse(entry.meta), type: entry.type })
+                    reply.push({ fn: shortName, ...JSON.parse(entry.meta), type: entry.type, updatedAt: entry.updatedAt })
                 } else {
                     subPaths.add(pathParts[0])
                 }

--- a/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
+++ b/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
@@ -123,7 +123,7 @@ describe('Library Storage API', function () {
             should(libraryEntry).equal('\nreturn msg;')
         })
 
-        it.only('Add to Library with path', async function () {
+        it('Add to Library with path', async function () {
             const funcText = '\nreturn msg;'
             const libraryURL = `/storage/library/${app.team.hashid}/`
             await app.inject({

--- a/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
+++ b/test/unit/forge/ee/routes/sharedLibrary/index_spec.js
@@ -123,7 +123,7 @@ describe('Library Storage API', function () {
             should(libraryEntry).equal('\nreturn msg;')
         })
 
-        it('Add to Library with path', async function () {
+        it.only('Add to Library with path', async function () {
             const funcText = '\nreturn msg;'
             const libraryURL = `/storage/library/${app.team.hashid}/`
             await app.inject({
@@ -131,22 +131,26 @@ describe('Library Storage API', function () {
                 url: `${libraryURL}test/foo/bar`,
                 payload: {
                     type: 'functions',
-                    meta: {},
+                    meta: { outputs: 123 },
                     body: funcText
                 },
                 headers: {
                     authorization: `Bearer ${tokens.token}`
                 }
             })
-            const response = await app.inject({
-                method: 'GET',
-                url: `${libraryURL}test`,
-                headers: {
-                    authorization: `Bearer ${tokens.token}`
-                }
-            })
-            const libraryEntry = response.json()
-            should(libraryEntry).containDeep(['foo'])
+            const libraryEntryFolderListing = await getFromLibrary(libraryURL, 'test')
+            libraryEntryFolderListing.should.have.length(1)
+            libraryEntryFolderListing[0].should.equal('foo')
+
+            const libraryEntryListing = await getFromLibrary(libraryURL, 'test/foo')
+            libraryEntryListing.should.have.length(1)
+            const entry = libraryEntryListing[0]
+            entry.should.have.property('fn', 'bar')
+            entry.should.have.property('type', 'functions')
+            entry.should.have.property('outputs', 123)
+            entry.should.have.property('updatedAt')
+            const updatedAt = new Date(entry.updatedAt)
+            ;(Math.abs(Date.now() - updatedAt) < 1000).should.be.true()
         })
 
         it('Add to Library - access from another team project', async function () {


### PR DESCRIPTION
## Description

Adds `updatedAt` field to the meta data object returned by the Team Storage Library api.

## Related Issue(s)

 - #1597 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

