### PR TITLE
Allow signup page to be customised from admin settings

### DIFF
--- a/config/cypress.config.js
+++ b/config/cypress.config.js
@@ -2,7 +2,6 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
     e2e: {
-        testIsolation: 'on',
         baseUrl: 'http://localhost:3000',
         experimentalSessionAndOrigin: true,
         downloadsFolder: 'test/e2e/frontend/cypress/downloads',

--- a/config/cypress.config.js
+++ b/config/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
     e2e: {
+        testIsolation: 'on',
         baseUrl: 'http://localhost:3000',
         experimentalSessionAndOrigin: true,
         downloadsFolder: 'test/e2e/frontend/cypress/downloads',

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
     },
     output: {
         path: getPath('frontend/dist/app'),
-        publicPath: '/app'
+        publicPath: '/app/',
+        assetModuleFilename: './assets/[hash][ext][query]'
     },
     module: {
         rules: [
@@ -72,7 +73,10 @@ module.exports = {
                 test: /\.scss$/,
                 use: [
                     'style-loader',
-                    'css-loader',
+                    {
+                        loader: 'css-loader',
+                        options: { import: true, url: true }
+                    },
                     'sass-loader'
                 ]
             },
@@ -85,11 +89,7 @@ module.exports = {
             },
             {
                 test: /\.(png|jpe?g|gif|webm|mp4|svg)$/,
-                loader: 'file-loader',
-                options: {
-                    outputPath: '/assets',
-                    esModule: false
-                }
+                type: 'asset'
             }
         ]
     },

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -44,5 +44,8 @@ module.exports = {
     // Is the trial feature enabled?
     'user:team:trial-mode': false,
     'user:team:trial-mode:duration': 0, // How many days - required if trials enabled
-    'user:team:trial-mode:projectType': null // Project type that is included in the trial - required if trials enabled
+    'user:team:trial-mode:projectType': null, // Project type that is included in the trial - required if trials enabled
+
+    'branding:account:signUpTopBanner': null,
+    'branding:account:signUpLeftBanner': null
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -243,3 +243,13 @@
         @apply text-red-400;
     }
 }
+
+@layer components {
+    .ff-layout--box--left,
+    .ff-layout--box--right {
+        @apply p-0 md:p-12;
+    }
+    .ff-layout--box--right .ff-layout--box--content {
+        @apply rounded-none md:rounded-xl;
+    }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -250,6 +250,6 @@
         @apply p-0 md:p-12;
     }
     .ff-layout--box--right .ff-layout--box--content {
-        @apply rounded-none md:rounded-xl;
+        @apply rounded-none md:rounded-xl m-auto;
     }
 }

--- a/frontend/src/layouts/Box.vue
+++ b/frontend/src/layouts/Box.vue
@@ -1,11 +1,16 @@
 <template>
     <div class="ff-layout--box">
-        <div class="ff-layout--box--wrapper">
-            <div class="ff-layout--box--content">
-                <div class="ff-logo">
-                    <img src="@/images/ff-logo--wordmark-caps--dark.png" />
+        <div class="ff-layout--box--wrapper" :class="{'grid-cols-2 max-w-6xl': !!this.$slots['splash-content'], 'max-w-2xl': !this.$slots['splash-content']}">
+            <div v-if="!!this.$slots['splash-content']" class="ff-layout--box--left">
+                <div class="ff-layout--box--content"><slot name="splash-content"></slot></div>
+            </div>
+            <div class="ff-layout--box--right">
+                <div class="ff-layout--box--content">
+                    <div class="ff-logo">
+                        <img src="@/images/ff-logo--wordmark-caps--dark.png" />
+                    </div>
+                    <slot name="form"></slot>
                 </div>
-                <slot></slot>
             </div>
         </div>
         <TransitionGroup class="ff-notifications" name="notifictions-list" tag="div">

--- a/frontend/src/layouts/Box.vue
+++ b/frontend/src/layouts/Box.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ff-layout--box">
-        <div class="ff-layout--box--wrapper" :class="{'grid-cols-2 max-w-6xl': !!this.$slots['splash-content'], 'max-w-2xl': !this.$slots['splash-content']}">
-            <div v-if="!!this.$slots['splash-content']" class="ff-layout--box--left">
+        <div class="ff-layout--box--wrapper" :class="{'md:grid-cols-2 max-w-6xl': !!this.$slots['splash-content'], 'max-w-2xl': !this.$slots['splash-content']}">
+            <div v-if="!!this.$slots['splash-content']" class="ff-layout--box--left hidden md:flex">
                 <div class="ff-layout--box--content">
                     <slot name="splash-content"></slot>
                 </div>

