### PR TITLE
Application Instances: Team Device Bug Fixes

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -76,11 +76,14 @@
                     />
                     <ff-list-item
                         v-if="!row.instance && displayingTeam"
-                        label="Add to Application Instance" @click="deviceAction('assignToProject', row.id)"
+                        label="Add to Application Instance"
+                        data-action="device-assign"
+                        @click="deviceAction('assignToProject', row.id)"
                     />
                     <ff-list-item
                         v-else
                         label="Remove from Application Instance"
+                        data-action="device-remove"
                         @click="deviceAction('removeFromProject', row.id)"
                     />
                     <ff-list-item

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -414,9 +414,14 @@ export default {
                     confirmLabel: 'Remove'
                 }, async () => {
                     await deviceApi.updateDevice(device.id, { project: null })
-                    delete device.project
 
-                    this.devices.delete(device.id)
+                    // TODO Remove temporary duplication
+                    delete device.project
+                    delete device.instance
+
+                    if (this.displayingInstance) {
+                        this.devices.delete(device.id)
+                    }
 
                     Alerts.emit('Successfully removed the device from the instance.', 'confirmation')
                 })

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -134,9 +134,9 @@
         @snapshot-assigned="$emit('instance-updated')"
     />
 
-    <DeviceAssignProjectDialog
+    <DeviceAssignInstanceDialog
         v-if="displayingTeam"
-        ref="deviceAssignProjectDialog"
+        ref="deviceAssignInstanceDialog"
         :instances="teamInstances"
         @assign-device="assignDevice"
     />
@@ -156,7 +156,7 @@ import ApplicationLink from '../pages/project/components/cells/ApplicationLink'
 import DeviceLink from '../pages/project/components/cells/DeviceLink.vue'
 import InstanceInstancesLink from '../pages/project/components/cells/InstanceInstancesLink.vue'
 import Snapshot from '../pages/project/components/cells/Snapshot.vue'
-import DeviceAssignProjectDialog from '../pages/team/Devices/dialogs/DeviceAssignProjectDialog'
+import DeviceAssignInstanceDialog from '../pages/team/Devices/dialogs/DeviceAssignInstanceDialog'
 import DeviceCredentialsDialog from '../pages/team/Devices/dialogs/DeviceCredentialsDialog'
 import TeamDeviceCreateDialog from '../pages/team/Devices/dialogs/TeamDeviceCreateDialog'
 
@@ -173,7 +173,7 @@ export default {
     name: 'ProjectOverview',
     components: {
         ClockIcon,
-        DeviceAssignProjectDialog,
+        DeviceAssignInstanceDialog,
         DeviceCredentialsDialog,
         PlusSmIcon,
         SnapshotAssignDialog,
@@ -422,7 +422,7 @@ export default {
                 })
             } else if (action === 'assignToProject') {
                 this.updateTeamInstances()
-                this.$refs.deviceAssignProjectDialog.show(device)
+                this.$refs.deviceAssignInstanceDialog.show(device)
             }
         }
     }

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -137,7 +137,7 @@
     <DeviceAssignProjectDialog
         v-if="displayingTeam"
         ref="deviceAssignProjectDialog"
-        :team="team"
+        :instances="teamInstances"
         @assign-device="assignDevice"
     />
 </template>
@@ -207,7 +207,8 @@ export default {
             deletingDevice: false,
             nextCursor: null,
             devices: new Map(),
-            checkInterval: null
+            checkInterval: null,
+            teamInstances: null
         }
     },
     computed: {
@@ -377,6 +378,10 @@ export default {
             this.loading = false
         },
 
+        async updateTeamInstances () {
+            this.teamInstances = (await teamApi.getTeamProjects(this.team.id)).projects // TODO Currently fetches projects not instances
+        },
+
         deviceAction (action, deviceId) {
             const device = this.devices.get(deviceId)
             if (action === 'edit') {
@@ -416,6 +421,7 @@ export default {
                     Alerts.emit('Successfully removed the device from the instance.', 'confirmation')
                 })
             } else if (action === 'assignToProject') {
+                this.updateTeamInstances()
                 this.$refs.deviceAssignProjectDialog.show(device)
             }
         }

--- a/frontend/src/components/FormRow.vue
+++ b/frontend/src/components/FormRow.vue
@@ -45,7 +45,7 @@
             <div :class="(wrapperClass ? wrapperClass : 'flex flex-col sm:flex-row relative')">
                 <!-- Dropdown -->
                 <template v-if="options && type !== 'uneditable'">
-                    <ff-dropdown v-model="localModelValue" class="w-full" :disabled="disabled">
+                    <ff-dropdown v-model="localModelValue" class="w-full" :disabled="disabled" :placeholder="placeholder">
                         <ff-dropdown-option v-for="option in options" :value="option.value" :label="option.label" :key="option.label" class="text-sm">
                             {{ option.label }}
                         </ff-dropdown-option>

--- a/frontend/src/pages/team/Devices/dialogs/DeviceAssignInstanceDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceAssignInstanceDialog.vue
@@ -4,6 +4,7 @@
         header="Add Device to Instance"
         class="ff-dialog-fixed-height"
         confirm-label="Add"
+        data-el="assign-device-dialog"
         @confirm="assignDevice()"
     >
         <template #default>
@@ -16,6 +17,7 @@
                     :options="options"
                     :disabled="disabled"
                     :placeholder="placeholder"
+                    data-form="instance"
                 >
                     Application Instance
                 </FormRow>

--- a/frontend/src/pages/team/Devices/dialogs/DeviceAssignInstanceDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceAssignInstanceDialog.vue
@@ -29,16 +29,14 @@ import FormRow from '@/components/FormRow'
 import alerts from '@/services/alerts'
 
 export default {
-    name: 'DeviceAssignProjectDialog',
+    name: 'DeviceAssignInstanceDialog',
     components: {
         FormRow
     },
     props: {
         instances: {
             type: Array,
-            default () {
-                return []
-            }
+            default: null
         }
     },
     setup () {

--- a/frontend/src/pages/team/createProject.vue
+++ b/frontend/src/pages/team/createProject.vue
@@ -21,7 +21,7 @@
         <div class="max-w-2xl m-auto">
             <ff-loading
                 v-if="loading"
-                message="Creating Instance..."
+                message="Creating Application..."
             />
             <ff-loading
                 v-else-if="sourceProjectId && !sourceProject"

--- a/test/e2e/frontend/cypress/tests/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices.spec.js
@@ -1,102 +1,175 @@
 import deviceOffline from '../fixtures/device-offline.json'
 
 describe('FlowForge - Devices', () => {
-    beforeEach(() => {
-        cy.intercept('GET', '/api/*/teams/*/devices').as('getDevices')
-        cy.login('alice', 'aaPassword')
-        cy.home()
+    describe('team with no devices', () => {
+        beforeEach(() => {
+            cy.intercept('GET', '/api/*/teams/*/devices').as('getDevices')
+            cy.login('alice', 'aaPassword')
+            cy.home()
 
-        cy.request('GET', '/api/v1/teams/')
-            .then((response) => {
-                const team = response.body.teams[0]
-                cy.visit(`/team/${team.slug}/devices`)
-                cy.wait('@getDevices')
-            })
-    })
+            cy.request('GET', '/api/v1/teams/')
+                .then((response) => {
+                    const team = response.body.teams[0]
+                    cy.visit(`/team/${team.slug}/devices`)
+                    cy.wait('@getDevices')
+                })
+        })
 
-    it('shows a placeholder message when no devices have been created', () => {
-        cy.get('main').contains('You don\'t have any devices yet')
-    })
+        it('shows a placeholder message when no devices have been created', () => {
+            cy.get('main').contains('You don\'t have any devices yet')
+        })
 
-    it('provides functionality to register a device', () => {
-        cy.intercept('POST', '/api/*/devices').as('registerDevice')
+        it('provides functionality to register a device', () => {
+            cy.intercept('POST', '/api/*/devices').as('registerDevice')
 
-        cy.get('button[data-action="register-device"]').click()
+            cy.get('button[data-action="register-device"]').click()
 
-        cy.get('.ff-dialog-box').should('be.visible')
-        cy.get('.ff-dialog-header').contains('Add Device')
-        // disabled primary button by default
-        cy.get('.ff-dialog-box button.ff-btn.ff-btn--primary').contains('Add').should('be.disabled')
+            cy.get('.ff-dialog-box').should('be.visible')
+            cy.get('.ff-dialog-header').contains('Add Device')
+            // disabled primary button by default
+            cy.get('.ff-dialog-box button.ff-btn.ff-btn--primary').contains('Add').should('be.disabled')
 
-        cy.get('[data-form="device-name"] input[type="text"]').type('device1')
-        // inserting device name is enough to enable button
-        cy.get('.ff-dialog-box button.ff-btn.ff-btn--primary').should('not.be.disabled')
-        cy.get('[data-form="device-type"] input[type="text"]').type('typeA')
+            cy.get('[data-form="device-name"] input[type="text"]').type('device1')
+            // inserting device name is enough to enable button
+            cy.get('.ff-dialog-box button.ff-btn.ff-btn--primary').should('not.be.disabled')
+            cy.get('[data-form="device-type"] input[type="text"]').type('typeA')
 
-        // click "Register"
-        cy.get('.ff-dialog-box button.ff-btn.ff-btn--primary').contains('Add').click()
+            // click "Register"
+            cy.get('.ff-dialog-box button.ff-btn.ff-btn--primary').contains('Add').click()
 
-        cy.wait('@registerDevice')
+            cy.wait('@registerDevice')
 
-        // show user the device credentials
-        cy.get('.ff-dialog-box').should('be.visible')
-        cy.get('.ff-dialog-header').contains('Device Credentials')
+            // show user the device credentials
+            cy.get('.ff-dialog-box').should('be.visible')
+            cy.get('.ff-dialog-header').contains('Device Credentials')
 
-        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
-        cy.get('[data-el="devices-browser"] tbody').find('tr').contains('device1')
-    })
+            cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
+            cy.get('[data-el="devices-browser"] tbody').find('tr').contains('device1')
+        })
 
-    it('can delete a device', () => {
-        cy.intercept('DELETE', '/api/*/devices/*').as('deleteDevice')
+        it('can delete a device', () => {
+            cy.intercept('DELETE', '/api/*/devices/*').as('deleteDevice')
 
-        // click kebab menu in row 1
-        cy.get('[data-el="devices-browser"] tbody').find('.ff-kebab-menu').eq(0).click()
-        // click the 4th option (Delete Device)
-        cy.get('[data-el="devices-browser"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Delete Device').click()
+            // click kebab menu in row 1
+            cy.get('[data-el="devices-browser"] tbody').find('.ff-kebab-menu').eq(0).click()
+            // click the 4th option (Delete Device)
+            cy.get('[data-el="devices-browser"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').contains('Delete Device').click()
 
-        cy.get('.ff-dialog-box').should('be.visible')
-        cy.get('.ff-dialog-header').contains('Delete Device')
+            cy.get('.ff-dialog-box').should('be.visible')
+            cy.get('.ff-dialog-header').contains('Delete Device')
 
-        // Click "Delete"
-        cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Delete').click()
+            // Click "Delete"
+            cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').contains('Delete').click()
 
-        cy.wait('@deleteDevice')
+            cy.wait('@deleteDevice')
 
-        cy.get('main').contains('You don\'t have any devices yet')
-    })
+            cy.get('main').contains('You don\'t have any devices yet')
+        })
 
-    it('can load multiple pages of devices when the API paginates', function () {
+        it('can load multiple pages of devices when the API paginates', function () {
         // Mock active and inactive stacks having multiple pages
-        cy.intercept('GET', '/api/v1/teams/*/devices', {
-            count: 2,
-            meta: { next_cursor: 'next' },
-            devices: [deviceOffline]
-        }).as('getDevicesPaginated')
+            cy.intercept('GET', '/api/v1/teams/*/devices', {
+                count: 2,
+                meta: { next_cursor: 'next' },
+                devices: [deviceOffline]
+            }).as('getDevicesPaginated')
 
-        cy.request('GET', '/api/v1/teams/')
-            .then((response) => {
-                const team = response.body.teams[0]
-                cy.visit(`/team/${team.slug}/devices`)
-                cy.wait('@getDevicesPaginated')
+            cy.request('GET', '/api/v1/teams/')
+                .then((response) => {
+                    const team = response.body.teams[0]
+                    cy.visit(`/team/${team.slug}/devices`)
+                    cy.wait('@getDevicesPaginated')
+                })
+
+            // Load more active
+            cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
+
+            cy.intercept('GET', '/api/v1/teams/*/devices?cursor=next', {
+                count: 2,
+                meta: { next_cursor: null },
+                devices: [{ ...deviceOffline, ...{ id: 2, name: 'device-2' } }]
+            }).as('getDevicesNextPage')
+
+            cy.get('[data-action="load-more"]').click()
+
+            cy.wait('@getDevicesNextPage')
+
+            cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 2)
+            cy.get('[data-el="devices-browser"] tbody').contains('td', 'device-2')
+
+            cy.get('[data-action="load-more"]').should('not.exist')
+        })
+    })
+
+    describe('team with devices', () => {
+        beforeEach(() => {
+            cy.intercept('GET', '/api/*/teams/*/devices').as('getDevices')
+            cy.login('bob', 'bbPassword')
+            cy.home()
+
+            cy.request('GET', '/api/v1/user/teams')
+                .then((response) => {
+                    const team = response.body.teams.find((team) => team.name === 'BTeam')
+                    cy.visit(`/team/${team.slug}/devices`)
+                    cy.wait('@getDevices')
+                })
+        })
+
+        it('can assign and unassign devices to instances', () => {
+            let selectedInstance
+
+            // Devices list
+            cy.get('[data-el="devices-browser"]').within(() => {
+                // Row
+                cy.contains('tr', 'team2-unassigned-device').within(() => {
+                    cy.get('.ff-kebab-menu').click()
+                    cy.get('.ff-kebab-menu .ff-kebab-options').find('[data-action="device-assign"]').click()
+                })
             })
 
-        // Load more active
-        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
+            // Dialog
+            cy.get('[data-el="assign-device-dialog"]')
+                .should('be.visible')
+                .within(() => {
+                    // Instance dropdown
+                    cy.get('[data-form="instance"]').within(() => {
+                        cy.get('.ff-dropdown').click()
+                        cy.get('.ff-dropdown-options').should('be.visible')
 
-        cy.intercept('GET', '/api/v1/teams/*/devices?cursor=next', {
-            count: 2,
-            meta: { next_cursor: null },
-            devices: [{ ...deviceOffline, ...{ id: 2, name: 'device-2' } }]
-        }).as('getDevicesNextPage')
+                        cy.get('.ff-dropdown-options > .ff-dropdown-option:first').invoke('text').then((text) => {
+                            selectedInstance = text
+                        })
 
-        cy.get('[data-action="load-more"]').click()
+                        cy.get('.ff-dropdown-options > .ff-dropdown-option:first').click()
+                    })
 
-        cy.wait('@getDevicesNextPage')
+                    cy.get('.ff-btn--primary').click()
+                })
 
-        cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 2)
-        cy.get('[data-el="devices-browser"] tbody').contains('td', 'device-2')
+            // Devices list
+            cy.get('[data-el="devices-browser"]').within(() => {
+                // Row
+                cy.contains('tr', 'team2-unassigned-device').within(() => {
+                    cy.contains(selectedInstance)
 
-        cy.get('[data-action="load-more"]').should('not.exist')
+                    cy.get('.ff-kebab-menu').click()
+                    cy.get('.ff-kebab-menu .ff-kebab-options').find('[data-action="device-remove"]').click()
+                })
+            })
+
+            // Remove dialog
+            cy.get('[data-el="platform-dialog"]')
+                .should('be.visible')
+                .within(() => {
+                    cy.get('.ff-btn--danger').click()
+                })
+
+            // Devices list
+            cy.get('[data-el="devices-browser"]').within(() => {
+                // Row
+                cy.contains('tr', 'team2-unassigned-device').should('not.have.text', selectedInstance)
+            })
+        })
     })
 })
 

--- a/test/e2e/frontend/cypress/tests/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices.spec.js
@@ -134,12 +134,13 @@ describe('FlowForge - Devices', () => {
                     // Instance dropdown
                     cy.get('[data-form="instance"]').within(() => {
                         cy.get('.ff-dropdown').click()
-                        cy.get('.ff-dropdown-options').should('be.visible')
 
+                        // Grab name of first instance
                         cy.get('.ff-dropdown-options > .ff-dropdown-option:first').invoke('text').then((text) => {
                             selectedInstance = text
                         })
 
+                        // Click first instance
                         cy.get('.ff-dropdown-options > .ff-dropdown-option:first').click()
                     })
 


### PR DESCRIPTION
## Description

- Fixes unassigning a device from an instance on the team table
- Adds a loading state to the assign device dialog
- Renames DeviceAssignInstanceDialog.vue
- Adds test coverage of assign and unassign

https://user-images.githubusercontent.com/507155/225306420-0a50a7f4-391d-4c10-b699-220ace6167cd.mov

## Related Issue(s)

Fixes #1838

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

