### PR TITLE
Fixes the "View Target Project" button & adds E2E test coverage

### DIFF
--- a/frontend/src/pages/project/Settings/DevOps.vue
+++ b/frontend/src/pages/project/Settings/DevOps.vue
@@ -17,7 +17,7 @@
         <ff-button :disabled="!input.target || loading" data-action="push-stage" @click="deploy()">
             {{ deploying ? `Pushing to "${input.target.name}"...` : 'Push to Stage' }}
         </ff-button>
-        <ff-button kind="secondary" :to="{name: 'Project', params: { 'id': input.target }}" :disabled="!input.target" data-action="view-target-project">
+        <ff-button kind="secondary" :to="{name: 'Project', params: { 'id': input.target?.id }}" :disabled="!input.target" data-action="view-target-project">
             View Target Project
         </ff-button>
     </div>

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -40,6 +40,7 @@ export default {
                 { name: 'Environment', path: './environment' }
             ]
             if (this.hasPermission('project:edit')) {
+                console.log('testing')
                 this.sideNavigation.push({ name: 'DevOps', path: './devops' })
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
                 this.sideNavigation.push({ name: 'Security', path: './security' })

--- a/frontend/src/pages/project/Settings/index.vue
+++ b/frontend/src/pages/project/Settings/index.vue
@@ -40,7 +40,6 @@ export default {
                 { name: 'Environment', path: './environment' }
             ]
             if (this.hasPermission('project:edit')) {
-                console.log('testing')
                 this.sideNavigation.push({ name: 'DevOps', path: './devops' })
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
                 this.sideNavigation.push({ name: 'Security', path: './security' })

--- a/test/e2e/frontend/cypress/tests/projects/staging.spec.js
+++ b/test/e2e/frontend/cypress/tests/projects/staging.spec.js
@@ -44,6 +44,28 @@ describe('FlowForge - Project Settings - DevOps', () => {
         cy.get('.ff-dialog-header').contains('Push to "project-with-devices"')
         cy.get('.ff-dialog-box .ff-btn--primary').contains('Confirm').click()
     })
+
+    it('successfully navigates to the Target Project when the option is selected', () => {
+        navigateToProjectStaging('BTeam', 'project2')
+
+        // buttons should be disabled
+        cy.get('[data-action="push-stage"]').should('be.disabled')
+        cy.get('[data-action="view-target-project"]').should('be.disabled')
+
+        cy.get('[data-el="target-project"] .ff-dropdown-options').should('not.be.visible')
+        cy.get('[data-el="target-project"] .ff-dropdown').click()
+        cy.get('[data-el="target-project"] .ff-dropdown-options').should('be.visible')
+
+        cy.get('[data-el="target-project"] .ff-dropdown-options > .ff-dropdown-option').eq(0).contains('project-with-devices').should('be.visible')
+        cy.get('[data-el="target-project"] .ff-dropdown-options > .ff-dropdown-option').eq(0).click()
+
+        cy.get('[data-action="push-stage"]').should('not.be.disabled')
+        cy.get('[data-action="view-target-project"]').should('not.be.disabled')
+
+        cy.get('[data-action="view-target-project"]').click()
+
+        cy.get('.ff-nested-title').contains('project-with-devices')
+    })
 })
 
 describe('FlowForge shows audit logs', () => {


### PR DESCRIPTION
## Description

[Issue found](https://github.com/flowforge/flowforge/issues/1580#issuecomment-1430366397) when verifying #1580 in Staging.

This fixes the issue by ensuring the `id` is used for the url param, and adds an E2E test to ensure this doesn't get reverted as it previously did.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass