### PR TITLE
add option to activate a new snapshot on creation

### DIFF
--- a/frontend/src/pages/project/Snapshots/index.vue
+++ b/frontend/src/pages/project/Snapshots/index.vue
@@ -74,7 +74,7 @@ export default {
         this.fetchData()
     },
     methods: {
-        fetchData: async function (newVal) {
+        fetchData: async function () {
             if (this.project.id) {
                 this.loading = true
                 const deviceCounts = await this.countDevices()
@@ -148,6 +148,9 @@ export default {
         },
         snapshotCreated (snapshot) {
             this.snapshots.unshift(snapshot)
+            // on next tick, update the table data to ensure
+            // the new snapshot is shown and the correct status are shown
+            this.$emit('projectUpdated')
         },
         async downloadSnapshotPackage (snapshot) {
             const ss = await snapshotApi.getSnapshot(this.project.id, snapshot.id)


### PR DESCRIPTION
## Description

Adds a checkbox to permit setting a newly created snapshot as the target snapshot

 
### Demo:
https://user-images.githubusercontent.com/44235289/218812027-6c6e6948-2f47-49ab-9012-8386e4127d77.mp4

### Audit Logs showing activities of above operations...
![image](https://user-images.githubusercontent.com/44235289/218812168-fbf42c47-4898-4d91-9855-5b27d185d6ed.png)


## Related Issue(s)

#1527 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [x] Concepts : Docs are already written in a way I believe cover this: https://flowforge.com/docs/user/concepts/#device
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

