### PR TITLE
Audit log license overage

### DIFF
--- a/forge/auditLog/platform.js
+++ b/forge/auditLog/platform.js
@@ -42,6 +42,20 @@ module.exports = {
                 },
                 async inspected (actionedBy, error, license) {
                     await log('platform.license.inspected', actionedBy, generateBody({ error, license }))
+                },
+                /**
+                * Log the update of an overage by a resource
+                * @param {number|object|'system'} actionedBy A user object or a user id. NOTE: 0 will denote the "system", >0 denotes a user
+                * @param {*} error An error to log (pass null if no error)
+                * @param {Object} options
+                * @param {'users'|'teams'|'projects'|'devices'} options.resource The resource that has overage
+                * @param {number} options.count The current count of the resource
+                * @param {number} options.limit The limit of the resource
+                */
+                async overage (actionedBy, error, { resource, count, limit } = {}) {
+                    ['users', 'teams', 'projects', 'devices'].includes(resource) || (resource = resource || 'unknown')
+                    const info = { resource, count, limit }
+                    await log('platform.license.overage', actionedBy, generateBody({ error, info }))
                 }
             }
         }

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -48,6 +48,12 @@ module.exports = {
                     }
                 }
             },
+            afterCreate: async (device, options) => {
+                const { devices } = await app.license.usage('devices')
+                if (devices.count > devices.limit) {
+                    await app.auditLog.Platform.platform.license.overage('system', null, devices)
+                }
+            },
             beforeSave: async (device, options) => {
                 // since `id`, `name` and `type` are added as FF_DEVICE_xx env vars, we
                 // should update the settings checksum if they are modified

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -109,6 +109,12 @@ module.exports = {
                     }
                 }
             },
