### PR TITLE
Application Instances: UX tweaks

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -49,7 +49,7 @@
                         <template #icon-right>
                             <PlusSmIcon />
                         </template>
-                        <span class="font-normal">Add Device</span>
+                        Add Device
                     </ff-button>
                 </template>
                 <template v-if="devices.size === 0" #table>
@@ -131,13 +131,13 @@ import { markRaw } from 'vue'
 
 import DeviceLastSeenBadge from '../pages/device/components/DeviceLastSeenBadge'
 import SnapshotAssignDialog from '../pages/instance/Snapshots/dialogs/SnapshotAssignDialog'
-import DeviceCredentialsDialog from '../pages/team/Devices/dialogs/DeviceCredentialsDialog'
-import TeamDeviceCreateDialog from '../pages/team/Devices/dialogs/TeamDeviceCreateDialog'
 
 import ProjectStatusBadge from '../pages/project/components/ProjectStatusBadge'
 import DeviceLink from '../pages/project/components/cells/DeviceLink.vue'
 import InstanceInstancesLink from '../pages/project/components/cells/InstanceInstancesLink.vue'
 import Snapshot from '../pages/project/components/cells/Snapshot.vue'
+import DeviceCredentialsDialog from '../pages/team/Devices/dialogs/DeviceCredentialsDialog'
+import TeamDeviceCreateDialog from '../pages/team/Devices/dialogs/TeamDeviceCreateDialog'
 
 import deviceApi from '@/api/devices'
 import instanceApi from '@/api/instances'

--- a/frontend/src/components/DropdownMenu.vue
+++ b/frontend/src/components/DropdownMenu.vue
@@ -24,20 +24,6 @@
                         <template v-else-if="item.disabled">
                             <div :class="[active ? 'bg-gray-200' : '', item.selected? 'bg-gray-100':'', 'block px-4 py-2 text-sm',...(item.class||[]),'opacity-20']">{{ item.name }}</div>
                         </template>
-                        <template v-else-if="item.external">
-                            <a :href="item.link" target="_blank" :class="[active ? 'bg-gray-200' : '', item.selected? 'bg-gray-100':'', 'block px-4 py-2 text-sm text-gray-700',...(item.class||[])]">
-                                <component v-if="item.icon" class="w-4 inline" :is="item.icon"></component>
-                                <img v-if="item.imgUrl" :src="item.imgUrl" class="h-4 v-4 inline rounded mr-1"/>
-                                {{ item.name }}
-                            </a>
-                        </template>
-                        <template v-else-if="item.link || item.path">
-                            <router-link :to="item.link || item" :class="[active ? 'bg-gray-200' : '', item.selected? 'bg-gray-100':'', 'block px-4 py-2 text-sm text-gray-700',...(item.class||[])]">
-                                <component v-if="item.icon" class="w-4 inline" :is="item.icon"></component>
-                                <img v-if="item.imgUrl" :src="item.imgUrl" class="h-4 v-4 inline rounded mr-1"/>
-                                {{ item.name }}
-                            </router-link>
-                        </template>
                         <template v-else>
                             <a @click="item.action" :class="[active ? 'bg-gray-200' : '', item.selected? 'bg-gray-100':'', 'block px-4 py-2 text-sm text-gray-700',...(item.class||[])]" :data-action="`menu-${item.name.toLowerCase()}`">
                                 <component v-if="item.icon" class="w-4 inline" :is="item.icon"></component>
@@ -45,7 +31,6 @@
                                 {{ item.name }}
                             </a>
                         </template>
-
                     </MenuItem>
                 </div>
             </MenuItems>
@@ -56,6 +41,7 @@
 <script>
 /**
  * This component is deprecated and should not be used
+ * ff-dropdown from forge-ui-components is the intended replacement
  */
 import { ref } from 'vue'
 import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'

