### PR TITLE
Add Application migration and instances endpoint

### DIFF
--- a/forge/db/migrations/20230313-01-create-application-instances.js
+++ b/forge/db/migrations/20230313-01-create-application-instances.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Create an Application object for each Project in the database
+ */
+const { DataTypes, QueryInterface, QueryTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        // Get a list of all projects
+        const projects = await context.sequelize.query('select "id", "name", "TeamId", "createdAt", "updatedAt" from "Projects"', { type: QueryTypes.SELECT })
+        for (const project of projects) {
+            await context.sequelize.transaction(async (transaction) => {
+                // Create an Application with matching name
+                const [results, metadata] = await context.sequelize.query(
+                    'INSERT into "Applications" ("name", "TeamId", "createdAt", "updatedAt") VALUES (?,?,?,?)',
+                    {
+                        replacements: [
+                            project.name,
+                            project.TeamId,
+                            project.createdAt,
+                            project.updatedAt
+                        ],
+                        transaction
+                    }
+                )
+                // Update the Project's ApplicationId
+                await context.sequelize.query(
+                    `UPDATE "Projects"
+                     SET ApplicationId = ?
+                     WHERE id = ?`,
+                    {
+                        replacements: [
+                            metadata.lastID,
+                            project.id
+                        ],
+                        transaction
+                    }
+                )
+            })
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -7,11 +7,6 @@ const { DataTypes } = require('sequelize')
 module.exports = {
     name: 'Application',
     schema: {
-        id: {
-            type: DataTypes.INTEGER,
-            primaryKey: true,
-            autoIncrement: true
-        },
         name: { type: DataTypes.STRING, allowNull: false }
     },
     associations: function (M) {

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -258,6 +258,10 @@ module.exports = {
                             model: M.Team,
                             include: [
                                 {
+                                    model: M.Application,
+                                    attributes: ['hashid', 'id', 'name', 'links']
+                                },
+                                {
                                     model: M.TeamMember,
                                     where: {
                                         UserId: user.id
@@ -286,6 +290,10 @@ module.exports = {
                             {
                                 model: M.Team,
                                 attributes: ['hashid', 'id', 'name', 'slug', 'links']
+                            },
+                            {
+                                model: M.Application,
+                                attributes: ['hashid', 'id', 'name', 'links']
                             },
                             {
                                 model: M.ProjectType,
@@ -320,6 +328,10 @@ module.exports = {
                                 model: M.Team,
                                 where: { id: teamId },
                                 attributes: ['hashid', 'id', 'name', 'slug', 'links']
+                            },
+                            {
+                                model: M.Application,
+                                attributes: ['hashid', 'id', 'name', 'links']
                             },
                             {
                                 model: M.ProjectType,

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -320,6 +320,34 @@ module.exports = {
                         ]
                     })
                 },
+                byApplication: async (applicationHashId) => {
+                    const applicationId = M.Application.decodeHashid(applicationHashId)
+                    return this.findAll({
+                        include: [
+                            {
+                                model: M.Team,
+                                attributes: ['hashid', 'id', 'name', 'slug', 'links']
+                            },
+                            {
+                                model: M.Application,
+                                where: { id: applicationId },
+                                attributes: ['hashid', 'id', 'name', 'links']
+                            },
+                            {
+                                model: M.ProjectType,
+                                attributes: ['hashid', 'id', 'name']
+                            }
+                            //,
+                            // {
+                            //     model: M.ProjectStack
+                            // },
+                            // {
+                            //     model: M.ProjectTemplate,
+                            //     attributes: ['hashid', 'id', 'name', 'links']
+                            // }
+                        ]
+                    })
+                },
                 byTeam: async (teamHashId) => {
                     const teamId = M.Team.decodeHashid(teamHashId)
                     return this.findAll({

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -337,14 +337,6 @@ module.exports = {
                                 model: M.ProjectType,
                                 attributes: ['hashid', 'id', 'name']
                             }
-                            //,
-                            // {
-                            //     model: M.ProjectStack
-                            // },
-                            // {
-                            //     model: M.ProjectTemplate,
-                            //     attributes: ['hashid', 'id', 'name', 'links']
-                            // }
                         ]
                     })
                 },

--- a/forge/db/views/Application.js
+++ b/forge/db/views/Application.js
@@ -1,14 +1,18 @@
 module.exports = {
     application: function (app, application) {
-        const raw = application.toJSON()
-        const filtered = {
-            id: raw.hashid,
-            name: raw.name,
-            createdAt: raw.createdAt,
-            updatedAt: raw.updatedAt,
-            links: raw.links
+        if (application) {
+            const raw = application.toJSON()
+            const filtered = {
+                id: raw.hashid,
+                name: raw.name,
+                createdAt: raw.createdAt,
+                updatedAt: raw.updatedAt,
+                links: raw.links
+            }
+            return filtered
+        } else {
+            return null
         }
-        return filtered
     },
 
     teamApplicationList: function (app, applications) {

--- a/forge/db/views/Application.js
+++ b/forge/db/views/Application.js
@@ -14,7 +14,19 @@ module.exports = {
             return null
         }
     },
-
+    applicationSummary: function (app, application) {
+        // application could already be a vanilla object,
+        // or a database model object.
+        if (Object.hasOwn(application, 'get')) {
+            application = application.get({ plain: true })
+        }
+        const result = {
+            id: application.hashid,
+            name: application.name,
+            links: application.links
+        }
+        return result
+    },
     teamApplicationList: function (app, applications) {
         return applications.map(app => {
             return {

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -39,7 +39,6 @@ module.exports = {
             result.application = {
                 id: proj.Application.hashid,
                 name: proj.Application.name,
-                fred: true,
                 links: proj.Application.links
             }
         }

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -33,7 +33,14 @@ module.exports = {
 
         const settingsHostnameRow = proj.ProjectSettings?.find((projectSettingsRow) => projectSettingsRow.key === KEY_HOSTNAME)
         result.hostname = settingsHostnameRow?.value || ''
-
+        if (proj.Application) {
+            result.application = {
+                id: proj.Application.hashid,
+                name: proj.Application.name,
+                fred: true,
+                links: proj.Application.links
+            }
+        }
         if (proj.Team) {
             result.team = {
                 id: proj.Team.hashid,
@@ -106,6 +113,7 @@ module.exports = {
                 createdAt: t.createdAt,
                 updatedAt: t.updatedAt,
                 links: t.links,
+                application: app.db.views.Application.application(t.Application),
                 team: app.db.views.Team.team(t.Team)
             }
         })

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -36,19 +36,10 @@ module.exports = {
         const settingsHostnameRow = proj.ProjectSettings?.find((projectSettingsRow) => projectSettingsRow.key === KEY_HOSTNAME)
         result.hostname = settingsHostnameRow?.value || ''
         if (proj.Application) {
-            result.application = {
-                id: proj.Application.hashid,
-                name: proj.Application.name,
-                links: proj.Application.links
-            }
+            result.application = app.db.views.Application.applicationSummary(proj.Application)
         }
         if (proj.Team) {
-            result.team = {
-                id: proj.Team.hashid,
-                name: proj.Team.name,
-                slug: proj.Team.slug,
-                links: proj.Team.links
-            }
+            result.team = app.db.views.Team.teamSummary(proj.Team)
         }
         if (proj.ProjectType) {
             result.projectType = {

--- a/forge/db/views/Team.js
+++ b/forge/db/views/Team.js
@@ -17,13 +17,15 @@ module.exports = {
         })
     },
     teamSummary: function (app, team) {
-        const d = team.get({ plain: true })
+        if (Object.hasOwn(team, 'get')) {
+            team = team.get({ plain: true })
+        }
         const result = {
-            id: d.hashid,
-            name: d.name,
-            slug: d.slug,
-            avatar: d.avatar,
-            links: d.links
+            id: team.hashid,
+            name: team.name,
+            slug: team.slug,
+            avatar: team.avatar,
+            links: team.links
         }
         return result
     },


### PR DESCRIPTION
This is a continuation of the work to introduce the Application concept into the runtime.

It targets the `feat-1735-application-model` branch which introduces the Application model and basic CRUD API.

This PR adds to that branch:

 - A migration that generates an Application object for every existing Project.
 - The `/api/v1/applications/:applicationId/instances` endpoint that lists the instances within an application
 - Updates the Project views to include the Application info
