### PR TITLE
Fix flaky date-time test failures on GitHub

### DIFF
--- a/test/unit/frontend/mixins/datetime.spec.js
+++ b/test/unit/frontend/mixins/datetime.spec.js
@@ -2,35 +2,40 @@ import { expect } from 'vitest'
 import DateTime from '../../../../frontend/src/mixins/DateTime.js'
 
 describe('DateTime', () => {
+    // Some test envs seem to use non-breaking spaces in the time-format
+    function normalizeWhiteSpace (str) {
+        return str.replace(/\s/g, ' ')
+    }
+
     describe('#formatDateTime', () => {
         // Timezone needs to be set to tests can run anywhere
         test('that a UNIX timestamp is formatted correctly', () => {
-            expect(DateTime.methods.formatDateTime(1652794780548, 'en-US', { timeZone: 'Etc/UTC' })).toBe('May 17, 2022 at 1:39 PM')
+            expect(normalizeWhiteSpace(DateTime.methods.formatDateTime(1652794780548, 'en-US', { timeZone: 'Etc/UTC' }))).toEqual('May 17, 2022 at 1:39 PM')
         })
         test('that a UNIX timestamp is formatted correctly, with an alternative locale', () => {
-            expect(DateTime.methods.formatDateTime(1652794780548, 'en-GB', { timeZone: 'Etc/UTC' })).toBe('17 May 2022 at 13:39')
+            expect(DateTime.methods.formatDateTime(1652794780548, 'en-GB', { timeZone: 'Etc/UTC' })).toEqual('17 May 2022 at 13:39')
         })
     })
 
     describe('#formatDate', () => {
         test('that a UNIX timestamp is formatted correctly', () => {
-            expect(DateTime.methods.formatDate(1652794780548, 'en-US')).toBe('May 17, 2022')
+            expect(DateTime.methods.formatDate(1652794780548, 'en-US')).toEqual('May 17, 2022')
         })
         test('that a UNIX timestamp is formatted correctly, with an alternative locale', () => {
-            expect(DateTime.methods.formatDate(1652794780548, 'en-GB')).toBe('17 May 2022')
+            expect(DateTime.methods.formatDate(1652794780548, 'en-GB')).toEqual('17 May 2022')
         })
         test('that a non-UNIX timestamp is handled appropriately, and returns itself', () => {
-            expect(DateTime.methods.formatDate('not a date')).toBe('not a date')
+            expect(DateTime.methods.formatDate('not a date')).toEqual('not a date')
         })
     })
 
     describe('#formatTime', () => {
         // Timezone needs to be set to tests can run anywhere
         test('that a UNIX timestamp is formatted correctly', () => {
-            expect(DateTime.methods.formatTime(1652794780548, 'en-US', { timeZone: 'Etc/UTC' })).toBe('1:39 PM')
+            expect(normalizeWhiteSpace(DateTime.methods.formatTime(1652794780548, 'en-US', { timeZone: 'Etc/UTC' }))).toEqual('1:39 PM')
         })
         test('that a UNIX timestamp is formatted correctly, with an alternative locale', () => {
-            expect(DateTime.methods.formatTime(1652794780548, 'en-GB', { timeZone: 'Etc/UTC' })).toBe('13:39')
+            expect(DateTime.methods.formatTime(1652794780548, 'en-GB', { timeZone: 'Etc/UTC' })).toEqual('13:39')
         })
     })
 })


### PR DESCRIPTION
## Description

It seems _some_ of the test runners on GitHub use non-breaking spaces to separate parts of the time when formatted with locale:

> May 17, 2022 at 1:39\u202fPM

This PR updates the relevant tests to normalize all whitespace, so the tests pass in all environments.

## Related Issue(s)

Discovered first in https://github.com/flowforge/flowforge/pull/1727

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

