### PR TITLE
Fix the router-link name for ProjectLink component

### DIFF
--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -91,7 +91,7 @@ const DeviceLink = {
 const ProjectLink = {
     template: `
         <template v-if="project">
-            <router-link :to="{ name: 'ProjectDeployments', params: { id: project.id }}">{{project.name}}</router-link>
+            <router-link :to="{ name: 'ProjectInstances', params: { id: project.id }}">{{ project.name }}</router-link>
         </template>
         <template v-else><span class="italic text-gray-500">unassigned</span></template>`,
     props: ['project']

--- a/frontend/src/pages/team/Settings/Devices.vue
+++ b/frontend/src/pages/team/Settings/Devices.vue
@@ -63,7 +63,7 @@ const TokenFieldFormatter = {
 const ProjectFieldFormatter = {
     template: `
         <template v-if="project">
-            <router-link :to="{ name: 'ProjectDeployments', params: { id: project }}">{{projectName}}</router-link>
+            <router-link :to="{ name: 'ProjectInstances', params: { id: project }}">{{projectName}}</router-link>
         </template>
         <template v-else><span class="italic text-gray-500">Don't assign</span></template>`,
     props: ['project', 'projectName']


### PR DESCRIPTION
## Description

https://d.pr/v/u7qcC7 flagged that when devices are attached to a project, the project name is not showing. Upon investigation, this was introduced in https://github.com/flowforge/flowforge/pull/1711 where we renamed the view "ProjectDeployments" to "ProjectInstances" and so when rendering the `ProjectLink` component, it was failing to render because it couldn't find the destination page (still pointing to `ProjectDeployments`).

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

