### PR TITLE
Fix mosquitto plugin path for docker install

### DIFF
--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -220,6 +220,7 @@ you can use a pre-built docker image that provides everything needed.
     You will need to customise the values to match your local configuration:
      - `auth_opt_http_host` value to match the IP address of either the docker0 interface or the external IP address of the machine running the Forge platform
      - `auth_opt_http_port` if you have changed the port the Forge platform is running on
+     - `auth_plugin` should be changed to `auth_plugin /mosquitto/broker/go-auth.so`
 
 3. Start the container with the following command
     ```bash

--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -220,7 +220,7 @@ you can use a pre-built docker image that provides everything needed.
     You will need to customise the values to match your local configuration:
      - `auth_opt_http_host` value to match the IP address of either the docker0 interface or the external IP address of the machine running the Forge platform
      - `auth_opt_http_port` if you have changed the port the Forge platform is running on
-     - `auth_plugin` should be changed to `auth_plugin /mosquitto/broker/go-auth.so`
+     - `auth_plugin` should be changed to `auth_plugin /mosquitto/go-auth.so`
 
 3. Start the container with the following command
     ```bash


### PR DESCRIPTION


## Description

<!-- Describe your changes in detail -->
Default path is wrong for docker, should be `auth_plugin auth_plugin /mosquitto/go-auth.so

## Related Issue(s)

NA

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

