### PR TITLE
Add IF EXISTS to DROP DATABASE in tests

### DIFF
--- a/test/node_modules/flowforge-test-utils/index.js
+++ b/test/node_modules/flowforge-test-utils/index.js
@@ -45,7 +45,7 @@ async function setupApp (config = {}) {
             })
             await client.connect()
             try {
-                await client.query(`DROP DATABASE ${config.db.database}`)
+                await client.query(`DROP DATABASE IF EXISTS ${config.db.database}`)
             } catch (err) {
                 // Don't mind if it doesn't exist
             }


### PR DESCRIPTION
## Description

Add `IF EXISTS` to `DROP DATABASE`  in `flowforge-test-utils` to make operations cleaner

## Related Issue(s)

Discovered while debugging tests issue with @hardillb 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 
