### PR TITLE
Better framing of "Application" & "Device" views

### DIFF
--- a/frontend/src/api/devices.js
+++ b/frontend/src/api/devices.js
@@ -22,6 +22,9 @@ const deleteDevice = async (deviceId) => {
 }
 const getDevice = async (deviceId) => {
     return await client.get(`/api/v1/devices/${deviceId}`).then(res => {
+        const device = res.data
+        device.lastSeenSince = device.lastSeenAt ? elapsedTime(0, device.lastSeenMs) + ' ago' : ''
+        res.data = device
         return res.data
     })
 }

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -8,14 +8,16 @@
 
             <table class="table-fixed w-full" v-if="device">
                 <tr class="border-b">
+                    <td class="w-1/4 font-medium">Last Seen</td>
+                    <td class="py-2">
+                        <DeviceLastSeenBadge :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
+                    </td>
+                </tr>
+                <tr class="border-b">
                     <td class="w-1/4 font-medium">Status</td>
                     <td class="py-2">
                         <ProjectStatusBadge :status="device.status"/>
                     </td>
-                </tr>
-                <tr class="border-b">
-                    <td class="w-1/4 font-medium">Last Seen</td>
-                    <td class="py-2">{{ lastSeen || "Not Available" }}</td>
                 </tr>
             </table>
         </div>
@@ -97,6 +99,7 @@ import elapsedTime from '@/utils/elapsedTime'
 
 // components
 import FormHeading from '@/components/FormHeading'
+import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
 import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
 
 // icons
