### PR TITLE
docs: Add Team library RBAC to table

### DIFF
--- a/docs/user/shared-library.md
+++ b/docs/user/shared-library.md
@@ -11,6 +11,8 @@ For example, you may have a standard set of flows that you want each project to
 include. By exporting them to the Team Library, you can quickly import them into
 new projects.
 
+A short video is available on [how to use this feature](https://www.youtube.com/watch?v=B7XK3TUklUU).
+
 ### Exporting flows
 
 To export flows to the library within the Node-RED editor:
@@ -20,7 +22,6 @@ To export flows to the library within the Node-RED editor:
 3. Select the `Team Library` tab
 4. Enter a name for the library entry
 5. Click Export
-
 
 ### Importing flows
 

--- a/docs/user/team/README.md
+++ b/docs/user/team/README.md
@@ -60,6 +60,10 @@ table summaries what actions are available to the different roles.
 | • Invite User                        | ✓     | -      | -      |
 | • Change Role                        | ✓     | -      | -      |
 | • Remove User from Team              | ✓     | - §1   | - §1   |
+| **Team Library**                     |       |        |        |
+| • Add an item                        | ✓     | ✓      | -      |
+| • Modify an item                     | ✓     | ✓      | -      |
+| • Delete an item                     | ✓     | ✓      | -      |
 
 Notes:
  - **§1** A user in any role can remove themselves from a team


### PR DESCRIPTION
Came up in a call today what the permissions were, which had gone undocumented. This change documents them.

## Checklist

 - [X] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [X] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [X] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

