### PR TITLE
Add support for past_due subscriptions

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -63,6 +63,9 @@ class SubscriptionHandler {
 
         const subscription = await this.requireSubscription(project.Team)
         if (subscription.isCanceled()) {
+            // Mark this project state as 'not_billed' so that it will get
+            // added back to any future subscription
+            await this._app.billing.setProjectBillingState(project, this.BILLING_STATES.NOT_BILLED)
             this._app.log.warn(`Skipped removing project '${project.id}' from subscription for canceled subscription '${subscription.subscription}'`)
             return
         }

--- a/forge/db/migrations/20230330-01-add-subscription-past-due.js
+++ b/forge/db/migrations/20230330-01-add-subscription-past-due.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-unused-vars */
+/**
+ * Add past_due as valid state for a Subscription
+ */
+
+const { DataTypes, QueryInterface } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (queryInterface) => {
+        const tableExists = await queryInterface.tableExists('Subscriptions')
+        if (!tableExists) {
+            return queryInterface.sequelize.log('Skipping Subscription migration as table does not exist')
+        }
+
+        if (queryInterface.sequelize.options.dialog === 'postgres') {
+            // Postgres enums need to be explicitly updated
+            queryInterface.sequelize.query("ALTER TYPE \"enum_Subscriptions_status\" ADD VALUE 'past_due';")
+        }
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/ee/db/models/Subscription.js
+++ b/forge/ee/db/models/Subscription.js
@@ -10,7 +10,7 @@ const STATUS = {
     // https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses
     ACTIVE: 'active',
     CANCELED: 'canceled',
-
+    PAST_DUE: 'past_due',
     // Local only status, not from Stripe
     TRIAL: 'trial'
 }
@@ -67,10 +67,13 @@ module.exports = {
             instance: {
                 // Should this subscription be treated as active/usable
                 isActive () {
-                    return this.status === STATUS.ACTIVE
+                    return this.status === STATUS.ACTIVE || this.status === STATUS.PAST_DUE
                 },
                 isCanceled () {
                     return this.status === STATUS.CANCELED
+                },
+                isPastDue () {
+                    return this.status === STATUS.PAST_DUE
                 },
                 isTrial () {
                     return !!this.trialEndsAt || this.status === STATUS.TRIAL

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -97,6 +97,7 @@ module.exports = async function (app) {
             if (subscription) {
                 result.billing.active = subscription.isActive()
                 result.billing.canceled = subscription.isCanceled()
+                result.billing.pastDue = subscription.isPastDue()
                 if (subscription.isTrial()) {
                     result.billing.trial = true
                     result.billing.trialEnded = subscription.isTrialEnded()

--- a/frontend/src/components/banners/SubscriptionExpired.vue
+++ b/frontend/src/components/banners/SubscriptionExpired.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        v-if="subscriptionExpired"
+        v-if="subscriptionExpired || subscriptionPastDue"
         class="ff-banner ff-banner-warning"
         :class="{
             'cursor-pointer': linkToBilling
@@ -9,13 +9,14 @@
         @click="navigateToBilling"
     >
         <span>
-            <ExclamationCircleIcon class="ff-icon mr-2" /> The subscription for this team has expired.
-
+            <ExclamationCircleIcon class="ff-icon mr-2" />
+            <span v-if="subscriptionExpired">The subscription for this team has expired.</span>
+            <span v-else-if="subscriptionPastDue">The subscription for this team has over due payments.</span>
             <template v-if="linkToBilling">
-                Please visit <strong>Billing settings</strong> to renew.
+                Please visit <strong>Billing settings</strong> to update.
             </template>
             <template v-else-if="!hasPermission('team:edit')">
-                Please ask a team administrator to renew the subscription.
+                Please ask a team administrator to update the subscription.
             </template>
         </span>
 
@@ -55,6 +56,9 @@ export default {
         },
         onBillingPage () {
             return this.$route.path.includes(this.billingPath)
+        },
+        subscriptionPastDue () {
+            return this.team.billing?.pastDue
         },
         subscriptionExpired () {
             return this.team.billing?.canceled

--- a/test/unit/forge/ee/db/controllers/Subscription_spec.js
+++ b/test/unit/forge/ee/db/controllers/Subscription_spec.js
@@ -141,4 +141,23 @@ describe('Subscription controller', function () {
             endedSubscription.isTrialEnded().should.be.true()
         })
     })
+
+    describe('Past Due state', function () {
+        it('treats a past_due subscription as still active', async function () {
+            const defaultTeamType = await app.db.models.TeamType.findOne()
+            const team = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: defaultTeamType.id })
+
+            const newSubscription = await app.db.controllers.Subscription.createSubscription(team, 'my-subscription', 'a-customer')
+            newSubscription.isActive().should.be.true()
+            newSubscription.isCanceled().should.be.false()
+            newSubscription.isPastDue().should.be.false()
+
+            newSubscription.status = 'past_due'
+            await newSubscription.save()
+
+            newSubscription.isActive().should.be.true()
+            newSubscription.isCanceled().should.be.false()
+            newSubscription.isPastDue().should.be.true()
+        })
+    })
 })


### PR DESCRIPTION
Fixes #1878 

As I originally thought this was going to collide with the changes in #1889 I chose to based this work on the `fix-coupons` branch. In hindsight, I think the changes are somewhat more self-contained so don't strictly need to be based on that branch... but they both need to go in regardless.

## Description

This adds track of 'past_due' stripe subscriptions. This is the state they go into as soon as a payment has failed.

With this PR, we update our internal state to 'past_due', but we still treat that as 'active' as far as all the billing logic goes. This ensures no change in functionality at this point in time. We may choose to restrict behaviour in the future - but not as part of this PR.

This then allows us to add a banner notifying the user if there is an over due payment:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/51083/228611152-6feea464-933e-4b01-9c76-38ff8fb5cc23.png">

This also includes a related fix where, when a subscription is canceled and we suspend all projects, we weren't resetting the billing state. This prevented them being re-added to new subscription once setup.

## Related Issue(s)

#1878 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

