### PR TITLE
Increase http body size to 5mb

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -23,6 +23,7 @@ module.exports = async (options = {}) => {
         loggerLevel = options.config.logging.level || 'info'
     }
     const server = fastify({
+        bodyLimit: 5242880,
         maxParamLength: 500,
         trustProxy: true,
         logger: {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Increase max http body size to 5mb, this matches the Node-RED default and allows larger flows to be stored using the storage API

## Related Issue(s)

<!-- What issue does this PR relate to? -->
fixes #1760

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

