### PR TITLE
Introduce fake log entries for the stub driver

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -222,7 +222,35 @@ module.exports = {
      * @return {array} logs
      */
     logs: async (project) => {
-        return []
+        const oneHour = 360000
+
+        return [
+            {
+                level: 'system',
+                msg: 'Fake Log Entry',
+                ts: `${Date.now() - oneHour}`
+            },
+            {
+                level: 'system',
+                msg: 'Starting Node-RED',
+                ts: `${Date.now() - oneHour / 2}`
+            },
+            {
+                level: 'info',
+                msg: '\n\nMulti Line Message\n===================\n',
+                ts: `${Date.now() - oneHour / 4}`
+            },
+            {
+                level: 'warn',
+                msg: 'This is the voice of the Mysterons. We know that you can hear us Earthmen.',
+                ts: `${Date.now() - oneHour / 5}`
+            },
+            {
+                level: 'error',
+                msg: 'Captain Scarlet is indestructible',
+                ts: `${Date.now()}`
+            }
+        ]
     },
     /**
      * Shutdown Driver


### PR DESCRIPTION
## Description

Previously this screen was always blank when using stub driver.

<img width="806" alt="Screenshot 2023-03-06 at 17 01 14" src="https://user-images.githubusercontent.com/507155/223164081-e27682a7-c01a-45c1-bc5b-270705f0c4c3.png">

## Related Issue(s)

None

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

