### PR TITLE
Deprecate FF_PROJECT_* in favour of FF_INSTANCE_* 

### DIFF
--- a/docs/user/envvar.md
+++ b/docs/user/envvar.md
@@ -39,13 +39,16 @@ The third one `user` is set for the instance, the value can be edited or the var
 
 Instances running on FlowForge are assigned a standard set environment variables as follows.
 
-- `FF_PROJECT_ID`
-- `FF_PROJECT_NAME`
+- `FF_INSTANCE_ID`
+- `FF_INSTANCE_NAME`
+- `FF_PROJECT_ID` (depreciated as of V1.6.0, use `FF_INSTANCE_ID` instead)
+- `FF_PROJECT_NAME` (depreciated as of V1.6.0, use `FF_INSTANCE_NAME` instead)
 - `FF_DEVICE_ID` (devices only)
 - `FF_DEVICE_NAME` (devices only)
+- `FF_DEVICE_TYPE` (devices only)
 
-`FF_PROJECT_ID` and `FF_PROJECT_NAME` are assigned to the Node-RED instance running on the FlowForge server as well as all associated Devices.
+`FF_INSTANCE_ID` and `FF_INSTANCE_NAME` are assigned to the Node-RED instance running on the FlowForge server as well as all associated Devices.
 
-Devices also have `FF_DEVICE_ID` and `FF_DEVICE_NAME` set so that flows can know where they are running.
+Devices also have `FF_DEVICE_ID`, `FF_DEVICE_NAME` and `FF_DEVICE_TYPE` set so that flows can know where they are running.
 
 

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -220,12 +220,14 @@ module.exports = {
         if (!envVars || !Array.isArray(envVars)) {
             envVars = []
         }
-        const makeVar = (name, value) => {
-            return { name, value: value || '', platform: true } // add `platform` flag for UI
+        const makeVar = (name, value, deprecated) => {
+            return { name, value: value || '', platform: true, deprecated } // add `platform` and `deprecated` flags for UI
         }
         const result = []
-        result.push(makeVar('FF_PROJECT_ID', project.id || ''))
-        result.push(makeVar('FF_PROJECT_NAME', project.name || ''))
+        result.push(makeVar('FF_INSTANCE_ID', project.id || ''))
+        result.push(makeVar('FF_INSTANCE_NAME', project.name || ''))
+        result.push(makeVar('FF_PROJECT_ID', project.id || '', true)) // deprecated as of V1.6.0
+        result.push(makeVar('FF_PROJECT_NAME', project.name || '', true)) // deprecated as of V1.6.0
         result.push(...app.db.controllers.Project.removePlatformSpecificEnvVars(envVars))
         return result
     },

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -20,6 +20,7 @@
                     <td class="px-4 py-4 border w-auto align-top">
                         <FormRow
                             class="font-mono"
+                            :inputClass="item.deprecated ? 'text-yellow-700 italic' : ''"
                             v-model="item.name"
                             :error="item.error"
                             :disabled="item.encrypted"
@@ -31,6 +32,7 @@
                         <div class="w-full" v-if="!item.encrypted">
                             <FormRow
                                 class="font-mono"
+                                :inputClass="item.deprecated ? 'text-yellow-700 italic' : ''"
                                 v-model="item.value"
                                 value-empty-text=""
                                 :type="(!readOnly && (editTemplate || item.policy === undefined || item.policy))?'text':'uneditable'"></FormRow>
@@ -44,6 +46,11 @@
                                     <TrashIcon />
                                 </template>
                             </ff-button>
+                        </div>
+                        <div v-else-if="(item.deprecated === true)"
+                             class="flex justify-center "
+                             v-ff-tooltip:left="'This setting has been deprecated'">
+                            <ExclamationIcon class="inline text-yellow-700 w-4" />
                         </div>
                         <div v-else-if="(item.platform === true)" class="flex justify-center ">
                             <LockClosedIcon class="inline w-4" />
@@ -93,7 +100,7 @@ import FormRow from '@/components/FormRow'
 import FormHeading from '@/components/FormHeading'
 import LockSetting from '../components/LockSetting'
 import ChangeIndicator from '../components/ChangeIndicator'
-import { TrashIcon, PlusSmIcon, LockClosedIcon } from '@heroicons/vue/outline'
+import { TrashIcon, PlusSmIcon, LockClosedIcon, ExclamationIcon } from '@heroicons/vue/outline'
 
 export default {
     name: 'TemplateEnvironmentEditor',
@@ -142,7 +149,7 @@ export default {
                     if (this.envVarNames[field.name] === undefined) {
                         this.envVarNames[field.name] = i
                     }
-                    if (field.policy === undefined && field.platform === true) {
+                    if (field.policy === undefined && (field.platform === true || field.deprecated === true)) {
                         field.policy = false
                     }
                     if (field.policy === undefined && this.envVarNames[field.name] !== i) {
@@ -189,7 +196,8 @@ export default {
         ChangeIndicator,
         TrashIcon,
         PlusSmIcon,
-        LockClosedIcon
+        LockClosedIcon,
+        ExclamationIcon
     }
 }
 </script>

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -48,8 +48,8 @@ describe('Device controller', function () {
         it('removes env vars', async function () {
             const dummyEnvVars = [
                 { name: 'FF_FUTURE_UNKNOWN_ENV_VAR', value: 'future unknown env var starting with FF_ should be removed' },
-                { name: 'FF_PROJECT_ID', value: 'a' },
-                { name: 'FF_DEVICE_NAME', value: 'b' },
+                { name: 'FF_INSTANCE_ID', value: 'a' },
+                { name: 'FF_INSTANCE_NAME', value: 'b' },
                 { name: 'FF_DEVICE_ID', value: 'c' },
                 { name: 'FF_DEVICE_NAME', value: 'd' },
                 { name: 'FF_DEVICE_TYPE', value: 'e' },

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -24,10 +24,10 @@ describe('Project controller', function () {
             })
             const env = app.db.controllers.Project.insertPlatformSpecificEnvVars(project, null)
             should(env).be.an.Array().with.lengthOf(4)
-            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project1', platform: true }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
-            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
-            env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project1', platform: true })
-            env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true })
+            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project1', platform: true, deprecated: true }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true, deprecated: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
+            env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project1', platform: true, deprecated: undefined })
+            env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true, deprecated: undefined })
         })
         it('merges env vars', async function () {
             const project = await app.db.models.Project.create({
@@ -41,10 +41,10 @@ describe('Project controller', function () {
             ]
             const env = app.db.controllers.Project.insertPlatformSpecificEnvVars(project, dummyEnvVars)
             should(env).be.an.Array().with.lengthOf(6)
-            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project2', platform: true }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
-            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
-            env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project2', platform: true })
-            env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true })
+            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project2', platform: true, deprecated: true    }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true, deprecated: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
+            env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project2', platform: true, deprecated: undefined })
+            env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true, deprecated: undefined })
             env.should.containEql({ name: 'one', value: '1' })
             env.should.containEql({ name: 'two', value: '2' })
         })

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -41,7 +41,7 @@ describe('Project controller', function () {
             ]
             const env = app.db.controllers.Project.insertPlatformSpecificEnvVars(project, dummyEnvVars)
             should(env).be.an.Array().with.lengthOf(6)
-            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project2', platform: true, deprecated: true    }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project2', platform: true, deprecated: true }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
             env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true, deprecated: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
             env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project2', platform: true, deprecated: undefined })
             env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true, deprecated: undefined })

