### PR TITLE
Application Instances: Project & Instance Status Polling

### DIFF
--- a/frontend/src/components/InstanceStatusHeader.vue
+++ b/frontend/src/components/InstanceStatusHeader.vue
@@ -2,12 +2,12 @@
     <div class="ff-section-header flex flex-wrap border-b border-gray-300 text-gray-500 justify-between px-6 py-4">
         <div class="flex">
             <div class="w-full flex items-center md:w-auto mr-8 gap-x-2">
-                <slot name="hero"></slot>
+                <slot name="hero" />
             </div>
         </div>
         <ul v-if="hasTools">
             <li class="w-full md:w-auto flex-grow text-right">
-                <slot name="tools"></slot>
+                <slot name="tools" />
             </li>
         </ul>
     </div>
@@ -24,11 +24,6 @@ export default {
             default: null
         }
     },
-    computed: {
-        hasInfoDialog () {
-            return !!this.$slots.helptext
-        }
-    },
     setup (props, { slots }) {
         const hasTools = ref(false)
         if (slots.tools && slots.tools().length) {
@@ -36,6 +31,11 @@ export default {
         }
         return {
             hasTools
+        }
+    },
+    computed: {
+        hasInfoDialog () {
+            return !!this.$slots.helptext
         }
     },
     methods: {

--- a/frontend/src/pages/instance/Devices.vue
+++ b/frontend/src/pages/instance/Devices.vue
@@ -18,8 +18,8 @@
 <script>
 import { mapState } from 'vuex'
 
-import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import DevicesBrowser from '../../components/DevicesBrowser.vue'
+import SectionTopMenu from '../../components/SectionTopMenu.vue'
 
 import permissionsMixin from '@/mixins/Permissions'
 

--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -98,7 +98,6 @@ export default {
             type: Boolean
         }
     },
-    emits: ['instance-overview-exit', 'instance-overview-enter'],
     data () {
         return {
             auditLog: []
@@ -119,11 +118,7 @@ export default {
         }
     },
     mounted () {
-        this.$emit('instance-overview-enter')
         this.loadLogs()
-    },
-    unmounted () {
-        this.$emit('instance-overview-exit')
     },
     methods: {
         loadLogs () {

--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -113,7 +113,7 @@ export default {
         }
     },
     watch: {
-        instance: function () {
+        'instance.id': function (old, news) {
             this.loadLogs()
         }
     },

--- a/frontend/src/pages/instance/Settings/DevOps.vue
+++ b/frontend/src/pages/instance/Settings/DevOps.vue
@@ -14,7 +14,7 @@
     </FormRow>
 
     <div class="mt-6 flex gap-4">
-        <ff-button :disabled="!input.target || loading" data-action="push-stage" @click="deploy()">
+        <ff-button :disabled="!input.target" data-action="push-stage" @click="deploy()">
             {{ deploying ? `Pushing to "${input.target.name}"...` : 'Push to Stage' }}
         </ff-button>
         <ff-button kind="secondary" :to="{name: 'Instance', params: { 'id': input.target?.id }}" :disabled="!input.target" data-action="view-target-project">

--- a/frontend/src/pages/instance/Settings/index.vue
+++ b/frontend/src/pages/instance/Settings/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="mb-3">
-        <SectionTopMenu hero="Settings" info=""></SectionTopMenu>
+        <SectionTopMenu hero="Settings" info="" />
     </div>
     <div class="flex flex-col sm:flex-row ml-6">
         <SectionSideMenu :options="sideNavigation" />
@@ -18,8 +18,8 @@
 <script>
 import { mapState } from 'vuex'
 
-import SectionTopMenu from '@/components/SectionTopMenu'
 import SectionSideMenu from '@/components/SectionSideMenu'
+import SectionTopMenu from '@/components/SectionTopMenu'
 import permissionsMixin from '@/mixins/Permissions'
 
 export default {
@@ -29,13 +29,13 @@ export default {
         SectionSideMenu
     },
     mixins: [permissionsMixin],
+    inheritAttrs: false,
     props: {
         instance: {
             type: Object,
             required: true
         }
     },
-
     emits: ['instance-updated', 'instance-confirm-delete'],
     data () {
         return {

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -63,6 +63,7 @@ export default {
         PlusSmIcon
     },
     mixins: [permissionsMixin],
+    inheritAttrs: false,
     props: {
         instance: {
             type: Object,

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -175,6 +175,13 @@ export default {
     },
     async created () {
         await this.updateInstance()
+
+        this.$watch(
+            () => this.$route.params.id,
+            async () => {
+                await this.updateInstance()
+            }
+        )
     },
     mounted () {
         this.checkAccess()

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -184,7 +184,6 @@ export default {
         )
     },
     mounted () {
-        this.checkAccess()
         this.mounted = true
 
         this.startPolling()
@@ -193,8 +192,7 @@ export default {
         this.stopPolling()
     },
     methods: {
-        async startPolling () {
-            await this.updateInstance()
+        startPolling () {
             this.checkWaitTime = 1000
             if (this.instance.pendingRestart && !this.instanceTransitionStates.includes(this.instance.state)) {
                 this.instance.pendingRestart = false

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -126,6 +126,7 @@ export default {
             instance: {},
             navigation: [],
             checkInterval: null,
+            checkWaitTime: 1000,
             loading: {
                 deleting: false,
                 suspend: false
@@ -187,6 +188,7 @@ export default {
     methods: {
         async startPolling () {
             await this.updateInstance()
+            this.checkWaitTime = 1000
             if (this.instance.pendingRestart && !this.instanceTransitionStates.includes(this.instance.state)) {
                 this.instance.pendingRestart = false
             }
@@ -226,6 +228,8 @@ export default {
             if (this.instance.pendingStateChange) {
                 clearTimeout(this.checkInterval)
                 this.checkInterval = setTimeout(async () => {
+                    this.checkWaitTime *= 1.1
+
                     if (this.instance.id) {
                         const data = await InstanceApi.getInstance(this.instance.id)
                         const wasPendingRestart = this.instance.pendingRestart
@@ -238,7 +242,7 @@ export default {
                         this.instance.pendingStatePrevious = wasPendingStatePrevious
                         this.instance.pendingStateChange = wasPendingStateChange
                     }
-                }, 1000)
+                }, this.checkWaitTime)
             }
         },
         checkAccess () {

--- a/frontend/src/pages/project/Logs.vue
+++ b/frontend/src/pages/project/Logs.vue
@@ -44,6 +44,7 @@ export default {
             required: true
         }
     },
+    emits: ['project-enable-polling', 'project-disable-polling'],
     data () {
         return {
             input: {
@@ -62,6 +63,12 @@ export default {
     },
     created () {
         this.projectChanged()
+    },
+    mounted () {
+        this.$emit('project-enable-polling')
+    },
+    unmounted () {
+        this.$emit('project-disable-polling')
     },
     methods: {
         projectChanged () {

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -55,7 +55,6 @@
 </template>
 
 <script>
-
 import { Roles } from '@core/lib/roles'
 
 import { markRaw } from 'vue'

--- a/frontend/src/pages/project/Overview.vue
+++ b/frontend/src/pages/project/Overview.vue
@@ -84,7 +84,7 @@ export default {
             required: true
         }
     },
-    emits: ['project-delete', 'project-suspend', 'project-restart', 'project-start', 'projectUpdated'],
+    emits: ['project-delete', 'project-suspend', 'project-restart', 'project-start', 'projectUpdated', 'project-enable-polling', 'project-disable-polling'],
     computed: {
         ...mapState('account', ['team', 'teamMembership']),
         cloudColumns () {
@@ -107,6 +107,12 @@ export default {
         isVisitingAdmin () {
             return this.teamMembership.role === Roles.Admin
         }
+    },
+    mounted () {
+        this.$emit('project-enable-polling')
+    },
+    unmounted () {
+        this.$emit('project-disable-polling')
     },
     methods: {
         selectedCloudRow (cloudInstance) {

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -26,8 +26,8 @@
         <router-view
             :project="project"
             :is-visiting-admin="isVisitingAdmin"
-            @project-overview-exit="onOverviewExit"
-            @project-overview-enter="onOverviewEnter"
+            @project-enable-polling="onEnablePolling"
+            @project-disable-polling="onDisablePolling"
             @projectUpdated="updateProject"
             @project-start="startProject"
             @project-restart="restartProject"
@@ -99,9 +99,6 @@ export default {
             }
         }
     },
-    async created () {
-        await this.updateProject()
-    },
     computed: {
         ...mapState('account', ['teamMembership', 'team']),
         isVisitingAdmin: function () {
@@ -116,24 +113,27 @@ export default {
         teamMembership: 'checkAccess',
         'project.pendingStateChange': 'refreshProject'
     },
+    async created () {
+        await this.updateProject()
+    },
     mounted () {
         this.checkAccess()
         this.mounted = true
     },
     beforeUnmount () {
-        this.onOverviewExit(true)
+        this.onDisablePolling(true)
     },
     methods: {
-        async onOverviewEnter () {
+        async onEnablePolling () {
             await this.updateProject()
-            this.overviewActive = true
+            this.pollingActive = true
             if (this.project.pendingRestart && !this.projectTransitionStates.includes(this.project.state)) {
                 this.project.pendingRestart = false
             }
             this.checkAccess()
         },
-        onOverviewExit (unmounting) {
-            this.overviewActive = false
+        onDisablePolling (unmounting) {
+            this.pollingActive = false
             if (unmounting) {
                 // ensure timer and flags are cleared when navigating away from page
                 if (this.project?.pendingStateChange || this.project?.pendingRestart) {


### PR DESCRIPTION
## Description

Enables polling for Application status on the application overview page, additionally: 

- Enables polling for all Instance pages (since status is shown in the header)
- Very slowly backs off polling (Roughly 10 polls, every 2.5 seconds; after 25, every 10 seconds)

## Related Issue(s)

Fixes #1822

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

