### PR TITLE
Update HTTPS docs to include updating the base_url

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -116,7 +116,7 @@ Then, in the `docker-compose.yml` file, edit the following lines added your doma
 - "LETSENCRYPT_HOST=forge.example.com"
 ```
 
-You will also need to update the `etc/flowforge.yml` file to change the `broker.public_url` entry from starting with `ws://` to `wss://`.
+You will also need to update the `etc/flowforge.yml` file to change `base_url` from starting with `http://` to `https://` and the `broker.public_url` entry from starting with `ws://` to `wss://`.
 
 #### Wildcard TLS Certificate
 


### PR DESCRIPTION


## Description

The docker install docs are missing an important change to ensure the `base_url` starts with `https://` when enabling certificates.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
part of #1854

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

