### PR TITLE
Add Billing URL to reminder emails

### DIFF
--- a/forge/ee/lib/billing/emailTemplates/TrialTeamReminder.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamReminder.js
@@ -3,6 +3,7 @@
 // - teamName
 // - endingInDuration
 // - billingSetup
+// - billingUrl
 
 module.exports = {
     subject: 'Your FlowForge trial ends soon',
@@ -25,6 +26,8 @@ suspend any trial projects you have created.
 If you want them to keep running, please setup billing before the trial ends. You
 will only get charged once the trial ends.
 {{/if}}
+
+You can mange your team's billing here: {{billingUrl}}
 
 Cheers!
 
@@ -50,6 +53,8 @@ suspend any trial projects you have created.</p>
 will only get charged once the trial ends.</p>
 {{/if}}
 </p>
+
+<p>You can mange your team's billing <a href="{{billingUrl}}">here</a></p>
 
 <p>Cheers!</p>
 

--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -65,9 +65,11 @@ module.exports.init = function (app) {
         for (const subscription of pendingEmailSubscriptions) {
             const endingInDurationDays = Math.ceil((subscription.trialEndsAt - Date.now()) / ONE_DAY)
             const endingInDuration = endingInDurationDays + ' day' + ((endingInDurationDays !== 1) ? 's' : '')
+            const billingUrl = `${app.config.base_url}/team/${subscription.Team.slug}/billing`
             await sendTrialEmail(subscription.Team, 'TrialTeamReminder', {
                 endingInDuration,
-                billingSetup: subscription.isActive()
+                billingSetup: subscription.isActive(),
+                billingUrl
             })
             if (subscription.trialStatus === app.db.models.Subscription.TRIAL_STATUS.CREATED) {
                 subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.WEEK_EMAIL_SENT

--- a/test/unit/forge/ee/lib/billing/trialTask_spec.js
+++ b/test/unit/forge/ee/lib/billing/trialTask_spec.js
@@ -146,7 +146,7 @@ describe('Billing - Trial Housekeeper Task', function () {
         await app.db.controllers.Subscription.createSubscription(trialTeam, subscription, customer)
         await trialSub.reload()
 
-        // Create another project - which should get billed normalled
+        // Create another project - which should get billed normally
         const response2 = await app.inject({
             method: 'POST',
             url: '/api/v1/projects',
@@ -268,6 +268,9 @@ describe('Billing - Trial Housekeeper Task', function () {
         const trialSub = await app.db.controllers.Subscription.createTrialSubscription(trialTeam, Date.now() + 30 * DAY_MS)
         await trialTeam.addUser(TestObjects.alice, { through: { role: Roles.Owner } })
 
+        // Generate the billing Url for later checking that emails contain it
+        const billingUrl = `${app.config.base_url}/team/${trialTeam.slug}/billing`
+
         await task(app)
 
         // Nothing should have happened
@@ -283,7 +286,11 @@ describe('Billing - Trial Housekeeper Task', function () {
         app.config.email.transport.messages.should.have.length(1)
         await trialSub.reload()
         trialSub.trialStatus.should.equal(app.db.models.Subscription.TRIAL_STATUS.WEEK_EMAIL_SENT)
-        app.config.email.transport.messages[0].text.includes(' 7 days.').should.be.true()
+        const email1 = app.config.email.transport.messages[0]
+        email1.text.includes(' 7 days.').should.be.true()
+        // check that the email includes the billing url to conform with stripe/visa requirements
+        email1.should.have.a.property('text').and.containEql(billingUrl)
+        email1.should.have.a.property('html').and.containEql(billingUrl)
 
         // Rerun task - ensure email not sent again
         await task(app)
@@ -297,7 +304,11 @@ describe('Billing - Trial Housekeeper Task', function () {
         app.config.email.transport.messages.should.have.length(2)
         await trialSub.reload()
         trialSub.trialStatus.should.equal(app.db.models.Subscription.TRIAL_STATUS.DAY_EMAIL_SENT)
-        app.config.email.transport.messages[1].text.includes(' 1 day.').should.be.true()
+        const email2 = app.config.email.transport.messages[1]
+        email2.text.includes(' 1 day.').should.be.true()
+        // check that the email text includes the billing url to conform with stripe/visa requirements
+        email2.should.have.a.property('text').and.containEql(billingUrl)
+        email2.should.have.a.property('html').and.containEql(billingUrl)
 
         // Rerun task - ensure email not sent again
         await task(app)


### PR DESCRIPTION
## Description

Ensure trial expiry emails contain link to billing

## Related Issue(s)

#1815 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