--- a/test/unit/forge/db/controllers/Project_spec.js
+++ b/test/unit/forge/db/controllers/Project_spec.js
@@ -23,9 +23,11 @@ describe('Project controller', function () {
                 url: ''
             })
             const env = app.db.controllers.Project.insertPlatformSpecificEnvVars(project, null)
-            should(env).be.an.Array().with.lengthOf(2)
-            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project1', platform: true })
-            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true })
+            should(env).be.an.Array().with.lengthOf(4)
+            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project1', platform: true }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
+            env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project1', platform: true })
+            env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true })
         })
         it('merges env vars', async function () {
             const project = await app.db.models.Project.create({
@@ -38,17 +40,21 @@ describe('Project controller', function () {
                 { name: 'two', value: '2' }
             ]
             const env = app.db.controllers.Project.insertPlatformSpecificEnvVars(project, dummyEnvVars)
-            should(env).be.an.Array().with.lengthOf(4)
-            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project2', platform: true })
-            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true })
+            should(env).be.an.Array().with.lengthOf(6)
+            env.should.containEql({ name: 'FF_PROJECT_NAME', value: 'project2', platform: true }) // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+            env.should.containEql({ name: 'FF_PROJECT_ID', value: project.id, platform: true }) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
+            env.should.containEql({ name: 'FF_INSTANCE_NAME', value: 'project2', platform: true })
+            env.should.containEql({ name: 'FF_INSTANCE_ID', value: project.id, platform: true })
             env.should.containEql({ name: 'one', value: '1' })
             env.should.containEql({ name: 'two', value: '2' })
         })
         it('removes env vars', async function () {
             const dummyEnvVars = [
                 { name: 'FF_FUTURE_UNKNOWN_ENV_VAR', value: 'future unknown env var starting with FF_ should be removed' },
-                { name: 'FF_PROJECT_ID', value: 'a' },
-                { name: 'FF_PROJECT_NAME', value: 'b' },
+                { name: 'FF_PROJECT_ID', value: 'a' }, // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
+                { name: 'FF_PROJECT_NAME', value: 'b' }, // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+                { name: 'FF_INSTANCE_ID', value: 'a' },
+                { name: 'FF_INSTANCE_NAME', value: 'b' },
                 { name: 'FF_DEVICE_ID', value: 'c' },
                 { name: 'FF_DEVICE_NAME', value: 'd' },
                 { name: 'FF_DEVICE_TYPE', value: 'e' },
@@ -130,8 +136,10 @@ describe('Project controller', function () {
             result.env.should.have.property('one', 'project-a')
             result.env.should.have.property('two', 'b')
             result.env.should.have.property('three', 'c')
-            result.env.should.have.property('FF_PROJECT_ID', project.id)
-            result.env.should.have.property('FF_PROJECT_NAME', 'testProject')
+            result.env.should.have.property('FF_PROJECT_ID', project.id) // deprecated in favour of FF_INSTANCE_ID as of V1.6.0
+            result.env.should.have.property('FF_PROJECT_NAME', 'testProject') // deprecated in favour of FF_INSTANCE_NAME as of V1.6.0
+            result.env.should.have.property('FF_INSTANCE_ID', project.id)
+            result.env.should.have.property('FF_INSTANCE_NAME', 'testProject')
             result.env.should.not.have.property('FF_PROJECT_VAR_TEST')
             result.env.should.not.have.property('FF_DEVICE_VAR_TEST')
             result.env.should.not.have.property('FF_RANDOM_XXX_123')

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -107,8 +107,10 @@ describe('Project model', function () {
             settings.should.have.a.property('settings')
             settings.settings.should.have.a.property('env').of.Array()
             settings.settings.env.length.should.equal(2)
-            settings.settings.env.find(e => e.name === 'FF_PROJECT_ID').should.have.a.property('value', project.id)
-            settings.settings.env.find(e => e.name === 'FF_PROJECT_NAME').should.have.a.property('value', 'testProject')
+            settings.settings.env.find(e => e.name === 'FF_PROJECT_ID').should.have.a.property('value', project.id) // deprecated in favour of FF_INSTANCE_ID as of 1.6.0
+            settings.settings.env.find(e => e.name === 'FF_PROJECT_NAME').should.have.a.property('value', 'testProject') // deprecated in favour of FF_INSTANCE_NAME as of 1.6.0
+            settings.settings.env.find(e => e.name === 'FF_INSTANCE_ID').should.have.a.property('value', project.id)
+            settings.settings.env.find(e => e.name === 'FF_INSTANCE_NAME').should.have.a.property('value', 'testProject')
         })
     })
 })

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -106,7 +106,7 @@ describe('Project model', function () {
             should(settings).be.an.Object()
             settings.should.have.a.property('settings')
             settings.settings.should.have.a.property('env').of.Array()
-            settings.settings.env.length.should.equal(2)
+            settings.settings.env.length.should.equal(4)
             settings.settings.env.find(e => e.name === 'FF_PROJECT_ID').should.have.a.property('value', project.id) // deprecated in favour of FF_INSTANCE_ID as of 1.6.0
             settings.settings.env.find(e => e.name === 'FF_PROJECT_NAME').should.have.a.property('value', 'testProject') // deprecated in favour of FF_INSTANCE_NAME as of 1.6.0
             settings.settings.env.find(e => e.name === 'FF_INSTANCE_ID').should.have.a.property('value', project.id)

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -364,8 +364,10 @@ describe('Project API', function () {
             runtimeSettings.should.have.property('settings')
             runtimeSettings.settings.should.have.property('header')
             runtimeSettings.settings.header.should.have.property('title', 'test-project')
-            runtimeSettings.should.have.property('env').which.have.property('FF_PROJECT_ID', result.id)
-            runtimeSettings.should.have.property('env').which.have.property('FF_PROJECT_NAME', 'test-project')
+            runtimeSettings.should.have.property('env').which.have.property('FF_PROJECT_ID', result.id) // depreciated in favour of FF_INSTANCE_ID as of V1.6.0
+            runtimeSettings.should.have.property('env').which.have.property('FF_PROJECT_NAME', 'test-project') // depreciated in favour of FF_INSTANCE_NAME as of V1.6.0
+            runtimeSettings.should.have.property('env').which.have.property('FF_INSTANCE_ID', result.id)
+            runtimeSettings.should.have.property('env').which.have.property('FF_INSTANCE_NAME', 'test-project')
         })
 
         it('Create a project with upper case characters in name', async function () {


### PR DESCRIPTION
## Description

Deprecate env vars `FF_PROJECT_*` in favour of `FF_INSTANCE_*` 

### Screenshot:
![image](https://user-images.githubusercontent.com/44235289/226683027-d2f2075d-cb1b-4653-9607-0f26f8403726.png)


## Related Issue(s)

#1844 

## Checklist


 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