--- a/frontend/src/layouts/Box.vue
+++ b/frontend/src/layouts/Box.vue
@@ -2,14 +2,16 @@
     <div class="ff-layout--box">
         <div class="ff-layout--box--wrapper" :class="{'grid-cols-2 max-w-6xl': !!this.$slots['splash-content'], 'max-w-2xl': !this.$slots['splash-content']}">
             <div v-if="!!this.$slots['splash-content']" class="ff-layout--box--left">
-                <div class="ff-layout--box--content"><slot name="splash-content"></slot></div>
+                <div class="ff-layout--box--content">
+                    <slot name="splash-content"></slot>
+                </div>
             </div>
             <div class="ff-layout--box--right">
                 <div class="ff-layout--box--content">
                     <div class="ff-logo">
                         <img src="@/images/ff-logo--wordmark-caps--dark.png" />
                     </div>
-                    <slot name="form"></slot>
+                    <slot></slot>
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-layout-box class="ff-login">
-        <template v-slot:form>
+        <template>
             <div v-if="!pending">
                 <ff-loading v-if="loggingIn" message="Logging in..." color="white"/>
                 <template v-else>

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -1,31 +1,31 @@
 <template>
     <ff-layout-box class="ff-login">
-        <div v-if="!pending">
-            <ff-loading v-if="loggingIn" message="Logging in..." color="white"/>
-            <template v-else>
-                <div>
+        <template v-slot:form>
+            <div v-if="!pending">
+                <ff-loading v-if="loggingIn" message="Logging in..." color="white"/>
+                <template v-else>
                     <label>username / email</label>
                     <ff-text-input ref="login-username" label="username" :error="errors.username" v-model="input.username" @enter="login"/>
-                    <label class="ff-error-inline" data-el="errors-username">{{ errors.username }}</label>
+                    <span class="ff-error-inline" data-el="errors-username">{{ errors.username }}</span>
                     <div v-if="passwordRequired">
                         <label>password</label>
                         <ff-text-input ref="login-password" label="password" :error="errors.password" v-model="input.password" @enter="login" type="password"/>
-                        <label class="ff-error-inline" data-el="errors-password">{{ errors.password }}</label>
+                        <span class="ff-error-inline" data-el="errors-password">{{ errors.password }}</span>
                     </div>
-                </div>
-                <label class="ff-error-inline" data-el="errors-general">{{ errors.general }}</label>
-                <div class="ff-actions">
-                    <ff-button @click="login()" data-action="login">Login</ff-button>
-                    <ff-button v-if="settings['user:signup']" kind="tertiary" to="/account/create" data-action="sign-up">Sign Up</ff-button>
-                    <ff-button v-if="passwordRequired && settings['user:reset-password']" kind="tertiary" :to="{'name': 'ForgotPassword'}" data-action="forgot-password">Forgot your password?</ff-button>
-                </div>
-            </template>
-        </div>
-        <div v-else>
-            <div class="flex justify-center">
-                <div class="w-1/2"><Logo /></div>
+                    <label class="ff-error-inline" data-el="errors-general">{{ errors.general }}</label>
+                    <div class="ff-actions">
+                        <ff-button @click="login()" data-action="login">Login</ff-button>
+                        <ff-button v-if="settings['user:signup']" kind="tertiary" to="/account/create" data-action="sign-up">Sign Up</ff-button>
+                        <ff-button v-if="passwordRequired && settings['user:reset-password']" kind="tertiary" :to="{'name': 'ForgotPassword'}" data-action="forgot-password">Forgot your password?</ff-button>
+                    </div>
+                </template>
             </div>
-        </div>
+            <div v-else>
+                <div class="flex justify-center">
+                    <div class="w-1/2"><Logo /></div>
+                </div>
+            </div>
+        </template>
     </ff-layout-box>
 </template>
 

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -1,31 +1,29 @@
 <template>
     <ff-layout-box class="ff-login">
-        <template>
-            <div v-if="!pending">
-                <ff-loading v-if="loggingIn" message="Logging in..." color="white"/>
-                <template v-else>
-                    <label>username / email</label>
-                    <ff-text-input ref="login-username" label="username" :error="errors.username" v-model="input.username" @enter="login"/>
-                    <span class="ff-error-inline" data-el="errors-username">{{ errors.username }}</span>
-                    <div v-if="passwordRequired">
-                        <label>password</label>
-                        <ff-text-input ref="login-password" label="password" :error="errors.password" v-model="input.password" @enter="login" type="password"/>
-                        <span class="ff-error-inline" data-el="errors-password">{{ errors.password }}</span>
-                    </div>
-                    <label class="ff-error-inline" data-el="errors-general">{{ errors.general }}</label>
-                    <div class="ff-actions">
-                        <ff-button @click="login()" data-action="login">Login</ff-button>
-                        <ff-button v-if="settings['user:signup']" kind="tertiary" to="/account/create" data-action="sign-up">Sign Up</ff-button>
-                        <ff-button v-if="passwordRequired && settings['user:reset-password']" kind="tertiary" :to="{'name': 'ForgotPassword'}" data-action="forgot-password">Forgot your password?</ff-button>
-                    </div>
-                </template>
-            </div>
-            <div v-else>
-                <div class="flex justify-center">
-                    <div class="w-1/2"><Logo /></div>
+        <div v-if="!pending">
+            <ff-loading v-if="loggingIn" message="Logging in..." color="white"/>
+            <template v-else>
+                <label>username / email</label>
+                <ff-text-input ref="login-username" label="username" :error="errors.username" v-model="input.username" @enter="login"/>
+                <span class="ff-error-inline" data-el="errors-username">{{ errors.username }}</span>
+                <div v-if="passwordRequired">
+                    <label>password</label>
+                    <ff-text-input ref="login-password" label="password" :error="errors.password" v-model="input.password" @enter="login" type="password"/>
+                    <span class="ff-error-inline" data-el="errors-password">{{ errors.password }}</span>
                 </div>
+                <label class="ff-error-inline" data-el="errors-general">{{ errors.general }}</label>
+                <div class="ff-actions">
+                    <ff-button @click="login()" data-action="login">Login</ff-button>
+                    <ff-button v-if="settings['user:signup']" kind="tertiary" to="/account/create" data-action="sign-up">Sign Up</ff-button>
+                    <ff-button v-if="passwordRequired && settings['user:reset-password']" kind="tertiary" :to="{'name': 'ForgotPassword'}" data-action="forgot-password">Forgot your password?</ff-button>
+                </div>
+            </template>
+        </div>
+        <div v-else>
+            <div class="flex justify-center">
+                <div class="w-1/2"><Logo /></div>
             </div>
-        </template>
+        </div>
     </ff-layout-box>
 </template>
 

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -3,45 +3,43 @@
         <template v-slot:splash-content v-if="splash">
             <div v-html="splash"></div>
         </template>
-        <template v-slot:form>
-            <form v-if="!emailSent && !ssoCreated" class="max-w-md m-auto">
-                <p v-if="settings['branding:account:signUpTopBanner']" class="text-center -mt-6 pb-4 text-gray-400" v-html="settings['branding:account:signUpTopBanner']"></p>
-                <div>
-                    <label>Username</label>
-                    <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
-                    <span class="ff-error-inline">{{ errors.username }}</span>
-                    <label>Full Name</label>
-                    <ff-text-input ref="signup-fullname" label="Full Name" :error="errors.name" v-model="input.name" />
-                    <span class="ff-error-inline">{{ errors.name }}</span>
-                    <label>E-Mail Address</label>
-                    <ff-text-input ref="signup-email" label="E-Mail Address" :error="errors.email" v-model="input.email" />
-                    <span class="ff-error-inline">{{ errors.email }}</span>
-                    <label>Password</label>
-                    <ff-text-input ref="signup-password" label="password" :error="errors.password" v-model="input.password" type="password"/>
-                    <span class="ff-error-inline">{{ errors.password }}</span>
-                </div>
-                <div v-if="settings['user:tcs-required']">
-                    <ff-checkbox v-model="input.tcs_accepted">
-                        I accept the <a target="_blank" :href="settings['user:tcs-url']">FlowForge Terms &amp; Conditions.</a>
-                    </ff-checkbox>
-                </div>
-                <label v-if="errors.general" class="pt-4 ff-error-inline">{{ errors.general }}</label>
-                <div class="ff-actions pt-4">
-                    <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
-                    <p class="flex text-gray-400 font-light mt-6 gap-2 w-full justify-center">
-                        Already registered? <a href="/" data-action="login">Log in here</a>
-                    </p>
-                </div>
-            </form>
-            <div v-else-if="emailSent">
-                <h5>Confirm your e-mail address.</h5>
-                <p>Please click the link in the email we sent to {{ input.email }}</p>
+        <form v-if="!emailSent && !ssoCreated" class="max-w-md m-auto">
+            <p v-if="settings['branding:account:signUpTopBanner']" class="text-center -mt-6 pb-4 text-gray-400" v-html="settings['branding:account:signUpTopBanner']"></p>
+            <div>
+                <label>Username</label>
+                <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
+                <span class="ff-error-inline">{{ errors.username }}</span>
+                <label>Full Name</label>
+                <ff-text-input ref="signup-fullname" label="Full Name" :error="errors.name" v-model="input.name" />
+                <span class="ff-error-inline">{{ errors.name }}</span>
+                <label>E-Mail Address</label>
+                <ff-text-input ref="signup-email" label="E-Mail Address" :error="errors.email" v-model="input.email" />
+                <span class="ff-error-inline">{{ errors.email }}</span>
+                <label>Password</label>
+                <ff-text-input ref="signup-password" label="password" :error="errors.password" v-model="input.password" type="password"/>
+                <span class="ff-error-inline">{{ errors.password }}</span>
             </div>