+            afterCreate: async (project, opts) => {
+                const { projects } = await app.license.usage('projects')
+                if (projects.count > projects.limit) {
+                    await app.auditLog.Platform.platform.license.overage('system', null, projects)
+                }
+            },
             afterDestroy: async (project, opts) => {
                 await M.AccessToken.destroy({
                     where: {

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -29,6 +29,12 @@ module.exports = {
                     }
                 }
             },
+            afterCreate: async (team, options) => {
+                const { teams } = await app.license.usage('teams')
+                if (teams.count > teams.limit) {
+                    await app.auditLog.Platform.platform.license.overage('system', null, teams)
+                }
+            },
             beforeSave: (team, options) => {
                 if (!team.avatar) {
                     team.avatar = generateTeamAvatar(team.name)

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -66,6 +66,12 @@ module.exports = {
                     user.name = user.username
                 }
             },
+            afterCreate: async (user, options) => {
+                const { users } = await app.license.usage('users')
+                if (users.count > users.limit) {
+                    await app.auditLog.Platform.platform.license.overage('system', null, users)
+                }
+            },
             beforeUpdate: async (user) => {
                 if (user._previousDataValues.admin === true && user.admin === false) {
                     const currentAdmins = await app.db.models.User.scope('admins').findAll()

--- a/forge/housekeeper/index.js
+++ b/forge/housekeeper/index.js
@@ -59,6 +59,7 @@ module.exports = fp(async function (app, _opts, next) {
     }
 
     await registerTask(require('./tasks/expireTokens'))
+    await registerTask(require('./tasks/licenseOverage'))
 
     app.decorate('housekeeper', {
         registerTask

--- a/forge/housekeeper/tasks/licenseOverage.js
+++ b/forge/housekeeper/tasks/licenseOverage.js
@@ -1,0 +1,24 @@
+module.exports = {
+    name: 'licenseOverage',
+    startup: true,
+    schedule: '@weekly', // Run once a week, sunday midnight
+    run: async function (app) {
+        try {
+            const { users, teams, projects, devices } = await app.license.usage()
+            if (users?.count > users?.limit) {
+                await app.auditLog.Platform.platform.license.overage('system', null, users)
+            }
+            if (teams?.count > teams?.limit) {
+                await app.auditLog.Platform.platform.license.overage('system', null, teams)
+            }
+            if (projects?.count > projects?.limit) {
+                await app.auditLog.Platform.platform.license.overage('system', null, projects)
+            }
+            if (devices?.count > devices?.limit) {
+                await app.auditLog.Platform.platform.license.overage('system', null, devices)
+            }
+        } catch (error) {
+            app.log.error(error)
+        }
+    }
+}

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -13,6 +13,7 @@
     <UserGroupIcon v-if="icon === 'users'" class="ff-icon text-teal-700" />
     <CurrencyDollarIcon v-if="icon === 'billing'" class="ff-icon text-yellow-500" />
     <KeyIcon v-if="icon === 'key'" class="ff-icon text-green-700" />
+    <KeyIcon v-if="icon === 'overage'" class="ff-icon text-red-700" />
     <LoginIcon v-if="icon === 'login'" class="ff-icon text-blue-700" />
     <LogoutIcon v-if="icon === 'logout'" class="ff-icon text-gray-600" />
     <ExclamationCircleIcon v-if="icon === 'error'" class="ff-icon text-red-500" />
@@ -86,6 +87,9 @@ const iconMap = {
         'platform.license.inspected',
         'platform.licence.apply',
         'platform.licence.inspect'
+    ],
+    overage: [
+        'platform.license.overage'
     ],
     settings: [
         'project.copied',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -218,7 +218,12 @@
         <span v-if="!error && entry.body?.license">A license was inspected with the following details: {{ entry.body.license }}</span>
         <span v-else-if="!error">License data not found in audit entry.</span>
     </template>
-    <!-- Platform License Events -->
+    <template v-else-if="entry.event === 'platform.license.overage'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span v-if="!error && typeof entry.body?.info === 'object'">Type: {{entry.body.info.resource }}, Count: {{ entry.body.info.count }}, Limit: {{ entry.body.info.limit }}</span>
+        <span v-else-if="!error">License data not found in audit entry.</span>
+    </template>
+    <!-- Platform project type Events -->
     <template v-else-if="entry.event === 'platform.project-type.created'">
         <label>{{ AuditEvents[entry.event] }}</label>
         <span v-if="!error && entry.body?.projectType">A new project type '{{ entry.body.projectType }}' has been created.</span>

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -220,7 +220,7 @@
     </template>
     <template v-else-if="entry.event === 'platform.license.overage'">
         <label>{{ AuditEvents[entry.event] }}</label>
-        <span v-if="!error && typeof entry.body?.info === 'object'">Type: {{entry.body.info.resource }}, Count: {{ entry.body.info.count }}, Limit: {{ entry.body.info.limit }}</span>
+        <span v-if="!error && typeof entry.body?.info === 'object'">Type: '{{entry.body.info.resource }}', Limit: {{ entry.body.info.limit }}, Count: {{ entry.body.info.count }}</span>
         <span v-else-if="!error">License data not found in audit entry.</span>
     </template>
     <!-- Platform project type Events -->

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -60,6 +60,7 @@
         "platform.licence.apply": "License Applied",
         "platform.license.inspected": "License Inspected",
         "platform.licence.inspect": "License Inspected",
+        "platform.license.overage": "License Overage",
         "platform.project-type.created": "New Project Type Created",
         "platform.project-type.deleted": "Project Type Deleted",
         "platform.project-type.updated": "Project Type Updated",

--- a/test/unit/forge/auditLog/platform_spec.js
+++ b/test/unit/forge/auditLog/platform_spec.js
@@ -189,4 +189,17 @@ describe('Audit Log > Platform', async function () {
         logEntry.body.license.should.only.have.keys('key')
         logEntry.body.license.key.should.equal('a-license')
     })
+
+    it('Provides a logger for a platform license overage', async function () {
+        // platform - license - overage
+        const overage = { resource: 'users', count: 6, limit: 5 }
+        await platformLogger.platform.license.overage('system', null, overage)
+
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'platform.license.overage')
+        logEntry.should.have.property('scope', { id: null, type: 'platform' })
+        logEntry.should.have.property('trigger', { id: 'system', type: 'system', name: 'Forge Platform' })
+        logEntry.should.have.property('body').and.be.an.Object()
+        logEntry.body.should.have.property('info', overage)
+    })
 })


### PR DESCRIPTION
## Description

NOTE: This PR depends on functionality added in #1743.  This PR is based of 1743 & therefore should be merged FIRST.

Audit logging & related UI updates for overages:
* Adds logging handler
* Logs overages at point of creation
* Utilises the housekeeper to log any overages at both startup and weekly points
* Provides friendly text and icon for activity log
* Adds test for new logger

Update: Swap limit and count wording for better readability following 1:1 review with @joepavitt 
![image](https://user-images.githubusercontent.com/44235289/220922200-7ee58fc6-804d-4184-b350-3befbc27e2e8.png)



## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

