### PR TITLE
Add new InstanceStatusHeader, update pages, add descriptions

### DIFF
--- a/frontend/src/components/InstanceStatusHeader.vue
+++ b/frontend/src/components/InstanceStatusHeader.vue
@@ -1,0 +1,48 @@
+<template>
+    <div class="ff-section-header flex flex-wrap border-b border-gray-300 text-gray-500 justify-between px-6 py-4">
+        <div class="flex">
+            <div class="w-full flex items-center md:w-auto mr-8 gap-x-2">
+                <slot name="hero"></slot>
+            </div>
+        </div>
+        <ul v-if="hasTools">
+            <li class="w-full md:w-auto flex-grow text-right">
+                <slot name="tools"></slot>
+            </li>
+        </ul>
+    </div>
+</template>
+<script>
+
+import { ref } from 'vue'
+
+export default {
+    name: 'InstanceStatusHeader',
+    props: {
+        hero: {
+            type: String,
+            default: null
+        }
+    },
+    computed: {
+        hasInfoDialog () {
+            return !!this.$slots.helptext
+        }
+    },
+    setup (props, { slots }) {
+        const hasTools = ref(false)
+        if (slots.tools && slots.tools().length) {
+            hasTools.value = true
+        }
+        return {
+            hasTools
+        }
+    },
+    methods: {
+        openInfoDialog () {
+            this.$refs['help-dialog'].show()
+        }
+    }
+}
+
+</script>

--- a/frontend/src/components/SectionTopMenu.vue
+++ b/frontend/src/components/SectionTopMenu.vue
@@ -1,10 +1,10 @@
 <template>
-    <div class="flex flex-wrap border-b border-gray-700 mb-4 sm:mb-2 text-gray-500 justify-between">
+    <div class="ff-section-header flex flex-wrap border-b border-gray-400 mb-4 sm:mb-2 text-gray-500 justify-between">
         <div class="flex">
             <div class="w-full flex items-center md:w-auto mb-2 mr-8 gap-x-2">
                 <slot name="hero">
                     <div class="flex">
-                        <div class="text-gray-800 text-xl font-bold">{{ hero }}</div>
+                        <div class="text-gray-800 text-xl font-medium">{{ hero }}</div>
                     </div>
                 </slot>
                 <InformationCircleIcon v-if="hasInfoDialog" class="min-w-[20px] ff-icon text-gray-800 cursor-pointer hover:text-blue-700" @click="openInfoDialog()" />

--- a/frontend/src/pages/instance/AuditLog.vue
+++ b/frontend/src/pages/instance/AuditLog.vue
@@ -1,10 +1,14 @@
 <template>
+    <div class="mb-3">
+        <SectionTopMenu hero="Audit Log" info=""></SectionTopMenu>
+    </div>
     <AuditLogBrowser ref="AuditLog" :users="users" :logEntries="logEntries" logType="project" @load-entries="loadEntries" />
 </template>
 
 <script>
 import { mapState } from 'vuex'
 
+import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import AuditLogBrowser from '../../components/audit-log/AuditLogBrowser'
 
 import InstanceApi from '@/api/instances'
