### PR TITLE
Application Instances: Team Devices

### DIFF
--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -65,6 +65,11 @@ const getInstanceDevices = async (instanceId, cursor, limit) => {
     const res = await client.get(url)
     res.data.devices.forEach(device => {
         device.lastSeenSince = device.lastSeenAt ? daysSince(device.lastSeenAt) : ''
+
+        // TODO: Remove this temporary copy of application over instance
+        if (device.project) {
+            device.instance = device.project
+        }
     })
     return res.data
 }

--- a/frontend/src/api/project.js
+++ b/frontend/src/api/project.js
@@ -70,6 +70,11 @@ const getProjectDevices = async (projectId, cursor, limit) => {
     const res = await client.get(url)
     res.data.devices.forEach(device => {
         device.lastSeenSince = device.lastSeenAt ? daysSince(device.lastSeenAt) : ''
+
+        // TODO: Remove this temporary copy of application over instance
+        if (device.project) {
+            device.instance = device.project
+        }
     })
     return res.data
 }

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -137,6 +137,11 @@ const getTeamDevices = async (teamId, cursor, limit) => {
     const res = await client.get(url)
     res.data.devices.forEach(device => {
         device.lastSeenSince = device.lastSeenAt ? daysSince(device.lastSeenAt) : ''
+
+        // TODO: Remove this temporary copy of application over instance
+        if (device.project) {
+            device.instance = device.project
+        }
     })
     return res.data
 }

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -343,7 +343,8 @@ export default {
         async pollForData () {
             try {
                 if (this.hasLoadedModel) {
-                    await this.fetchData(null, true) // to-do: For now, this only polls the first page...
+                    const firstRequest = !this.checkInterval
+                    await this.fetchData(null, !firstRequest) // to-do: For now, this only polls the first page...
                 }
             } finally {
                 this.checkInterval = setTimeout(this.pollForData, 10000)

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -17,7 +17,7 @@
         />
         <template v-else>
             <ff-data-table
-                :data-el="`${displayingTeam ? 'devices' : 'remote-instances'}`"
+                data-el="devices-browser"
                 :columns="columns"
                 :rows="Array.from(devices.values())"
                 :show-search="true"

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -201,24 +201,25 @@ export default {
             if (!this.displayingInstance) {
                 columns.push({
                     label: 'Instance',
-                    key: 'project',
+                    key: 'instance',
                     class: ['w-64'],
                     sortable: true,
                     component: {
                         is: markRaw(InstanceInstancesLink),
                         map: {
-                            id: 'project.id',
-                            name: 'project.name'
+                            id: 'instance.id',
+                            name: 'instance.name'
                         }
                     }
                 })
             }
 
-            columns.push(
-                { label: 'Last Seen', key: 'lastSeenAt', class: ['w-32'], sortable: true, component: { is: markRaw(DeviceLastSeenBadge) } },
-                { label: 'Last Known Status', class: ['w-32'], component: { is: markRaw(ProjectStatusBadge) } },
-                { label: 'Deployed Snapshot', class: ['w-48'], component: { is: markRaw(Snapshot) } }
-            )
+            if (!this.displayingTeam) {
+                columns.push(
+                    ...statusColumns,
+                    { label: 'Deployed Snapshot', class: ['w-48'], component: { is: markRaw(Snapshot) } }
+                )
+            }
 
             return columns
         },

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -336,8 +336,10 @@ export default {
             const updatedDevice = await deviceApi.updateDevice(device.id, { project: projectId })
 
             // TODO Remove temporary duplication
-            device.project = updatedDevice.project
-            device.instance = updatedDevice.project
+            if (updatedDevice.project) {
+                device.project = updatedDevice.project
+                device.instance = updatedDevice.project
+            }
         },
 
         async pollForData () {

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -17,7 +17,7 @@
         />
         <template v-else>
             <ff-data-table
-                data-el="remote-instances"
+                :data-el="`${displayingTeam ? 'devices' : 'remote-instances'}`"
                 :columns="columns"
                 :rows="Array.from(devices.values())"
                 :show-search="true"

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -1,252 +1,41 @@
 <template>
     <SectionTopMenu hero="Devices" help-header="FlowForge - Devices" info="A list of all edge devices registered in your team. Assign them to application instances in order to deploy Node-RED remotely.">
-        <template v-slot:helptext>
+        <template #helptext>
             <p>FlowForge can be used to manage instances of Node-RED running on remote devices.</p>
             <p>Each device must run the <a href="https://flowforge.com/docs/user/devices/" target="_blank">FlowForge Device Agent</a>, which connects back to the platform to receive updates.</p>
             <p>Devices are registered to a Team, and assigned to a Project within that team.</p>
             <p>Flows can then be deployed remotely to the devices through a Project Snapshot.</p>
         </template>
-        <template v-slot:tools>
-            <ff-button v-if="addDeviceEnabled" data-action="register-device" kind="primary" size="small" @click="showCreateDeviceDialog"><template v-slot:icon-left><PlusSmIcon /></template>Register Device</ff-button>
-        </template>
     </SectionTopMenu>
-    <div class="space-y-6">
-        <ff-loading v-if="loading" message="Loading Devices..." />
-        <ff-loading v-else-if="creatingDevice" message="Creating Device..." />
-        <ff-loading v-else-if="deletingDevice" message="Deleting Device..." />
-        <template v-else>
-            <template v-if="this.devices.size === 0">
-                <div class="ff-no-data ff-no-data-large">
-                    You don't have any devices yet
-                </div>
-            </template>
-            <template v-if="this.devices.size > 0">
-                <ff-data-table
-                    data-el="devices"
-                    :columns="columns"
-                    :rows="Array.from(this.devices.values())"
-                    :show-search="true"
-                    search-placeholder="Search Devices..."
-                    :show-load-more="!!nextCursor"
-                    @load-more="loadMore"
-                >
-                    <template v-if="hasPermission('device:edit')" v-slot:context-menu="{row}">
-                        <ff-list-item label="Edit Details" @click="deviceAction('edit', row.id)"/>
-                        <ff-list-item v-if="!row.project" label="Add to Application Instance" @click="deviceAction('assignToProject', row.id)" />
-                        <ff-list-item v-else label="Remove from Application Instance" @click="deviceAction('removeFromProject', row.id)" />
-                        <ff-list-item kind="danger" label="Regenerate Credentials" @click="deviceAction('updateCredentials', row.id)"/>
-                        <ff-list-item v-if="hasPermission('device:delete')" kind="danger" label="Delete Device" @click="deviceAction('delete', row.id)" />
-                    </template>
-                </ff-data-table>
-            </template>
-        </template>
-    </div>
-    <TeamDeviceCreateDialog :team="team" @deviceCreating="deviceCreating" @deviceCreated="deviceCreated" @deviceUpdated="deviceUpdated" ref="teamDeviceCreateDialog">
-        <template v-slot:description>
-            <p>Here, you can register a new device to your team. This will provide you with a <b>device.yml</b>
-                to be moved to the respective device. Further details on Devices in FlowForge can be found
-                <a href="https://flowforge.com/docs/user/devices/" target="_blank">here</a>.</p>
-            <p class="mt-4 mb-2">If you want to register devices straight to a particular application instance you can use provisioning tokens
-                in your <router-link :to="{'name': 'TeamSettingsDevices', 'params': {team_slug: team.slug}}">Team Settings</router-link></p>
-        </template>
-    </TeamDeviceCreateDialog>
-    <DeviceCredentialsDialog ref="deviceCredentialsDialog" />
-    <DeviceAssignProjectDialog :team="team" @assignDevice="assignDevice" ref="deviceAssignProjectDialog" />
+
+    <DevicesBrowser
+        :team="team"
+        :teamMembership="teamMembership"
+    />
 </template>
 
 <script>
-import { markRaw } from 'vue'
-
-import permissionsMixin from '@/mixins/Permissions'
-
-import Alerts from '@/services/alerts'
-import Dialog from '@/services/dialog'
-
-import teamApi from '@/api/team'
-import deviceApi from '@/api/devices'
+import DevicesBrowser from '../../../components/DevicesBrowser'
 
 import SectionTopMenu from '@/components/SectionTopMenu'
-import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
-import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
-
-import { PlusSmIcon } from '@heroicons/vue/outline'
-
-import TeamDeviceCreateDialog from './dialogs/TeamDeviceCreateDialog'
-import DeviceCredentialsDialog from './dialogs/DeviceCredentialsDialog'
-import DeviceAssignProjectDialog from './dialogs/DeviceAssignProjectDialog'
-
-import DeviceLink from '../../project/components/cells/DeviceLink'
-import InstanceInstancesLink from '../../project/components/cells/InstanceInstancesLink'
-import ApplicationLink from '../../project/components/cells/ApplicationLink'
+import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'TeamDevices',
+    components: {
+        SectionTopMenu,
+        DevicesBrowser
+    },
     mixins: [permissionsMixin],
-    data () {
-        return {
-            loading: true,
-            creatingDevice: false,
-            deletingDevice: false,
-            devices: new Map(),
-            checkInterval: null,
-            nextCursor: null
-        }
-    },
-    watch: {
-        team: 'fetchData'
-    },
-    async mounted () {
-        await this.fetchData()
-        this.loading = false
-        this.checkInterval = setTimeout(this.pollForData, 10000)
-    },
-    unmounted () {
-        clearInterval(this.checkInterval)
-    },
-    methods: {
-        async pollForData () {
-            try {
-                await this.fetchData(null, true) // to-do: For now, this only polls the first page...
-            } finally {
-                this.checkInterval = setTimeout(this.pollForData, 10000)
-            }
-        },
-        async fetchData (nextCursor = null, polled = false) {
-            const data = await teamApi.getTeamDevices(this.team.id, nextCursor)
-
-            // Polling never resets the devices list
-            if (!nextCursor && !polled) {
-                this.devices = new Map()
-            }
-            data.devices.forEach(device => {
-                this.devices.set(device.id, device)
-            })
-
-            // to-do: Polling only loads the first page
-            if (!polled) {
-                this.nextCursor = data.meta.next_cursor
-            }
-        },
-        async loadMore () {
-            await this.fetchData(this.nextCursor)
-        },
-        showCreateDeviceDialog () {
-            this.$refs.teamDeviceCreateDialog.show(null, this.project)
-        },
-        showEditDeviceDialog (device) {
-            this.$refs.teamDeviceCreateDialog.show(device)
-        },
-        deviceCreating () {
-            this.creatingDevice = true
-        },
-        async deviceCreated (device) {
-            this.creatingDevice = false
-            if (device) {
-                setTimeout(() => {
-                    this.$refs.deviceCredentialsDialog.show(device)
-                }, 500)
-                this.devices.set(device.id, device)
-            }
-        },
-        deviceUpdated (device) {
-            this.devices.set(device.id, device)
-        },
-        async assignDevice (device, projectId) {
-            const updatedDevice = await deviceApi.updateDevice(device.id, { project: projectId })
-            device.project = updatedDevice.project
-        },
-        deviceAction (action, deviceId) {
-            const device = this.devices.get(deviceId)
-            if (action === 'edit') {
-                this.showEditDeviceDialog(device)
-            } else if (action === 'delete') {
-                Dialog.show({
-                    header: 'Delete Device',
-                    kind: 'danger',
-                    text: 'Are you sure you want to delete this device? Once deleted, there is no going back.',
-                    confirmLabel: 'Delete'
-                }, async () => {
-                    this.deletingDevice = true
-                    try {
-                        await deviceApi.deleteDevice(device.id)
-                        Alerts.emit('Successfully deleted the device', 'confirmation')
-                        this.devices.delete(device.id)
-                    } catch (err) {
-                        Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
-                    } finally {
-                        this.deletingDevice = false
-                    }
-                })
-            } else if (action === 'updateCredentials') {
-                this.$refs.deviceCredentialsDialog.show(device)
-            } else if (action === 'removeFromProject') {
-                Dialog.show({
-                    header: 'Remove Device from Project',
-                    kind: 'danger',
-                    text: 'Are you sure you want to remove this device from the instance? This will stop the instance running on the device.',
-                    confirmLabel: 'Remove'
-                }, async () => {
-                    await deviceApi.updateDevice(device.id, { project: null })
-                    delete device.project
-                    Alerts.emit('Successfully unassigned the instance from this device.', 'confirmation')
-                })
-            } else if (action === 'assignToProject') {
-                this.$refs.deviceAssignProjectDialog.show(device)
-            }
-        }
-    },
-    computed: {
-        addDeviceEnabled: function () {
-            return this.hasPermission('device:create')
-        },
-        columns: function () {
-            return [
-                { label: 'Device', class: ['w-64'], key: 'name', sortable: true, component: { is: markRaw(DeviceLink) } },
-                { label: 'Last Seen', class: ['w-32'], key: 'lastSeenAt', sortable: true, component: { is: markRaw(DeviceLastSeenBadge) } },
-                { label: 'Last Known Status', class: ['w-32'], key: 'status', sortable: true, component: { is: markRaw(ProjectStatusBadge) } },
-                {
-                    label: 'Application',
-                    class: ['w-64'],
-                    key: 'project',
-                    sortable: true,
-                    component: {
-                        is: markRaw(ApplicationLink),
-                        map: {
-                            id: 'project.id',
-                            name: 'project.name'
-                        }
-                    }
-                },
-                {
-                    label: 'Instance',
-                    class: ['w-64'],
-                    key: 'project',
-                    sortable: true,
-                    component: {
-                        is: markRaw(InstanceInstancesLink),
-                        map: {
-                            id: 'project.id',
-                            name: 'project.name'
-                        }
-                    }
-                }
-            ]
-        }
-    },
     props: {
         team: {
+            type: Object,
             required: true
         },
         teamMembership: {
+            type: Object,
             required: true
         }
-    },
-    components: {
-        TeamDeviceCreateDialog,
-        DeviceCredentialsDialog,
-        DeviceAssignProjectDialog,
-        SectionTopMenu,
-        PlusSmIcon
     }
 }
 </script>

--- a/test/e2e/frontend/cypress/tests/admin.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin.spec.js
@@ -92,7 +92,7 @@ describe('FlowForge platform admin users', () => {
         cy.get('[data-nav="team-devices"]').click()
         cy.wait('@getDevices')
 
-        cy.get('[data-el="devices"]').contains('team2-unassigned-device').click()
+        cy.get('[data-el="devices-browser"]').contains('team2-unassigned-device').click()
         cy.wait('@getDevice')
 
         cy.get('[data-el="banner-device-as-admin"]').should('exist')

--- a/test/e2e/frontend/cypress/tests/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices.spec.js
@@ -42,17 +42,17 @@ describe('FlowForge - Devices', () => {
         cy.get('.ff-dialog-box').should('be.visible')
         cy.get('.ff-dialog-header').contains('Device Credentials')
 
-        cy.get('[data-el="devices"] tbody').find('tr').should('have.length', 1)
-        cy.get('[data-el="devices"] tbody').find('tr').contains('device1')
+        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
+        cy.get('[data-el="devices-browser"] tbody').find('tr').contains('device1')
     })
 
     it('can delete a device', () => {
         cy.intercept('DELETE', '/api/*/devices/*').as('deleteDevice')
 
         // click kebab menu in row 1
-        cy.get('[data-el="devices"] tbody').find('.ff-kebab-menu').eq(0).click()
+        cy.get('[data-el="devices-browser"] tbody').find('.ff-kebab-menu').eq(0).click()
         // click the 4th option (Delete Device)
-        cy.get('[data-el="devices"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Delete Device').click()
+        cy.get('[data-el="devices-browser"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Delete Device').click()
 
         cy.get('.ff-dialog-box').should('be.visible')
         cy.get('.ff-dialog-header').contains('Delete Device')
@@ -81,7 +81,7 @@ describe('FlowForge - Devices', () => {
             })
 
         // Load more active
-        cy.get('[data-el="devices"] tbody').find('tr').should('have.length', 1)
+        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
 
         cy.intercept('GET', '/api/v1/teams/*/devices?cursor=next', {
             count: 2,
@@ -93,8 +93,8 @@ describe('FlowForge - Devices', () => {
 
         cy.wait('@getDevicesNextPage')
 
-        cy.get('[data-el="devices"] tbody').find('tr').should('have.length', 2)
-        cy.get('[data-el="devices"] tbody').contains('td', 'device-2')
+        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 2)
+        cy.get('[data-el="devices-browser"] tbody').contains('td', 'device-2')
 
         cy.get('[data-action="load-more"]').should('not.exist')
     })


### PR DESCRIPTION
## Description

Updates team devices page to be consistent with Application > Instances and Instance > Remote Instances by making use of the DeviceBrowser component.

Additionally adds a description to the register new device modal for the Application > Instances and Instance > Remote Instances Popups

#### Before
![Screenshot 2023-03-13 at 17 23 15](https://user-images.githubusercontent.com/507155/224763794-3db61dee-76b2-4892-ad0b-e298b8fdad64.png)

![Screenshot 2023-03-13 at 17 24 33](https://user-images.githubusercontent.com/507155/224764169-77a6ff22-9190-4718-b94e-3e764ce71b14.png)


#### After
![Screenshot 2023-03-13 at 17 21 46](https://user-images.githubusercontent.com/507155/224763687-ff9979b0-ec93-499d-9510-261db6f3c9db.png)

![Screenshot 2023-03-13 at 17 24 42](https://user-images.githubusercontent.com/507155/224764126-850b5cae-0b50-4243-84fd-5342c37bc065.png)



## Related Issue(s)

Closes #1801, part of #1689

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

