### PR TITLE
docs: Fix broken links and anchors

### DIFF
--- a/docs/install/kubernetes/aws.md
+++ b/docs/install/kubernetes/aws.md
@@ -187,7 +187,7 @@ it from inside the cluster (and not the Node-RED instances).
 
 Please read it carefully before running it to ensure you understand it.
 
-A copy of this file can be found [here](setup-rds.sh)
+A copy of this file can be found [here](./setup-rds.sh)
 
 Run the following command
 

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -66,8 +66,7 @@ that was introduced in FlowForge 1.1.
 Details of how to configure this can be found at the following links:
 
 - [LocalFS](../install/file-storage/README.md#localfs)
-- [Docker](../install/file-storage/README.md#docker-compose)
-- [Kubernetes](../install/file-storage/README.md#kubernetes-helm)
+- [Docker and Kubernetes](../install/file-storage/README.md#configuring)
 
 ### Upgrading to 1.1
 
@@ -91,7 +90,7 @@ This release introduces an MQTT Broker into the FlowForge platform used to commu
 between devices and the core platform.
 
 For LocalFS users, they will need to manually setup the broker and ensure it is
-properly configured. The documentation for this is available [here](../install/local/README.md#mosquitto)
+properly configured. The documentation for this is available [here](../install/local/#setting-up-mosquitto-(optional))
 
 #### LocalFS Users
 

--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -6,10 +6,10 @@ are a few concepts the platform introduces to help organise things.
  - [Team](#team)
  - [Application](#application)
  - [Instance](#instance)
-   - [Type](#type)
+   - [Type](#instance-type)
    - [Stack](#stack)
    - [Template](#template)
-   - [Snapshot](#snapshot)
+   - [Snapshot](#instance-snapshot)
  - [Device](#device)
 
 


### PR DESCRIPTION
Part of a link checker to CI[1], these links were marked as broken. This change fix for all known issues at this time.

[1]: https://github.com/flowforge/website/pull/536