### PR TITLE
Add theme choice (FF themes only)

### DIFF
--- a/docs/user/instance-settings.md
+++ b/docs/user/instance-settings.md
@@ -49,6 +49,7 @@ This covers a number of options to customize the Node-RED editor. This includes:
  - Disabling the editor entirely
  - Modifying the paths the editor and dashboard are served on
  - Controlling the runtime timezone
+ - Choosing a dark or light theme for the editor
 
 ## Security
 

--- a/docs/user/instance-settings.md
+++ b/docs/user/instance-settings.md
@@ -48,8 +48,11 @@ This covers a number of options to customize the Node-RED editor. This includes:
 
  - Disabling the editor entirely
  - Modifying the paths the editor and dashboard are served on
+ - Choosing which code editor to use in your Node-RED nodes
+ - Setting a custom title for the editor
+ - Choosing a light or dark theme for the editor
  - Controlling the runtime timezone
- - Choosing a dark or light theme for the editor
+ - Controlling the use of node modules in function nodes
 
 ## Security
 

--- a/frontend/src/pages/admin/Template/sections/Editor.vue
+++ b/frontend/src/pages/admin/Template/sections/Editor.vue
@@ -72,6 +72,15 @@
         </div>
         <div class="flex flex-col sm:flex-row">
             <div class="w-full max-w-md sm:mr-8">
+                <FormRow v-model="editable.settings.theme" :disabled="!editTemplate && !editable.policy.theme" type="select" :options="themes">
+                    Editor Theme
+                    <template #append><ChangeIndicator :value="editable.changed.settings.theme"></ChangeIndicator></template>
+                </FormRow>
+            </div>
+            <LockSetting class="flex justify-end flex-col" :editTemplate="editTemplate" v-model="editable.policy.theme" :changed="editable.changed.policy.theme"></LockSetting>
+        </div>
+        <div class="flex flex-col sm:flex-row">
+            <div class="w-full max-w-md sm:mr-8">
                 <FormRow v-model="editable.settings.timeZone" :disabled="!editTemplate && !editable.policy.timeZone" type="select" :options="timezones">
                     Time Zone
                     <template #append><ChangeIndicator :value="editable.changed.settings.timeZone"></ChangeIndicator></template>
@@ -129,7 +138,6 @@ export default {
         return {
             timezones: timezonesData.timezones,
             themes: [
-                { label: 'Node-RED', value: '' },
                 { label: 'FlowForge Light', value: 'forge-light' },
                 { label: 'FlowForge Dark', value: 'forge-dark' }
             ] // FUTURE: Get from theme plugins


### PR DESCRIPTION
## Description

Provide a means of setting the Node-RED editor theme

NOTE: At this time, we are hard coding the entries to our own themes therefore it will not be possible at this time to enumerate other installed (contrib) themes at this time.

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1816
#214 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

