### PR TITLE
Move registration of `monitor` to after registration of `ee`

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -53,8 +53,6 @@ module.exports = async (options = {}) => {
         await server.register(db)
         // Settings
         await server.register(settings)
-        // Monitor
-        await server.register(monitor)
         // License
         await server.register(license)
         // Audit Logging
@@ -94,6 +92,9 @@ module.exports = async (options = {}) => {
         await server.register(containers)
 
         await server.register(ee)
+
+        // Monitor
+        await server.register(monitor)
 
         await server.ready()
 


### PR DESCRIPTION
fixes #1681

## Description

Move the registration of the `monitor` module to after the `ee` module to fix startup timing issue

## Related Issue(s)

#1681 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

