### PR TITLE
ElapsedTime handles timezones and strings

### DIFF
--- a/frontend/src/utils/elapsedTime.js
+++ b/frontend/src/utils/elapsedTime.js
@@ -10,12 +10,24 @@ const periodSeconds = {
     seconds: 1
 }
 
-function dateDiff (to, from) {
-    if (typeof from === 'string') {
-        from = (new Date(from)).getTime()
+function dateDiff (to, from = new Date()) {
+    if (typeof to === 'string') {
+        to = new Date(to)
     }
 
-    let delta = Math.abs(to - from) / 1000
+    if (typeof from === 'string') {
+        from = new Date(from)
+    }
+
+    if (!(to instanceof Date) || isNaN(to)) {
+        throw new RangeError('To field is required to be a valid ISO 8601 string or Date object')
+    }
+
+    if (!(from instanceof Date) || isNaN(from)) {
+        throw new RangeError('From field is required to be a valid ISO 8601 string or Date object')
+    }
+
+    let delta = Math.abs(to.getTime() - from.getTime()) / 1000
 
     const res = {}
 

--- a/frontend/src/utils/elapsedTime.js
+++ b/frontend/src/utils/elapsedTime.js
@@ -10,21 +10,29 @@ const periodSeconds = {
     seconds: 1
 }
 
-function dateDiff (to, from = new Date()) {
-    if (typeof to === 'string') {
+function dateDiff (toStringDateOrNumber, fromStringDateOrNumber = new Date()) {
+    let to = toStringDateOrNumber
+    if (typeof to === 'string' || typeof to === 'number') {
+        if (!isNaN(to)) {
+            to = Number.parseInt(to)
+        }
         to = new Date(to)
     }
 
-    if (typeof from === 'string') {
+    let from = fromStringDateOrNumber
+    if (typeof from === 'string' || typeof from === 'number') {
+        if (!isNaN(from)) {
+            from = Number.parseInt(from)
+        }
         from = new Date(from)
     }
 
     if (!(to instanceof Date) || isNaN(to)) {
-        throw new RangeError('To field is required to be a valid ISO 8601 string or Date object')
+        throw new RangeError(`To date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object, received ${toStringDateOrNumber}`)
     }
 
     if (!(from instanceof Date) || isNaN(from)) {
-        throw new RangeError('From field is required to be a valid ISO 8601 string or Date object')
+        throw new RangeError(`From date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object, received ${fromStringDateOrNumber}`)
     }
 
     let delta = Math.abs(to.getTime() - from.getTime()) / 1000

--- a/test/unit/frontend/utils/elapsedTime.spec.js
+++ b/test/unit/frontend/utils/elapsedTime.spec.js
@@ -36,6 +36,14 @@ describe('elapsedTime', () => {
         expect(elapsedTime('2023-01-01T00:00:00.000+08:00', '2023-01-01T05:30:00Z')).toBe('13 hours, 30 minutes') // PST
     })
 
+    test('converts epoch numbers or strings of numbers into datetime strings', () => {
+        expect(elapsedTime(1672576200000, '2023-01-01T00:00:00Z')).toBe('12 hours, 30 minutes') // 2023-01-01 12:30 UTC
+        expect(elapsedTime('1672576200000', '2023-01-01T00:00:00Z')).toBe('12 hours, 30 minutes') // 2023-01-01 12:30 UTC
+
+        expect(elapsedTime('2023-01-01T00:00:00Z', 1672551000000)).toBe('5 hours, 30 minutes') // 2023-01-01 5:30 UTC
+        expect(elapsedTime('2023-01-01T00:00:00Z', '1672551000000')).toBe('5 hours, 30 minutes') // 2023-01-01 5:30 UTC
+    })
+
     test('compares relative to now if only a to date is passed', () => {
         const tomorrow = new Date()
         tomorrow.setDate(tomorrow.getDate() + 1)
@@ -51,11 +59,11 @@ describe('elapsedTime', () => {
     })
 
     test('raises if invalid dates are passed', () => {
-        expect(() => elapsedTime(null)).toThrowError('To field is required to be a valid ISO 8601 string or Date object')
-        expect(() => elapsedTime('2023-13-01')).toThrowError('To field is required to be a valid ISO 8601 string or Date object')
-        expect(() => elapsedTime(new Date('2023-13-01'))).toThrowError('To field is required to be a valid ISO 8601 string or Date object')
+        expect(() => elapsedTime(null)).toThrowError('To date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object')
+        expect(() => elapsedTime('2023-13-01')).toThrowError('To date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object')
+        expect(() => elapsedTime(new Date('2023-13-01'))).toThrowError('To date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object')
 
-        expect(() => elapsedTime(new Date(), '2023-12-99')).toThrowError('From field is required to be a valid ISO 8601 string or Date object')
-        expect(() => elapsedTime(new Date(), new Date('2023-12-99'))).toThrowError('From field is required to be a valid ISO 8601 string or Date object')
+        expect(() => elapsedTime(new Date(), '2023-12-99')).toThrowError('From date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object')
+        expect(() => elapsedTime(new Date(), new Date('2023-12-99'))).toThrowError('From date is required to be a valid ISO 8601 string, milliseconds since epoch or Date object')
     })
 })

--- a/test/unit/frontend/utils/elapsedTime.spec.js
+++ b/test/unit/frontend/utils/elapsedTime.spec.js
@@ -28,4 +28,34 @@ describe('elapsedTime', () => {
         expect(elapsedTime(new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 1)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('moments')
         expect(elapsedTime(new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 999)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('moments')
     })
+
+    test('converts ISO datetime strings with and without time zone to date time', () => {
+        expect(elapsedTime('2023-01-01', '2023-01-01T05:30:00Z')).toBe('5 hours, 30 minutes') // Local timezone
+        expect(elapsedTime('2023-01-01T00:00:00.000Z', '2023-01-01T05:30:00Z')).toBe('5 hours, 30 minutes') // UTC
+        expect(elapsedTime('2023-01-01T00:00:00.000+05:00', '2023-01-01T05:30:00Z')).toBe('10 hours, 30 minutes') // EST
+        expect(elapsedTime('2023-01-01T00:00:00.000+08:00', '2023-01-01T05:30:00Z')).toBe('13 hours, 30 minutes') // PST
+    })
+
+    test('compares relative to now if only a to date is passed', () => {
+        const tomorrow = new Date()
+        tomorrow.setDate(tomorrow.getDate() + 1)
+        tomorrow.setHours(tomorrow.getHours() + 1)
+
+        expect(elapsedTime(tomorrow)).toBe('1 day')
+
+        const soon = new Date()
+        soon.setMinutes(soon.getMinutes() + 30)
+        soon.setSeconds(soon.getSeconds() + 15)
+
+        expect(elapsedTime(soon)).toBe('30 minutes, 15 seconds')
+    })
+
+    test('raises if invalid dates are passed', () => {
+        expect(() => elapsedTime(null)).toThrowError('To field is required to be a valid ISO 8601 string or Date object')
+        expect(() => elapsedTime('2023-13-01')).toThrowError('To field is required to be a valid ISO 8601 string or Date object')
+        expect(() => elapsedTime(new Date('2023-13-01'))).toThrowError('To field is required to be a valid ISO 8601 string or Date object')
+
+        expect(() => elapsedTime(new Date(), '2023-12-99')).toThrowError('From field is required to be a valid ISO 8601 string or Date object')
+        expect(() => elapsedTime(new Date(), new Date('2023-12-99'))).toThrowError('From field is required to be a valid ISO 8601 string or Date object')
+    })
 })


### PR DESCRIPTION
## Description

ElapsedTime function should support strings in the to/from field and convert it to a date.

## Related Issue(s)

Fixes #1700 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