@@ -107,6 +110,7 @@ export default {
     props: ['device'],
     components: {
         FormHeading,
+        DeviceLastSeenBadge,
         ProjectStatusBadge,
         CheckCircleIcon,
         ExclamationIcon,

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -34,25 +34,6 @@
                         </div>
                     </div>
                 </template>
-                <template #tools>
-                    <div class="space-x-2 flex align-center">
-                        <div v-if="editorAvailable">
-                            <a v-if="!isVisitingAdmin" :href="instance.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
-                                Open Editor
-                                <span class="ff-btn--icon ff-btn--icon-right">
-                                    <ExternalLinkIcon />
-                                </span>
-                            </a>
-                            <button v-else title="Unable to open editor when visiting as an admin" class="ff-btn ff-btn--secondary" disabled>
-                                Open Editor
-                                <span class="ff-btn--icon ff-btn--icon-right">
-                                    <ExternalLinkIcon />
-                                </span>
-                            </button>
-                        </div>
-                        <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
-                    </div>
-                </template>
             </InstanceStatusHeader>
         </div>
         <div class="text-sm sm:px-6 mt-4 sm:mt-8">

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -10,27 +10,58 @@
             </template>
         </SideNavigationTeamOptions>
     </Teleport>
-    <main>
+    <main class="ff-with-status-header">
         <Teleport v-if="mounted" to="#platform-banner">
             <div v-if="isVisitingAdmin" class="ff-banner" data-el="banner-project-as-admin">You are viewing this team as an Administrator</div>
             <SubscriptionExpiredBanner :team="team" />
             <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
         </Teleport>
-        <SectionTopMenu>
-            <template #hero>
-                <div class="flex-grow space-x-6 items-center inline-flex">
-                    <router-link :to="navigation[0]?navigation[0].path:''" class="inline-flex items-center" data-nav="device-overview">
-                        <div class="text-gray-800 text-xl font-bold">{{ device?.name }}</div>
-                        <div class="text-gray-400 text-md font-bold ml-3">{{ device?.type }}</div>
-                    </router-link>
-                </div>
-            </template>
-        </SectionTopMenu>
+        <div class="ff-instance-header">
+            <InstanceStatusHeader>
+                <template #hero>
+                    <div class="flex-grow items-center inline-flex flex-wrap" data-el="device-name">
+                        <div class="text-gray-800 text-xl font-bold mr-6">
+                            {{ device.name }}
+                        </div>
+                        <DeviceLastSeenBadge class="mr-6" :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
+                        <ProjectStatusBadge :status="device.status"/>
+                        <div class="w-full text-sm mt-1">
+                            <div v-if="device?.project">
+                                Instance:
+                                <router-link :to="{name: 'Instance', params: {id: device.project.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.project.name }}</router-link>
+                            </div>
+                            <span v-else class="text-gray-400 italic">Device Not Assigned to an Instance</span>
+                        </div>
+                    </div>
+                </template>
+                <template #tools>
+                    <div class="space-x-2 flex align-center">
+                        <div v-if="editorAvailable">
+                            <a v-if="!isVisitingAdmin" :href="instance.url" target="_blank" class="ff-btn ff-btn--secondary" data-action="open-editor">
+                                Open Editor
+                                <span class="ff-btn--icon ff-btn--icon-right">
+                                    <ExternalLinkIcon />
+                                </span>
+                            </a>
+                            <button v-else title="Unable to open editor when visiting as an admin" class="ff-btn ff-btn--secondary" disabled>
+                                Open Editor
+                                <span class="ff-btn--icon ff-btn--icon-right">
+                                    <ExternalLinkIcon />
+                                </span>
+                            </button>
+                        </div>
+                        <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
+                    </div>
+                </template>
+            </InstanceStatusHeader>
+        </div>
         <div class="text-sm sm:px-6 mt-4 sm:mt-8">
             <Teleport v-if="mounted && isVisitingAdmin" to="#platform-banner">
                 <div class="ff-banner" data-el="banner-device-as-admin">You are viewing this device as an Administrator</div>
             </Teleport>
-            <router-view :device="device" @device-updated="loadDevice()"></router-view>
+            <div class="px-3 pb-3 md:px-6 md:pb-6">
+                <router-view :device="device" @device-updated="loadDevice()"></router-view>
+            </div>
         </div>
     </main>
 </template>
@@ -44,7 +75,9 @@ import { Roles } from '@core/lib/roles'
 
 // components
 import NavItem from '@/components/NavItem'
-import SectionTopMenu from '@/components/SectionTopMenu'
+import InstanceStatusHeader from '@/components/InstanceStatusHeader'
+import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
+import DeviceLastSeenBadge from '@/pages/device/components/DeviceLastSeenBadge'
 import SideNavigationTeamOptions from '@/components/SideNavigationTeamOptions'
 import SubscriptionExpiredBanner from '@/components/banners/SubscriptionExpired.vue'
 import TeamTrialBanner from '@/components/banners/TeamTrial.vue'
@@ -56,7 +89,9 @@ export default {
     name: 'DevicePage',
     components: {
         NavItem,
-        SectionTopMenu,
+        InstanceStatusHeader,
+        ProjectStatusBadge,
+        DeviceLastSeenBadge,
         SideNavigationTeamOptions,
         SubscriptionExpiredBanner,
         TeamTrialBanner

--- a/frontend/src/pages/project/Activity.vue
+++ b/frontend/src/pages/project/Activity.vue
@@ -1,7 +1,7 @@
 <template>
     <AuditLogBrowser ref="AuditLog" :users="users" :logEntries="logEntries" logType="project" @load-entries="loadEntries">
         <template #title>
-            <SectionTopMenu hero="Application Audit Log" info="Recorded events that have taken place in within this application." />
+            <SectionTopMenu hero="Audit Log" info="Recorded events that have taken place in within this application." />
         </template>
         <template #extraFilters>
             <FormHeading class="mt-4">Application Instance:</FormHeading>

--- a/frontend/src/pages/project/Settings.vue
+++ b/frontend/src/pages/project/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-    <SectionTopMenu hero="Application Settings" info="Live logs from your FlowForge instances of Node-RED"></SectionTopMenu>
+    <SectionTopMenu hero="Settings" info="Live logs from your FlowForge instances of Node-RED"></SectionTopMenu>
     <div class="flex flex-col sm:flex-row mt-3 ml-6">
         <SectionSideMenu :options="sideNavigation" />
         <div class="space-y-6">

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -2,7 +2,7 @@
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigationTeamOptions>
             <template v-slot:nested-menu>
-                <div class="ff-nested-title">{{ project.name ?? 'Application' }}</div>
+                <div class="ff-nested-title">Application</div>
                 <router-link v-for="route in navigation" :key="route.label" :to="route.path">
                     <nav-item :icon="route.icon" :label="route.label" :data-nav="route.tag"></nav-item>
                 </router-link>
@@ -15,7 +15,7 @@
     <main v-else-if="!project?.id">
         <ff-loading message="Loading Application..." />
     </main>
-    <main v-else>
+    <main v-else class="ff-with-status-header">
         <ConfirmInstanceDeleteDialog @confirm="deleteInstance" ref="confirmInstanceDeleteDialog"/>
         <ConfirmApplicationDeleteDialog @confirm="deleteApplication" ref="confirmApplicationDeleteDialog"/>
         <Teleport v-if="mounted" to="#platform-banner">
@@ -23,18 +23,33 @@
             <SubscriptionExpiredBanner :team="team" />
             <TeamTrialBanner v-if="team.billing?.trial" :team="team" />
         </Teleport>
-        <router-view
-            :project="project"
-            :is-visiting-admin="isVisitingAdmin"
-            @project-enable-polling="onEnablePolling"
-            @project-disable-polling="onDisablePolling"
-            @projectUpdated="updateProject"
-            @project-start="startProject"
-            @project-restart="restartProject"
-            @project-suspend="showConfirmSuspendDialog"
-            @project-delete="showConfirmDeleteInstanceDialog"
-            @application-delete="showConfirmDeleteApplicationDialog"
-        />
+
+        <div class="ff-instance-header">
+            <InstanceStatusHeader>
+                <template #hero>
+                    <div class="flex-grow space-x-6 items-center inline-flex" data-el="instance-name">
+                        <div class="text-gray-800 text-xl font-bold">
+                            <div class="text-sm font-medium text-gray-500">Application:</div>
+                            {{ project.name }}
+                        </div>
+                    </div>
+                </template>
+            </InstanceStatusHeader>
+        </div>
+        <div class="px-3 py-3 md:px-6 md:py-6">
+            <router-view
+                :project="project"
+                :is-visiting-admin="isVisitingAdmin"
+                @project-enable-polling="onEnablePolling"
+                @project-disable-polling="onDisablePolling"
+                @projectUpdated="updateProject"
+                @project-start="startProject"
+                @project-restart="restartProject"
+                @project-suspend="showConfirmSuspendDialog"
+                @project-delete="showConfirmDeleteInstanceDialog"
+                @application-delete="showConfirmDeleteApplicationDialog"
+            />
+        </div>
     </main>
 </template>
 
@@ -44,6 +59,7 @@ import { ChevronLeftIcon, CogIcon, TerminalIcon, ViewListIcon } from '@heroicons
 
 import { mapState } from 'vuex'
 
+import InstanceStatusHeader from '@/components/InstanceStatusHeader'
 import ConfirmInstanceDeleteDialog from '../instance/Settings/dialogs/ConfirmInstanceDeleteDialog'
 
 import ConfirmApplicationDeleteDialog from './Settings/dialogs/ConfirmApplicationDeleteDialog'
@@ -78,6 +94,7 @@ export default {
     components: {
         ConfirmApplicationDeleteDialog,
         ConfirmInstanceDeleteDialog,
+        InstanceStatusHeader,
         NavItem,
         SideNavigationTeamOptions,
         SubscriptionExpiredBanner,

--- a/frontend/src/pages/project/index.vue
+++ b/frontend/src/pages/project/index.vue
@@ -27,7 +27,7 @@
         <div class="ff-instance-header">
             <InstanceStatusHeader>
                 <template #hero>
-                    <div class="flex-grow space-x-6 items-center inline-flex" data-el="instance-name">
+                    <div class="flex-grow space-x-6 items-center inline-flex" data-el="application-name">
                         <div class="text-gray-800 text-xl font-bold">
                             <div class="text-sm font-medium text-gray-500">Application:</div>
                             {{ project.name }}

--- a/frontend/src/pages/team/Projects.vue
+++ b/frontend/src/pages/team/Projects.vue
@@ -31,14 +31,11 @@
 </template>
 
 <script>
-import { markRaw } from 'vue'
 import permissionsMixin from '@/mixins/Permissions'
 
 import teamApi from '@/api/team'
 import { PlusSmIcon } from '@heroicons/vue/outline'
 import SectionTopMenu from '@/components/SectionTopMenu'
-
-import ProjectStatusBadge from '@/pages/project/components/ProjectStatusBadge'
 
 export default {
     name: 'TeamProjects',
@@ -48,9 +45,7 @@ export default {
             loading: false,
             projects: [],
             columns: [
-                { label: 'Name', class: ['flex-grow'], key: 'name', sortable: true },
-                { label: 'Status', class: ['w-44'], key: 'status', sortable: true, component: { is: markRaw(ProjectStatusBadge) } },
-                { label: 'Updated', class: ['w-44', 'text-xs'], key: 'updatedSince', sortable: true }
+                { label: 'Name', class: ['flex-grow'], key: 'name', sortable: true }
             ]
         }
     },


### PR DESCRIPTION
## Description

Inspired by https://github.com/flowforge/flowforge/pull/1852 I've decided to use that same header style across our Applications & Devices too, it offers better boundaries, and also targets some of the thinking in https://github.com/flowforge/flowforge/issues/1830 whereby it's now possible to go from a Device straight to it's attached Instance.

### Application View:

<img width="1728" alt="Screenshot 2023-03-16 at 16 03 16" src="https://user-images.githubusercontent.com/99246719/225680368-37f4d31a-b426-4b36-badf-31b20e12470d.png">

### Device View:

<img width="1728" alt="Screenshot 2023-03-16 at 16 23 32" src="https://user-images.githubusercontent.com/99246719/225686317-5711e3af-1d3a-430c-9785-c8f94a5bb2bd.png">


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