@@ -13,6 +17,7 @@ import TeamAPI from '@/api/team'
 export default {
     name: 'InstanceAuditLog',
     components: {
+        SectionTopMenu,
         AuditLogBrowser
     },
     inheritAttrs: false,

--- a/frontend/src/pages/instance/Devices.vue
+++ b/frontend/src/pages/instance/Devices.vue
@@ -1,4 +1,12 @@
 <template>
+    <SectionTopMenu hero="Devices" help-header="FlowForge - Devices" info="A list of all edge devices registered to this instance.">
+        <template #helptext>
+            <p>FlowForge can be used to manage instances of Node-RED running on remote devices.</p>
+            <p>Each device must run the <a href="https://flowforge.com/docs/user/devices/" target="_blank">FlowForge Device Agent</a>, which connects back to the platform to receive updates.</p>
+            <p>Devices are registered to a Team, and assigned to an Instance within an Application.</p>
+            <p>Flows can then be deployed remotely to the devices as an Instance Snapshot.</p>
+        </template>
+    </SectionTopMenu>
     <DevicesBrowser
         :team="team"
         :teamMembership="teamMembership"
@@ -10,6 +18,7 @@
 <script>
 import { mapState } from 'vuex'
 
+import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import DevicesBrowser from '../../components/DevicesBrowser.vue'
 
 import permissionsMixin from '@/mixins/Permissions'
@@ -17,7 +26,8 @@ import permissionsMixin from '@/mixins/Permissions'
 export default {
     name: 'InstanceRemoteInstances',
     components: {
-        DevicesBrowser
+        DevicesBrowser,
+        SectionTopMenu
     },
     mixins: [permissionsMixin],
     inheritAttrs: false,

--- a/frontend/src/pages/instance/Logs.vue
+++ b/frontend/src/pages/instance/Logs.vue
@@ -1,14 +1,19 @@
 <template>
+    <div class="mb-3">
+        <SectionTopMenu hero="Node-RED Logs" info=""></SectionTopMenu>
+    </div>
     <LogsShared :instance="instance" />
 </template>
 
 <script>
+import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import LogsShared from './components/InstanceLogs'
 
 export default {
     name: 'InstanceLogs',
     components: {
-        LogsShared
+        LogsShared,
+        SectionTopMenu
     },
     inheritAttrs: false,
     props: {

--- a/frontend/src/pages/instance/Settings/index.vue
+++ b/frontend/src/pages/instance/Settings/index.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="flex flex-col sm:flex-row">
+    <div class="mb-3">
+        <SectionTopMenu hero="Settings" info=""></SectionTopMenu>
+    </div>
+    <div class="flex flex-col sm:flex-row ml-6">
         <SectionSideMenu :options="sideNavigation" />
         <div class="flex-grow">
             <router-view
@@ -15,12 +18,14 @@
 <script>
 import { mapState } from 'vuex'
 
+import SectionTopMenu from '@/components/SectionTopMenu'
 import SectionSideMenu from '@/components/SectionSideMenu'
 import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'InstanceSettings',
     components: {
+        SectionTopMenu,
         SectionSideMenu
     },
     mixins: [permissionsMixin],

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -1,4 +1,13 @@
 <template>
+    <div class="mb-3">
+        <SectionTopMenu hero="Snapshots" help-header="FlowForge - Snapshots">
+            <template #helptext>
+                <p>Snapshots generate a point-in-time backup of your Node-RED flow, credentials and runtime settings.</p>
+                <p>Snapshots are also required for deploying to devices. In the Deployments page of a Project, you can define your “Target Snapshot”, which will then be deployed to all connected devices.</p>
+                <p>You can also generate Snapshots directly from any instance of Node-RED using the <a target="_blank" href="https://github.com/flowforge/flowforge-nr-tools-plugin">FlowForge NR Tools Plugin.</a></p>
+            </template>
+        </SectionTopMenu>
+    </div>
     <div class="space-y-6">
         <ff-loading v-if="loading" message="Loading Snapshots..." />
         <template v-if="snapshots.length > 0">
@@ -40,6 +49,7 @@ import SnapshotCreateDialog from './dialogs/SnapshotCreateDialog'
 import InstanceApi from '@/api/instances'
 import SnapshotApi from '@/api/projectSnapshots'
 
+import SectionTopMenu from '@/components/SectionTopMenu.vue'
 import UserCell from '@/components/tables/cells/UserCell'
 import permissionsMixin from '@/mixins/Permissions'
 import Alerts from '@/services/alerts'
@@ -48,6 +58,7 @@ import Dialog from '@/services/dialog'
 export default {
     name: 'InstanceSnapshots',
     components: {
+        SectionTopMenu,
         SnapshotCreateDialog,
         PlusSmIcon
     },

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -19,50 +19,54 @@
     <main v-else-if="!instance?.id">
         <ff-loading message="Loading Instance..." />
     </main>
-    <main v-else data-el="instances-section">
-        <SectionTopMenu>
-            <template #hero>
-                <div class="flex-grow space-x-6 items-center inline-flex" data-el="instance-name">
-                    <div class="text-gray-800 text-xl font-bold">
-                        {{ instance.name }}
+    <main v-else data-el="instances-section" class="ff-with-status-header">
+        <div class="ff-instance-header">
+            <InstanceStatusHeader>
+                <template #hero>
+                    <div class="flex-grow space-x-6 items-center inline-flex" data-el="instance-name">
+                        <div class="text-gray-800 text-xl font-bold">
+                            {{ instance.name }}
+                        </div>
+                        <InstanceStatusBadge v-if="instance.meta" :status="instance.meta.state" :pendingStateChange="instance.pendingStateChange" />
                     </div>
-                    <InstanceStatusBadge v-if="instance.meta" :status="instance.meta.state" :pendingStateChange="instance.pendingStateChange" />
-                </div>
-            </template>
-            <template #tools>
-                <div class="space-x-2 flex">
-                    <div v-if="editorAvailable">
-                        <a v-if="!isVisitingAdmin" :href="instance.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
-                            Open Editor
-                            <span class="ff-btn--icon ff-btn--icon-right">
-                                <ExternalLinkIcon />
-                            </span>
-                        </a>
-                        <button v-else title="Unable to open editor when visiting as an admin" class="ff-btn ff-btn--secondary" disabled>
-                            Open Editor
-                            <span class="ff-btn--icon ff-btn--icon-right">
-                                <ExternalLinkIcon />
-                            </span>
-                        </button>
+                </template>
+                <template #tools>
+                    <div class="space-x-2 flex align-center">
+                        <div v-if="editorAvailable">
+                            <a v-if="!isVisitingAdmin" :href="instance.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
+                                Open Editor
+                                <span class="ff-btn--icon ff-btn--icon-right">
+                                    <ExternalLinkIcon />
+                                </span>
+                            </a>
+                            <button v-else title="Unable to open editor when visiting as an admin" class="ff-btn ff-btn--secondary" disabled>
+                                Open Editor
+                                <span class="ff-btn--icon ff-btn--icon-right">
+                                    <ExternalLinkIcon />
+                                </span>
+                            </button>
+                        </div>
+                        <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
                     </div>
-                    <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
-                </div>
-            </template>
-        </SectionTopMenu>
+                </template>
+            </InstanceStatusHeader>
+        </div>
         <ConfirmInstanceDeleteDialog ref="confirmInstanceDeleteDialog" @confirm="deleteInstance" />
         <Teleport v-if="mounted" to="#platform-banner">
             <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-project-as-admin">You are viewing this instance as an Administrator</div>
             <SubscriptionExpiredBanner :team="team" />
             <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
         </Teleport>
-        <router-view
-            :instance="instance"
-            :is-visiting-admin="isVisitingAdmin"
-            @instance-overview-exit="onOverviewExit"
-            @instance-overview-enter="onOverviewEnter"
-            @instance-updated="updateInstance"
-            @instance-confirm-delete="showConfirmDeleteDialog"
-        />
+        <div class="px-3 py-3 md:px-6 md:py-6">
+            <router-view
+                :instance="instance"
+                :is-visiting-admin="isVisitingAdmin"
+                @instance-overview-exit="onOverviewExit"
+                @instance-overview-enter="onOverviewEnter"
+                @instance-updated="updateInstance"
+                @instance-confirm-delete="showConfirmDeleteDialog"
+            />
+        </div>
     </main>
 </template>
 
@@ -81,7 +85,7 @@ import SnapshotApi from '@/api/projectSnapshots'
 
 import DropdownMenu from '@/components/DropdownMenu'
 import NavItem from '@/components/NavItem'
-import SectionTopMenu from '@/components/SectionTopMenu'
+import InstanceStatusHeader from '@/components/InstanceStatusHeader'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions.vue'
 import SubscriptionExpiredBanner from '@/components/banners/SubscriptionExpired.vue'
 import TeamTrialBanner from '@/components/banners/TeamTrial.vue'
@@ -109,7 +113,7 @@ export default {
         ExternalLinkIcon,
         NavItem,
         InstanceStatusBadge,
-        SectionTopMenu,
+        InstanceStatusHeader,
         SideNavigationTeamOptions,
         SubscriptionExpiredBanner,
         TeamTrialBanner

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -1,13 +1,13 @@
 <template>
     <div>
-        <SectionTopMenu hero="FlowForge Hosted Instances" help-header="FlowForge - Instances - Local" info="Instances of Node-RED running in the FlowForge cloud">
+        <SectionTopMenu hero="Node-RED Instances" help-header="Node-RED Instances - Running in FlowForge" info="Instances of Node-RED, in this application, that are running in the FlowForge cloud.">
             <template #pictogram>
                 <img src="../../images/pictograms/edge_red.png">
             </template>
             <template #helptext>
                 <p>This is a list of all instances of this Application hosted on the same domain as FlowForge.</p>
                 <p>It will always run the latest flow deployed in Node-RED and use the latest credentials and runtime settings defined in the Projects settings.</p>
-                <p>To edit an Applications flow, open the editor of the Instance.</p>
+                <p>To edit an Application's flow, open the editor of the Instance.</p>
             </template>
         </SectionTopMenu>
 

--- a/frontend/src/pages/project/Settings.vue
+++ b/frontend/src/pages/project/Settings.vue
@@ -1,5 +1,6 @@
 <template>
-    <div class="flex flex-col sm:flex-row">
+    <SectionTopMenu hero="Application Settings" info="Live logs from your FlowForge instances of Node-RED"></SectionTopMenu>
+    <div class="flex flex-col sm:flex-row mt-3 ml-6">
         <SectionSideMenu :options="sideNavigation" />
         <div class="space-y-6">
             <FormHeading class="mb-6">Application Details</FormHeading>
@@ -31,12 +32,14 @@
 <script>
 import FormHeading from '@/components/FormHeading'
 import FormRow from '@/components/FormRow'
+import SectionTopMenu from '@/components/SectionTopMenu'
 import SectionSideMenu from '@/components/SectionSideMenu'
 import permissionsMixin from '@/mixins/Permissions'
 
 export default {
     name: 'ProjectSettings',
     components: {
+        SectionTopMenu,
         SectionSideMenu,
         FormHeading,
         FormRow

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -189,9 +189,9 @@ export default {
         },
         checkAccess () {
             this.navigation = [
-                { label: 'Instances', path: `/project/${this.project.id}/instances`, tag: 'project-overview', icon: ProjectsIcon },
-                { label: 'Audit Log', path: `/project/${this.project.id}/activity`, tag: 'project-activity', icon: ViewListIcon },
+                { label: 'Node-RED Instances', path: `/project/${this.project.id}/instances`, tag: 'project-overview', icon: ProjectsIcon },
                 { label: 'Node-RED Logs', path: `/project/${this.project.id}/logs`, tag: 'project-logs', icon: TerminalIcon },
+                { label: 'Audit Log', path: `/project/${this.project.id}/activity`, tag: 'project-activity', icon: ViewListIcon },
                 { label: 'Settings', path: `/project/${this.project.id}/settings`, tag: 'project-settings', icon: CogIcon }
             ]
             if (this.mounted && this.project.meta) {

--- a/frontend/src/pages/team/Devices/index.vue
+++ b/frontend/src/pages/team/Devices/index.vue
@@ -3,8 +3,8 @@
         <template #helptext>
             <p>FlowForge can be used to manage instances of Node-RED running on remote devices.</p>
             <p>Each device must run the <a href="https://flowforge.com/docs/user/devices/" target="_blank">FlowForge Device Agent</a>, which connects back to the platform to receive updates.</p>
-            <p>Devices are registered to a Team, and assigned to a Project within that team.</p>
-            <p>Flows can then be deployed remotely to the devices through a Project Snapshot.</p>
+            <p>Devices are registered to a Team, and assigned to an Instance within an Application.</p>
+            <p>Flows can then be deployed remotely to the devices as an Instance Snapshot.</p>
         </template>
     </SectionTopMenu>
 

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -176,6 +176,14 @@ $nav_height: 60px;
         padding: 12px;
         background-color: $ff-grey-50;
     }
+    main.ff-with-status-header {
+        margin: 9px;
+        padding: 0px;
+        .ff-instance-header {
+            padding: 0px;
+            background-color: $ff-white;
+        }
+    }
 }
 
 .ff-notifications {
@@ -645,6 +653,14 @@ $nav_height: 60px;
         main {
             margin: 24px;
             padding: 32px;
+        }
+        main.ff-with-status-header {
+            margin: 24px;
+            padding: 0px;
+            .ff-instance-header {
+                padding: 0px;
+                background-color: $ff-white;
+            }
         }
     }
     .ff-navigation {


### PR DESCRIPTION
## Description

- Add new `InstanceStatusHeader`
- Use this header on all `Instance > ...` pages
- Add `SectionTopHeader` beneath the `InstanceStatusHeader` to detail active page title & relevant helper info/dialog.

## Related Issue(s)

Closes #1833 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass

