### PR TITLE
Only copy AccessToken data, if it exists

### DIFF
--- a/forge/db/migrations/20230205-01-add-id-to-access-tokens.js
+++ b/forge/db/migrations/20230205-01-add-id-to-access-tokens.js
@@ -60,7 +60,9 @@ module.exports = {
             }, { transaction: t })
 
             // copy the data from the old table to the new table
-            await context.bulkInsert('AccessTokens2', dataOriginal, { transaction: t })
+            if (dataOriginal.length > 0) {
+                await context.bulkInsert('AccessTokens2', dataOriginal, { transaction: t })
+            }
 
             // ensure that the data was copied correctly
             const dataIntermediate = await context.select(null, 'AccessTokens2', { transaction: t })

--- a/forge/db/migrations/20230205-01-add-id-to-access-tokens.js
+++ b/forge/db/migrations/20230205-01-add-id-to-access-tokens.js
@@ -60,7 +60,7 @@ module.exports = {
             }, { transaction: t })
 
             // copy the data from the old table to the new table
-            if (dataOriginal.length > 0) {
+            if (dataOriginal?.length > 0) {
                 await context.bulkInsert('AccessTokens2', dataOriginal, { transaction: t })
             }
 


### PR DESCRIPTION
## Description

Fixes an exception raised during migrations.

If the AccessTokens table was empty, this would throw as you cannot bulk insert an empty array into a table.

## Related Issue(s)

#1659 
#1212 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

