### PR TITLE
docs: Reorder doc line order for explict skip step

### DIFF
--- a/docs/user/filenodes.md
+++ b/docs/user/filenodes.md
@@ -7,6 +7,9 @@ Edge devices will store files on its local filesystem.
 
 ## Enabling Persistent File Storage
 
+These nodes are enabled by default on the FlowForge Cloud platform. If you're
+running a self-hosted environment you should follow the next steps.
+
 FlowForge file nodes replace the core Node-RED file nodes. To make use of these
 nodes, the FlowForge platform Administrator must ensure the core file nodes are 
 not loaded.
@@ -16,8 +19,6 @@ section of your FlowForge projects settings under  the **Palette** section.
 
 This setting is modifiable only by a project owner and only if it has not been
 locked in the [project template](concepts.md#project-template) by the platform Administrator.
-
-These nodes are enabled by default on the FlowForge cloud platform.
 
 ## Nodes
 


### PR DESCRIPTION
When reading and executing docs line by line the customers for FF Cloud get confused as they're requested to change things they can't. This commit just changes the order of the docs.

## Checklist

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label