### PR TITLE
Ensure telemetry is enabled for licensed installs

### DIFF
--- a/docs/admin/telemetry.md
+++ b/docs/admin/telemetry.md
@@ -22,6 +22,8 @@ Settings section of the platform UI.
 It is also possible to disable in the `flowforge.yml` configuration file. This
 overrides whatever option is set in the Admin Settings UI.
 
+**IMPORTANT: Licensed installations cannot disable telemetry**
+
 ```yaml
 telemetry:
   enabled: false

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -101,6 +101,7 @@ See [here](./email_providers.md) for example configuration with common email pro
 
 By default, the platform will send anonymous usage information back to us at FlowForge Inc.
 This can be disabled via the Admin Settings in the UI, or turned off in the configuration file with the `telemetry.enabled` option.
+**IMPORTANT: Licensed installations cannot disable telemetry**
 
 Additionally, you can configure your own instance of FlowForge to report back to you on how users are using your instance of FlowForge. FlowForge supports integration with two different services:
 

--- a/forge/monitor/index.js
+++ b/forge/monitor/index.js
@@ -72,11 +72,13 @@ module.exports = fp(async function (app, _opts, next) {
      */
     async function ping () {
         // Only do the ping if:
+        // - The licence is active (EE)
+        // OR
         // - telemetry.enabled has not been set to false in yml file (this overrides any admin set value)
         // - setup:initialised is true - the system has been setup
         // - telemetry:enabled is true - the admin has not disabled the callback
 
-        if (app.config.telemetry.enabled !== false && app.settings.get('setup:initialised') && app.settings.get('telemetry:enabled')) {
+        if (app.license.active() || (app.config.telemetry.enabled !== false && app.settings.get('setup:initialised') && app.settings.get('telemetry:enabled'))) {
             const payload = await gather()
             try {
                 app.log.trace('Sending ping callback')

--- a/forge/monitor/index.js
+++ b/forge/monitor/index.js
@@ -78,7 +78,11 @@ module.exports = fp(async function (app, _opts, next) {
         // - setup:initialised is true - the system has been setup
         // - telemetry:enabled is true - the admin has not disabled the callback
 
-        if (app.license.active() || (app.config.telemetry.enabled !== false && app.settings.get('setup:initialised') && app.settings.get('telemetry:enabled'))) {
+        const isLicensed = app.license.active()
+        const isInitialised = app.settings.get('setup:initialised')
+        const isTelemetryEnabled = (app.config.telemetry.enabled !== false && app.settings.get('telemetry:enabled'))
+
+        if (isInitialised && (isLicensed || isTelemetryEnabled)) {
             const payload = await gather()
             try {
                 app.log.trace('Sending ping callback')

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -28,7 +28,7 @@ module.exports = async function (app) {
 
             if (request.session.User.admin) {
                 response['platform:licensed'] = isLicensed
-                response['telemetry:enabled'] = isLicensed || app.settings.get('telemetry:enabled')
+                response['telemetry:enabled'] = app.settings.get('telemetry:enabled')
                 response['user:signup'] = app.settings.get('user:signup')
                 response['user:reset-password'] = app.settings.get('user:reset-password')
                 response['user:team:auto-create'] = app.settings.get('user:team:auto-create')

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -12,6 +12,7 @@ module.exports = async function (app) {
         //   to change via the UI
 
         if (request.session && request.session.User) {
+            const isLicensed = app.license.active()
             const response = {
                 'team:user:invite:external': app.settings.get('team:user:invite:external') && app.postoffice.enabled(),
                 'team:create': app.settings.get('team:create'),
@@ -26,7 +27,8 @@ module.exports = async function (app) {
             }
 
             if (request.session.User.admin) {
-                response['telemetry:enabled'] = app.settings.get('telemetry:enabled')
+                response['platform:licensed'] = isLicensed
+                response['telemetry:enabled'] = isLicensed || app.settings.get('telemetry:enabled')
                 response['user:signup'] = app.settings.get('user:signup')
                 response['user:reset-password'] = app.settings.get('user:reset-password')
                 response['user:team:auto-create'] = app.settings.get('user:team:auto-create')

--- a/forge/settings/index.js
+++ b/forge/settings/index.js
@@ -33,6 +33,9 @@ module.exports = fp(async function (app, _opts, next) {
 
     const settingsApi = {
         get: (key) => {
+            if (key === 'telemetry:enabled' && app.license.active()) {
+                return true
+            }
             return settings[key]
         },
         set: async (key, value) => {

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -88,8 +88,8 @@
                     sent to that email address.</p>
             </template>
         </FormRow>
-        <FormHeading>Platform</FormHeading>
-        <FormRow v-model="input['telemetry:enabled']" type="checkbox" :disabled="isLicensed">
+        <FormHeading v-if="!isLicensed">Platform</FormHeading>
+        <FormRow v-model="input['telemetry:enabled']" type="checkbox" v-if="!isLicensed">
             Enable collection of anonymous statistics
             <template #description>
                 <p>
@@ -100,7 +100,6 @@
                     For more information about the data we collect and how it is used,
                     please see our <a class="forge-link" href="https://github.com/flowforge/flowforge/tree/main/docs/admin/telemetry.md" target="_blank">Usage Data Collection Policy</a>
                 </p>
-                <p v-if="isLicensed"><b>NOTE: Telemetry is always enabled for licensed installs.</b></p>
             </template>
         </FormRow>
         <div>

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -89,7 +89,7 @@
             </template>
         </FormRow>
         <FormHeading>Platform</FormHeading>
-        <FormRow v-model="input['telemetry:enabled']" type="checkbox">
+        <FormRow v-model="input['telemetry:enabled']" type="checkbox" :disabled="isLicensed">
             Enable collection of anonymous statistics
             <template #description>
                 <p>
@@ -100,6 +100,7 @@
                     For more information about the data we collect and how it is used,
                     please see our <a class="forge-link" href="https://github.com/flowforge/flowforge/tree/main/docs/admin/telemetry.md" target="_blank">Usage Data Collection Policy</a>
                 </p>
+                <p v-if="isLicensed"><b>NOTE: Telemetry is always enabled for licensed installs.</b></p>
             </template>
         </FormRow>
         <div>
@@ -151,6 +152,9 @@ export default {
     },
     computed: {
         ...mapState('account', ['features', 'settings']),
+        isLicensed () {
+            return !!this.settings['platform:licensed']
+        },
         tcsDate () {
             const _tcsDate = this.input['user:tcs-date']
             if (_tcsDate && (typeof _tcsDate === 'string' || (_tcsDate instanceof Date && !isNaN(_tcsDate) && _tcsDate > 0))) {

--- a/test/system/001-setup_spec.js
+++ b/test/system/001-setup_spec.js
@@ -141,6 +141,27 @@ describe('First run setup', function () {
             forge.settings.get('setup:initialised').should.be.false()
         })
     })
+
+    describe('Apply settings (pre-license)', function () {
+        it('should accept settings', async function () {
+            forge.settings.get('telemetry:enabled').should.be.true()
+
+            const response = await forge.inject({
+                method: 'POST',
+                url: '/setup/settings',
+                payload: {
+                    _csrf: CSRF_TOKEN,
+                    telemetry: false
+                },
+                cookies: CSRF_COOKIE
+            })
+            const body = response.json()
+            body.should.have.property('status', 'okay')
+            // Telemetry can be disabled because license is not yet applied
+            forge.settings.get('telemetry:enabled').should.be.false()
+            forge.settings.get('setup:initialised').should.be.false()
+        })
+    })
     describe('Upload license', function () {
         it('should reject missing csrf - secret', async function () {
             const response = await forge.inject({
@@ -213,7 +234,7 @@ describe('First run setup', function () {
         })
     })
 
-    describe('Apply settings', function () {
+    describe('Apply settings (post-license)', function () {
         it('should reject missing csrf - secret', async function () {
             const response = await forge.inject({
                 method: 'POST',
@@ -239,7 +260,7 @@ describe('First run setup', function () {
             body.should.have.property('message').match(/Invalid csrf token/)
         })
 
-        it('should accept settings', async function () {
+        it('should not disable telemetry', async function () {
             forge.settings.get('telemetry:enabled').should.be.true()
 
             const response = await forge.inject({
@@ -253,7 +274,8 @@ describe('First run setup', function () {
             })
             const body = response.json()
             body.should.have.property('status', 'okay')
-            forge.settings.get('telemetry:enabled').should.be.false()
+            // Telemetry should not be disabled because license is active
+            forge.settings.get('telemetry:enabled').should.be.true()
             forge.settings.get('setup:initialised').should.be.false()
         })
     })

--- a/test/unit/forge/routes/api/settings_spec.js
+++ b/test/unit/forge/routes/api/settings_spec.js
@@ -56,4 +56,67 @@ describe('Settings API', function () {
             settings.features.should.have.property('test-private-feature', 456)
         })
     })
+    describe('Telemetry Setting', function () {
+        const TELEMETRY_KEY = 'telemetry:enabled'
+        it('Can disable telemetry when unlicensed', async function () {
+            app.settings.set(TELEMETRY_KEY, true)
+            app.settings.get(TELEMETRY_KEY).should.be.true()
+
+            await app.inject({
+                method: 'PUT',
+                url: settingsURL,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    [TELEMETRY_KEY]: false
+                }
+            })
+            app.settings.get(TELEMETRY_KEY).should.be.false()
+            const response = await app.inject({
+                method: 'GET',
+                url: settingsURL,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const settings = response.json()
+            settings.should.have.property(TELEMETRY_KEY, false)
+        })
+        it('Cannot disable telemetry when licensed', async function () {
+            /*
+                License Details:
+                {
+                    "iss": "FlowForge Inc.",
+                    "sub": "FlowForge Inc.",
+                    "nbf": 1662422400,
+                    "exp": 7986902399,
+                    "note": "Development-mode Only. Not for production",
+                    "users": 4,
+                    "teams": 5,
+                    "projects": 6,
+                    "devices": 7,
+                    "dev": true
+                }
+            */
+            await app.license.apply('eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo0LCJ0ZWFtcyI6NSwicHJvamVjdHMiOjYsImRldmljZXMiOjcsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNDc2OTg5fQ.XJfAKSKH0ndmrD8z-GX1eWr7OdMnStIdP0ebtC3mKWvnT22TZK0pUx0jDMPFRROFDAJo_eh50T5OUHHfwSp1YQ')
+            app.settings.set(TELEMETRY_KEY, true)
+            app.settings.get(TELEMETRY_KEY).should.be.true()
+
+            await app.inject({
+                method: 'PUT',
+                url: settingsURL,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    [TELEMETRY_KEY]: false
+                }
+            })
+            app.settings.get(TELEMETRY_KEY).should.be.true()
+            const response = await app.inject({
+                method: 'GET',
+                url: settingsURL,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const settings = response.json()
+            settings.should.have.property(TELEMETRY_KEY, true)
+        })
+    })
 })


### PR DESCRIPTION
## Description





<details closed>
<summary>Outdated (click to reveal)</summary>

#### pre 2023/02/22
1. Ensure `telemetry:enabled` setting is always true if product is licensed
2. Add `platform:licensed` boolean setting for the following 2 items...
3. Disable telemetry setting checkbox
4. Add info below telemetry setting to indicate it is always enabled for Licensed installs

![image](https://user-images.githubusercontent.com/44235289/220457667-bc3a692f-fb16-44fd-8dff-8c335b508c11.png)

</details>


<details open>
<summary>Updated 2023/02/22</summary>

1. Ensure `telemetry:enabled` setting is always true if product is licensed (both client and server side)
2. Add `platform:licensed` boolean (readonly) setting 
3. Use  `platform:licensed` setting to hide telemetry setting checkbox and parent group title

![image](https://user-images.githubusercontent.com/44235289/220573634-caa2bd95-d17a-44f8-b602-357947d96721.png)

![image](https://user-images.githubusercontent.com/44235289/220573735-2834036a-efd8-48bd-95db-dc22831980ce.png)


</details>



## Related Issue(s)

#1640

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