-            <div v-else>
-                <p>You can now login using your SSO Provider.</p>
-                <ff-button :to="{ name: 'Home' }" data-action="login">Login</ff-button>
+            <div v-if="settings['user:tcs-required']">
+                <ff-checkbox v-model="input.tcs_accepted">
+                    I accept the <a target="_blank" :href="settings['user:tcs-url']">FlowForge Terms &amp; Conditions.</a>
+                </ff-checkbox>
             </div>
-        </template>
+            <label v-if="errors.general" class="pt-4 ff-error-inline">{{ errors.general }}</label>
+            <div class="ff-actions pt-4">
+                <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
+                <p class="flex text-gray-400 font-light mt-6 gap-2 w-full justify-center">
+                    Already registered? <a href="/" data-action="login">Log in here</a>
+                </p>
+            </div>
+        </form>
+        <div v-else-if="emailSent">
+            <h5>Confirm your e-mail address.</h5>
+            <p>Please click the link in the email we sent to {{ input.email }}</p>
+        </div>
+        <div v-else>
+            <p>You can now login using your SSO Provider.</p>
+            <ff-button :to="{ name: 'Home' }" data-action="login">Login</ff-button>
+        </div>
     </ff-layout-box>
 </template>
 

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -49,7 +49,6 @@
 import { mapState } from 'vuex'
 
 import userApi from '@/api/user'
-import SettingsAPI from '@/api/settings'
 
 import { useRoute } from 'vue-router'
 

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -1,10 +1,12 @@
 <template>
     <ff-layout-box class="ff-signup">
         <template v-slot:splash-content v-if="splash">
-            <div v-html="splash"></div>
+            <div v-html="splash" data-el="splash"></div>
         </template>
         <form v-if="!emailSent && !ssoCreated" class="max-w-md m-auto">
