### PR TITLE
Add "Last Seen" status pill

### DIFF
--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -194,24 +194,22 @@ import { mapState } from 'vuex'
 import Alerts from '@/services/alerts'
 import Dialog from '@/services/dialog'
 
-import SectionTopMenu from '@/components/SectionTopMenu'
+import deviceApi from '@/api/devices'
+import projectApi from '@/api/project'
 
-import DeviceCredentialsDialog from '../team/Devices/dialogs/DeviceCredentialsDialog'
-import TeamDeviceCreateDialog from '../team/Devices/dialogs/TeamDeviceCreateDialog'
-
-import SnapshotAssignDialog from './Snapshots/dialogs/SnapshotAssignDialog'
+import permissionsMixin from '@/mixins/Permissions'
 
 import DeploymentLink from './components/cells/DeploymentLink.vue'
+import DeviceCredentialsDialog from '../team/Devices/dialogs/DeviceCredentialsDialog'
+import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
 import DeviceLink from './components/cells/DeviceLink.vue'
 import LastSeen from './components/cells/LastSeen.vue'
 import ProjectEditorLink from './components/cells/ProjectEditorLink.vue'
-import Snapshot from './components/cells/Snapshot.vue'
-
-import deviceApi from '@/api/devices'
-import projectApi from '@/api/project'
-import permissionsMixin from '@/mixins/Permissions'
 import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
-import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
+import SectionTopMenu from '@/components/SectionTopMenu'
+import Snapshot from './components/cells/Snapshot.vue'
+import SnapshotAssignDialog from './Snapshots/dialogs/SnapshotAssignDialog'
+import TeamDeviceCreateDialog from '../team/Devices/dialogs/TeamDeviceCreateDialog'
 
 export default {
     name: 'ProjectDeployments',

--- a/frontend/src/pages/project/Deployments.vue
+++ b/frontend/src/pages/project/Deployments.vue
@@ -191,6 +191,9 @@ import { PlusSmIcon } from '@heroicons/vue/solid'
 import { markRaw } from 'vue'
 import { mapState } from 'vuex'
 
+import Alerts from '@/services/alerts'
+import Dialog from '@/services/dialog'
+
 import SectionTopMenu from '@/components/SectionTopMenu'
 
 import DeviceCredentialsDialog from '../team/Devices/dialogs/DeviceCredentialsDialog'
@@ -208,8 +211,7 @@ import deviceApi from '@/api/devices'
 import projectApi from '@/api/project'
 import permissionsMixin from '@/mixins/Permissions'
 import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
-import Alerts from '@/services/alerts'
-import Dialog from '@/services/dialog'
+import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
 
 export default {
     name: 'ProjectDeployments',
@@ -242,17 +244,17 @@ export default {
         ...mapState('account', ['team', 'teamMembership']),
         columns () {
             return [
-                { label: 'Device', class: ['w-64'], sortable: true, component: { is: markRaw(DeviceLink) } },
-                { label: 'Last Seen', class: ['w-48'], sortable: true, component: { is: markRaw(LastSeen) } },
-                { label: 'Deployed Snapshot', class: ['w-32'], component: { is: markRaw(Snapshot) } },
-                { label: '', class: ['w-20'], component: { is: markRaw(ProjectStatusBadge) } }
+                { label: 'Device', key: 'name', class: ['w-64'], sortable: true, component: { is: markRaw(DeviceLink) } },
+                { label: 'Last Seen', key: 'lastSeenAt', class: ['w-32'], sortable: true, component: { is: markRaw(DeviceLastSeenBadge) } },
+                { label: 'Last Known Status', class: ['w-32'], component: { is: markRaw(ProjectStatusBadge) } },
+                { label: 'Deployed Snapshot', class: ['w-48'], component: { is: markRaw(Snapshot) } }
             ]
         },
         cloudColumns () {
             return [
                 { label: 'Location', class: ['w-64'], component: { is: markRaw(DeploymentLink), extraProps: { disabled: !this.projectRunning || this.isVisitingAdmin } } },
                 { label: 'Last Deployed', class: ['w-48'], component: { is: markRaw(LastSeen), map: { lastSeenSince: 'flowLastUpdatedSince' } } },
-                { label: 'Deployment Status', class: ['w-32'], component: { is: markRaw(ProjectStatusBadge), map: { status: 'meta.state' } } },
+                { label: 'Deployment Status', class: ['w-48'], component: { is: markRaw(ProjectStatusBadge), map: { status: 'meta.state' } } },
                 { label: '', class: ['w-20'], component: { is: markRaw(ProjectEditorLink), extraProps: { disabled: !this.projectRunning || this.isVisitingAdmin } } }
             ]
         },


### PR DESCRIPTION
## Description

Missed adding the new status pill onto the Project > Deployments page. This adds it in.

<img width="1728" alt="Screenshot 2023-02-15 at 15 03 27" src="https://user-images.githubusercontent.com/99246719/219065347-be345265-6f2c-48cf-8133-7ac8dae4d560.png">

## Related Issue(s)

Closes #1709

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