--- a/frontend/src/components/DropdownMenu.vue
+++ b/frontend/src/components/DropdownMenu.vue
@@ -4,7 +4,7 @@
             <MenuButton :class="[buttonClass ? buttonClass : 'forge-button', !hasLabel?'px-1':'']">
                 <slot></slot>
                 <span class="sr-only">{{ alt }}</span>
-                <ChevronDownIcon :class="[hasLabel?'ml-2 -mr-1 ':'','w-5 h-5 my-1 text-gray-400']" aria-hidden="true" />
+                <ChevronDownIcon class="ff-btn--icon ff-btn--icon-right" aria-hidden="true" />
             </MenuButton>
         </div>
         <transition
@@ -52,8 +52,11 @@
         </transition>
     </HeadlessUIMenu>
 </template>
-<script>
 
+<script>
+/**
+ * This component is deprecated and should not be used
+ */
 import { ref } from 'vue'
 import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'
 import { ChevronDownIcon } from '@heroicons/vue/solid'

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -4,14 +4,14 @@
         @submit.prevent="$emit('on-submit', input)"
     >
         <SectionTopMenu
-            :hero="creatingNew ? 'Create a new instance' : 'Update Instance'"
+            :hero="creatingNew ? 'Create a new Application' : 'Update Instance'"
         />
 
         <!-- Form title -->
         <div class="mb-8 text-sm text-gray-500">
             <template v-if="creatingNew">
                 <template v-if="!isCopyProject">
-                    Let's get your new Node-RED instances setup in no time.
+                    Let's get your new Node-RED application and first instance setup in no time.
                 </template>
             </template>
             <template v-else>
@@ -19,7 +19,7 @@
             </template>
         </div>
 
-        <!-- Instance Name -->
+        <!-- Application Name -->
         <div>
             <FormRow
                 v-model="input.name"
@@ -28,13 +28,14 @@
                 data-form="project-name"
             >
                 <template #default>
-                    Instance Name
+                    Application Name
                 </template>
                 <template
                     v-if="creatingNew"
                     #description
                 >
-                    Please note, currently, instance names cannot be changed once a instance is created
+                    This will be shared by the application and it's first instance<br>
+                    Please note, currently, names cannot be changed once created
                 </template>
                 <template
                     v-if="creatingNew"
@@ -178,7 +179,7 @@
                 type="submit"
             >
                 <template v-if="creatingNew">
-                    Create Instance
+                    Create Application
                 </template>
                 <template v-else>
                     Confirm Changes
@@ -379,7 +380,7 @@ export default {
         }
 
         if (this.projectTypes.length === 0) {
-            this.errors.projectType = 'No project types available. Ask an Administrator to create a new project type'
+            this.errors.projectType = 'No instance types available. Ask an Administrator to create a new instance type'
         } else if (activeProjectTypeCount === 1) {
             this.input.projectType = this.projectTypes.find(pt => !pt.disabled).id
         }
@@ -443,7 +444,7 @@ export default {
 
             if (this.stacks.length === 0) {
                 this.input.stack = null
-                this.errors.stack = 'No stacks available for this project type. Ask an Administrator to create a new stack definition'
+                this.errors.stack = 'No stacks available for this instance type. Ask an Administrator to create a new stack definition'
                 return
             }
 

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -45,7 +45,7 @@
                             </span>
                         </button>
                     </div>
-                    <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" alt="Open actions menu" :options="actionsDropdownOptions" data-action="open-actions">Actions</DropdownMenu>
+                    <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
                 </div>
             </template>
         </SectionTopMenu>
@@ -143,7 +143,7 @@ export default {
         editorAvailable () {
             return this.instanceRunning
         },
-        actionsDropdownOptions: function () {
+        actionsDropdownOptions () {
             const flowActionsDisabled = !(this.instance.meta && this.instance.meta.state !== 'suspended')
 
             const result = [

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -9,9 +9,6 @@
                 <p>It will always run the latest flow deployed in Node-RED and use the latest credentials and runtime settings defined in the Projects settings.</p>
                 <p>To edit an Applications flow, open the editor of the Instance.</p>
             </template>
-            <template #tools>
-                <ff-button v-if="hasPermission('project:create')" data-action="create-project-1" kind="primary" size="small" :to="`/team/${team.slug}/projects/create`" data-nav="create-instance"><template #icon-left><PlusSmIcon /></template>Create Instance</ff-button>
-            </template>
         </SectionTopMenu>
 
         <div class="space-y-6 mb-12">
@@ -92,8 +89,8 @@ import { PlusSmIcon } from '@heroicons/vue/solid'
 import { markRaw } from 'vue'
 import { mapState } from 'vuex'
 
-import SectionTopMenu from '../../components/SectionTopMenu'
 import DevicesBrowser from '../../components/DevicesBrowser'
+import SectionTopMenu from '../../components/SectionTopMenu'
 
 import ProjectStatusBadge from './components/ProjectStatusBadge'
 import DeploymentName from './components/cells/DeploymentName.vue'

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -172,7 +172,7 @@ export default {
         },
         checkAccess () {
             this.navigation = [
-                { label: 'Overview', path: `/project/${this.project.id}/overview`, tag: 'project-overview', icon: ProjectsIcon },
+                { label: 'Instances', path: `/project/${this.project.id}/instances`, tag: 'project-overview', icon: ProjectsIcon },
                 { label: 'Audit Log', path: `/project/${this.project.id}/activity`, tag: 'project-activity', icon: ViewListIcon },
                 { label: 'Node-RED Logs', path: `/project/${this.project.id}/logs`, tag: 'project-logs', icon: TerminalIcon },
                 { label: 'Settings', path: `/project/${this.project.id}/settings`, tag: 'project-settings', icon: CogIcon }

--- a/frontend/src/pages/project/routes.js
+++ b/frontend/src/pages/project/routes.js
@@ -14,7 +14,7 @@ export default [
     {
         path: '/project/:id',
         redirect: to => {
-            return `/project/${to.params.id}/overview`
+            return `/project/${to.params.id}/instances`
         },
         name: 'Project',
         component: Project,
@@ -22,7 +22,13 @@ export default [
             title: 'Application - Overview'
         },
         children: [
-            { path: 'overview', component: ProjectOverview },
+            {
+                path: 'instances',
+                component: ProjectOverview,
+                meta: {
+                    title: 'Application - Instances'
+                }
+            },
             {
                 path: 'settings',
                 component: ProjectSettings,

--- a/test/e2e/frontend/cypress/tests/projects/overview.spec.js
+++ b/test/e2e/frontend/cypress/tests/projects/overview.spec.js
@@ -11,7 +11,7 @@ describe('FlowForge - Project - Overview', () => {
                 const project = response.body.projects.find(
                     (project) => project.name === projectName
                 )
-                cy.visit(`/project/${project.id}/overview`)
+                cy.visit(`/project/${project.id}/instances`)
                 cy.wait('@getProjectDevices')
             })
     }


### PR DESCRIPTION
## Description

Fixes all but one of the UX polish tasks for application instances outlined in #1802

- Renames the Application 'Overview' tab to Application 'Instances'
- Create Application page now refers to applications
- No create instance button (only via create application)
- Styling changes for buttons for consistency

It does not get rename Instances > Remote Instances to Instances > Devices as further conversation involving @joepavitt will  happen this afternoon first.

![Screenshot 2023-03-13 at 13 15 15](https://user-images.githubusercontent.com/507155/224704915-579c7c74-2317-4819-aace-f9ce46a0ce70.png)
![Screenshot 2023-03-13 at 13 41 32](https://user-images.githubusercontent.com/507155/224704907-8924ab4b-497e-41a2-a7eb-f9e6e6e2618a.png)
![Screenshot 2023-03-13 at 13 41 40](https://user-images.githubusercontent.com/507155/224704901-bd791078-1612-4f12-9b34-e42aaa100002.png)


## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1802

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