-            <p v-if="settings['branding:account:signUpTopBanner']" class="text-center -mt-6 pb-4 text-gray-400" v-html="settings['branding:account:signUpTopBanner']"></p>
+            <p v-if="settings['branding:account:signUpTopBanner']" data-el="banner-text"
+               class="text-center -mt-6 pb-4 text-gray-400"
+               v-html="settings['branding:account:signUpTopBanner']"></p>
             <div>
                 <label>Username</label>
                 <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -63,7 +63,6 @@ export default {
     data () {
         return {
             teams: [],
-            splash: null, // content to show on left of sign up page
             emailSent: false,
             ssoCreated: false,
             input: {
@@ -82,10 +81,12 @@ export default {
     },
     mounted () {
         this.input.email = useRoute().query.email || ''
-        this.loadCustomContent()
     },
     computed: {
         ...mapState('account', ['settings', 'pending']),
+        splash () {
+            return this.settings['branding:account:signUpLeftBanner']
+        },
         formValid () {
             return (this.input.email && !this.errors.email) &&
                    (this.input.username && !this.errors.username) &&
@@ -123,14 +124,6 @@ export default {
         }
     },
     methods: {
-        loadCustomContent () {
-            SettingsAPI.getSettings().then((settings) => {
-                if (settings['branding:account:signUpLeftBanner']) {
-                    console.log(settings['branding:account:signUpLeftBanner'])
-                    this.splash = settings['branding:account:signUpLeftBanner']
-                }
-            })
-        },
         checkPassword () {
             if (this.input.password.length < 8) {
                 this.errors.password = 'Password must be at least 8 characters'

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -2,7 +2,7 @@
     <ff-layout-box class="ff-signup">
         <div v-if="!emailSent && !ssoCreated" class="max-w-md">
             <h2>Sign Up</h2>
-            <p v-if="settings.branding?.account?.signUpTopBanner" class="-mt-6 pb-4 text-gray-400">{{ settings.branding?.account?.signUpTopBanner }}</p>
+            <p v-if="settings['branding:account:signUpTopBanner']" class="-mt-6 pb-4 text-gray-400" v-html="settings['branding:account:signUpTopBanner']"></p>
             <div class="pb-4">
                 <label>Username</label>
                 <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -1,41 +1,47 @@
 <template>
     <ff-layout-box class="ff-signup">
-        <div v-if="!emailSent && !ssoCreated" class="max-w-md">
-            <h2>Sign Up</h2>
-            <p v-if="settings['branding:account:signUpTopBanner']" class="-mt-6 pb-4 text-gray-400" v-html="settings['branding:account:signUpTopBanner']"></p>
-            <div class="pb-4">
-                <label>Username</label>
-                <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
-                <label class="ff-error-inline">{{ errors.username }}</label>
-                <label>Full Name</label>
-                <ff-text-input ref="signup-fullname" label="Full Name" :error="errors.name" v-model="input.name" />
-                <label class="ff-error-inline">{{ errors.name }}</label>
-                <label>E-Mail Address</label>
-                <ff-text-input ref="signup-email" label="E-Mail Address" :error="errors.email" v-model="input.email" />
-                <label class="ff-error-inline">{{ errors.email }}</label>
-                <label>Password</label>
-                <ff-text-input ref="signup-password" label="password" :error="errors.password" v-model="input.password" type="password"/>
-                <label class="ff-error-inline">{{ errors.password }}</label>
+        <template v-slot:splash-content v-if="splash">
+            <div v-html="splash"></div>
+        </template>
+        <template v-slot:form>
+            <form v-if="!emailSent && !ssoCreated" class="max-w-md m-auto">
+                <p v-if="settings['branding:account:signUpTopBanner']" class="text-center -mt-6 pb-4 text-gray-400" v-html="settings['branding:account:signUpTopBanner']"></p>
+                <div>
+                    <label>Username</label>
+                    <ff-text-input ref="signup-username" label="username" :error="errors.username" v-model="input.username" />
+                    <span class="ff-error-inline">{{ errors.username }}</span>
+                    <label>Full Name</label>
+                    <ff-text-input ref="signup-fullname" label="Full Name" :error="errors.name" v-model="input.name" />
+                    <span class="ff-error-inline">{{ errors.name }}</span>
+                    <label>E-Mail Address</label>
+                    <ff-text-input ref="signup-email" label="E-Mail Address" :error="errors.email" v-model="input.email" />
+                    <span class="ff-error-inline">{{ errors.email }}</span>
+                    <label>Password</label>
+                    <ff-text-input ref="signup-password" label="password" :error="errors.password" v-model="input.password" type="password"/>
+                    <span class="ff-error-inline">{{ errors.password }}</span>
+                </div>
+                <div v-if="settings['user:tcs-required']">
+                    <ff-checkbox v-model="input.tcs_accepted">
+                        I accept the <a target="_blank" :href="settings['user:tcs-url']">FlowForge Terms &amp; Conditions.</a>
+                    </ff-checkbox>
+                </div>
+                <label v-if="errors.general" class="pt-4 ff-error-inline">{{ errors.general }}</label>
+                <div class="ff-actions pt-4">
+                    <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
+                    <p class="flex text-gray-400 font-light mt-6 gap-2 w-full justify-center">
+                        Already registered? <a href="/" data-action="login">Log in here</a>
+                    </p>
+                </div>
+            </form>
+            <div v-else-if="emailSent">
+                <h5>Confirm your e-mail address.</h5>
+                <p>Please click the link in the email we sent to {{ input.email }}</p>
             </div>
-            <div v-if="settings['user:tcs-required']">
-                <ff-checkbox v-model="input.tcs_accepted">
-                    I accept the <a target="_blank" :href="settings['user:tcs-url']">FlowForge Terms &amp; Conditions.</a>
-                </ff-checkbox>
+            <div v-else>
+                <p>You can now login using your SSO Provider.</p>
+                <ff-button :to="{ name: 'Home' }" data-action="login">Login</ff-button>
             </div>
-            <label class="ff-error-inline">{{ errors.general }}</label>
-            <div class="ff-actions">
-                <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
-                <ff-button kind="tertiary" to="/" data-action="sign-up">Already registered? Log in here</ff-button>
-            </div>
-        </div>
-        <div v-else-if="emailSent">
-            <h5>Confirm your e-mail address.</h5>
-            <p>Please click the link in the email we sent to {{ input.email }}</p>
-        </div>
-        <div v-else>
-            <p>You can now login using your SSO Provider.</p>
-            <ff-button :to="{ name: 'Home' }" data-action="login">Login</ff-button>
-        </div>
+        </template>
     </ff-layout-box>
 </template>
 
@@ -43,6 +49,7 @@
 import { mapState } from 'vuex'
 
 import userApi from '@/api/user'
+import SettingsAPI from '@/api/settings'
 
 import { useRoute } from 'vue-router'
 
@@ -56,6 +63,7 @@ export default {
     data () {
         return {
             teams: [],
+            splash: null, // content to show on left of sign up page
             emailSent: false,
             ssoCreated: false,
             input: {
@@ -74,6 +82,7 @@ export default {
     },
     mounted () {
         this.input.email = useRoute().query.email || ''
+        this.loadCustomContent()
     },
     computed: {
         ...mapState('account', ['settings', 'pending']),
@@ -114,6 +123,14 @@ export default {
         }
     },
     methods: {
+        loadCustomContent () {
+            SettingsAPI.getSettings().then((settings) => {
+                if (settings['branding:account:signUpLeftBanner']) {
+                    console.log(settings['branding:account:signUpLeftBanner'])
+                    this.splash = settings['branding:account:signUpLeftBanner']
+                }
+            })
+        },
         checkPassword () {
             if (this.input.password.length < 8) {
                 this.errors.password = 'Password must be at least 8 characters'

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -2,7 +2,7 @@
     <ff-loading v-if="loading" message="Saving Settings..."/>
     <div v-else class="space-y-4">
         <FormHeading>Users</FormHeading>
-        <FormRow v-model="input['user:signup']" type="checkbox"  :error="errors.requiresEmail" :disabled="errors.requiresEmail">
+        <FormRow data-el="enable-signup" v-model="input['user:signup']" type="checkbox" :error="errors.requiresEmail" :disabled="errors.requiresEmail">
             Allow new users to register on the login screen
             <template #description>
                 If self-registration is not enabled, an Administrator must create users
@@ -10,12 +10,12 @@
             </template>
         </FormRow>
         <template v-if="input['user:signup']">
-            <FormRow v-model="input['branding:account:signUpTopBanner']" containerClass="max-w-sm ml-9">
+            <FormRow data-el="banner" v-model="input['branding:account:signUpTopBanner']" containerClass="max-w-sm ml-9">
                 HTML content to show above the sign-up form
             </FormRow>
             <FormRow v-model="input['branding:account:signUpLeftBanner']" containerClass="max-w-sm ml-9">
                 HTML content to show to the left of the sign-up form
-                <template #input><textarea class="w-full" rows="6" v-model="input['branding:account:signUpLeftBanner']"></textarea></template>
+                <template #input><textarea data-el="splash" class="w-full" rows="6" v-model="input['branding:account:signUpLeftBanner']"></textarea></template>
             </FormRow>
         </template>
         <FormRow v-model="input['user:team:auto-create']" type="checkbox">

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -9,6 +9,15 @@
                 and provide their login details manually
             </template>
         </FormRow>
+        <template v-if="input['user:signup']">
+            <FormRow v-model="input['branding:account:signUpTopBanner']" containerClass="max-w-sm ml-9">
+                HTML content to show above the sign-up form
+            </FormRow>
+            <FormRow v-model="input['branding:account:signUpLeftBanner']" containerClass="max-w-sm ml-9">
+                HTML content to show to the left of the sign-up form
+                <template #input><textarea class="w-full" rows="6" v-model="input['branding:account:signUpLeftBanner']"></textarea></template>
+            </FormRow>
+        </template>
         <FormRow v-model="input['user:team:auto-create']" type="checkbox">
             Create a personal team for users when they register
             <template #description>
@@ -121,7 +130,9 @@ const validSettings = [
     'telemetry:enabled',
     'user:team:trial-mode',
     'user:team:trial-mode:duration',
-    'user:team:trial-mode:projectType'
+    'user:team:trial-mode:projectType',
+    'branding:account:signUpTopBanner',
+    'branding:account:signUpLeftBanner'
 ]
 
 export default {

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -231,9 +231,11 @@ export default {
                 .then(() => {
                     this.$store.dispatch('account/refreshSettings')
                     this.input['user:tcs-date'] = this.settings['user:tcs-date']
+                    Alerts.emit('Settings changed successfully.', 'confirmation')
                 })
                 .catch((err) => {
                     console.warn(err)
+                    Alerts.emit(`Something went wrong: ${err}`, 'warning')
                 })
                 .finally(() => {
                     this.loading = false

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -1,3 +1,8 @@
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import '~@flowforge/forge-ui-components/dist/scss/forge-colors.scss';
 @import '~@flowforge/forge-ui-components/dist/scss/forge-variables.scss';
 
@@ -44,9 +49,7 @@ $nav_height: 60px;
 .ff-layout--box--left,
 .ff-layout--box--right {
     border-top: 2px solid $ff-red-400;
-    padding: 64px 48px;
     height: 100%;
-    display: flex;
     justify-content: center;
     align-items: center;
 }
@@ -72,14 +75,10 @@ $nav_height: 60px;
 }
 
 .ff-layout--box--right .ff-layout--box--content {
-
-}
-
-.ff-layout--box--right .ff-layout--box--content {
     background-color: $ff-grey-700;
     min-height: 400px;
     padding: 64px 24px;
-    border-radius: 32px;
+    @apply rounded-xl;
     color: white;
     h2 {
         margin-top: -12px;

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -17,24 +17,22 @@ $nav_height: 60px;
     justify-content: center;
     align-items: center;
     min-height: inherit;
-    background-image: url("@/images/ff-flow-bg-white.svg");
+    background-image: url("./images/ff-flow-bg-red.png");
     background-size: contain;
     background-repeat: no-repeat;
     background-position-y: 90%;
     .ff-error-inline {
-        color: $ff-red-300;
+        font-size: 0.875rem;;
+        display: block;
+        margin-top: 0.25rem;
+        color: $ff-red-200;
     }
 }
 
 .ff-layout--box--wrapper {
     width: calc(100% - 48px);
-    border-top: 2px solid $ff-red-400;
-    max-width: 1024px;
     height: 60%;
-    padding: 64px 24px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    display: grid;
     background-color: rgba($ff-grey-600, 0.2);
     .ff-logo {
         max-width: 200px;
@@ -43,9 +41,42 @@ $nav_height: 60px;
     }
 }
 
+.ff-layout--box--left,
+.ff-layout--box--right {
+    border-top: 2px solid $ff-red-400;
+    padding: 64px 48px;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.ff-layout--box--left {
+    color: white;
+    background-color: rgba($ff-grey-900, 0.5);
+    h1 {
+        max-width: 420px;
+    }
+    h3 {
+        font-size: 1.25rem;
+    }
+    p {
+        font-weight: 200;
+        line-height: 1.5rem;
+        color: $ff-grey-300;
+    }
+}
+
 .ff-layout--box--content {
-    background-color: $ff-grey-700;
     width: 100%;
+}
+
+.ff-layout--box--right .ff-layout--box--content {
+
+}
+
+.ff-layout--box--right .ff-layout--box--content {
+    background-color: $ff-grey-700;
     min-height: 400px;
     padding: 64px 24px;
     border-radius: 32px;
@@ -308,7 +339,6 @@ $nav_height: 60px;
         position: absolute;
         top: 100%;
         margin-top: 2px;
-        // display: none;
         img {
             padding: 0;
             margin-right: 9px;
@@ -608,13 +638,7 @@ $nav_height: 60px;
 @media screen and (min-width: $ff-screen-sm) {
     /* Box */
     .ff-layout--box--wrapper {
-        width: 75%;
-        padding: 128px 0;
-    }
-    .ff-layout--box--content {
-        min-width: 400px;
-        width: initial;
-        padding: 64px;
+        width: 85%;
     }
     /* Platform */
     .ff-layout--platform--wrapper {

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -17,7 +17,7 @@ $nav_height: 60px;
     justify-content: center;
     align-items: center;
     min-height: inherit;
-    background-image: url("./images/ff-flow-bg-red.png");
+    background-image: url("./images/ff-flow-bg-white.svg");
     background-size: contain;
     background-repeat: no-repeat;
     background-position-y: 90%;

--- a/frontend/src/stylesheets/pages/login.scss
+++ b/frontend/src/stylesheets/pages/login.scss
@@ -1,1 +1,14 @@
 @import '~@flowforge/forge-ui-components/dist/scss/forge-colors.scss';
+
+.ff-login {
+    .ff-layout--box--wrapper {
+        width: 75%;
+        max-width: 1048px;
+        .ff-layout--box--right {
+            padding: 128px 48px;
+        }
+        .ff-layout--box--content {
+            max-width: 380px;
+        }
+    }
+}

--- a/test/e2e/frontend/cypress/support/commands.js
+++ b/test/e2e/frontend/cypress/support/commands.js
@@ -37,8 +37,11 @@ Cypress.Commands.add('login', (username, password) => {
     })
 })
 
-Cypress.Commands.add('logout', (username, password) => {
-    cy.request('post', '/account/logout')
+Cypress.Commands.add('logout', () => {
+    // clear Cypress session, and logout from FlowForge
+    cy.session([null, null], () => {
+        cy.request('post', '/account/logout')
+    })
 })
 
 // Navigate to the home page, and given we are logged in,

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -111,9 +111,7 @@ describe('FlowForge platform admin users', () => {
 
         cy.get('[data-action="save-settings"]').click()
 
-        cy.get('.ff-navigation.ff-user-options').click()
-        cy.get('[data-nav="sign-out"]').click()
-        cy.wait('@logout')
+        cy.logout()
 
         cy.visit('/')
 
@@ -136,9 +134,7 @@ describe('FlowForge platform admin users', () => {
 
         cy.get('[data-action="save-settings"]').click()
 
-        cy.get('.ff-navigation.ff-user-options').click()
-        cy.get('[data-nav="sign-out"]').click()
-        cy.wait('@logout')
+        cy.logout()
 
         cy.visit('/')
 

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -98,6 +98,57 @@ describe('FlowForge platform admin users', () => {
 
         cy.get('[data-el="banner-device-as-admin"]').should('exist')
     })
+
+    it('can enable sign up', () => {
+        cy.intercept('GET', '/api/*/settings').as('getSettings')
+        cy.intercept('POST', '/account/logout').as('logout')
+
+        cy.visit('/admin/settings/general')
+        cy.wait('@getSettings')
+
+        // enable sign up
+        cy.get('[data-el="enable-signup"] [data-el="form-row-title"]').click()
+
+        cy.get('[data-action="save-settings"]').click()
+
+        cy.get('.ff-navigation.ff-user-options').click()
+        cy.get('[data-nav="sign-out"]').click()
+        cy.wait('@logout')
+
+        cy.visit('/')
+
+        cy.get('[data-action="sign-up"]').click()
+
+        cy.url().should('include', '/account/create')
+
+        cy.get('[data-el="banner-text"]').should('not.exist')
+        cy.get('[data-el="splash"]').should('not.exist')
+    })
+
+    it('can customise the content of the "Sign Up" screen', () => {
+        cy.intercept('GET', '/api/*/settings').as('getSettings')
+
+        cy.visit('/admin/settings/general')
+        cy.wait('@getSettings')
+
+        cy.get('[data-el="banner"]').type('this is banner')
+        cy.get('[data-el="splash"]').type('<h1>Welcome to FlowForge</h1>')
+
+        cy.get('[data-action="save-settings"]').click()
+
+        cy.get('.ff-navigation.ff-user-options').click()
+        cy.get('[data-nav="sign-out"]').click()
+        cy.wait('@logout')
+
+        cy.visit('/')
+
+        cy.get('[data-action="sign-up"]').click()
+
+        cy.url().should('include', '/account/create')
+
+        cy.get('[data-el="banner-text"]').contains('this is banner')
+        cy.get('[data-el="splash"]').contains('Welcome to FlowForge')
+    })
 })
 
 describe('FlowForge platform non-admin users', () => {


### PR DESCRIPTION
## Description

In 1.3 we added `branding.account.signUpTopBanner` to `flowforge.yml` as a way to insert custom text above the sign-up form.

Via #1621 we have a requirement to insert longer text next to the sign-up form.

The downside of using `flowforge.yml` is that is requires a platform restart to pickup changes - making it hard to iterate.

This PR allows the Admin to set the content for both pieces of HTML via the Admin Settings screen - if 'allow signup' is enabled.

<img width="485" alt="image" src="https://user-images.githubusercontent.com/51083/218075798-419b51bd-3ffd-4e70-b81d-2ae0a0ba7a81.png">

If will still use the value of `branding.account.signUpTopBanner` from flowforge.yml unless overridden via this new setting.  The only limitation being you cannot set it to blank via admin settings and have *that* override a value from the yml file (blank is interpreted as unset, so the yml file value gets used). The right answer being to remove it from flowforge.yml as a one-off admin task.

The new setting `branding:account:signUpLeftBanner` does not, as of the current state of this PR, get displayed anywhere. That is over to @joepavitt to add.



## Related Issue(s)

#1621 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

