### PR TITLE
PostHog events & groups first pass

### DIFF
--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -1,4 +1,5 @@
 import client from './client.js'
+import product from '../services/product.js'
 import daysSince from '../utils/daysSince.js'
 import elapsedTime from '../utils/elapsedTime.js'
 import { RoleNames, Roles } from '../../../forge/lib/roles.js'
@@ -19,20 +20,22 @@ const logout = () => {
 }
 
 const registerUser = async (options) => {
-    window.posthog?.identify(options.username, {
+    product.identify(options.username, {
         name: options.name,
         username: options.username,
-        email: options.email
+        email: options.email,
+        'ff-user': true
     })
     return client.post('/account/register', options).then(res => res.data)
 }
 
 const getUser = () => {
     return client.get('/api/v1/user/').then((res) => {
-        window.posthog?.identify(res.data.username, {
+        product.identify(res.data.username, {
             name: res.data.name,
             username: res.data.username,
-            email: res.data.email
+            email: res.data.email,
+            'ff-user': true
         })
         return res.data
     })
@@ -66,14 +69,26 @@ const getTeamInvitations = async () => {
         return res.data
     })
 }
-const acceptTeamInvitation = async (invitationId) => {
+const acceptTeamInvitation = async (invitationId, teamId) => {
     return client.patch('/api/v1/user/invitations/' + invitationId).then(res => {
+        // product.capture('$ff-invite-accepted', {
+        //     'invite-id': invitationId,
+        //     'accepted-at': (new Date()).toISOString()
+        // }, {
+        //     team: teamId
+        // })
         return res.data
     })
 }
 
-const rejectTeamInvitation = async (invitationId) => {
+const rejectTeamInvitation = async (invitationId, teamId) => {
     return client.delete('/api/v1/user/invitations/' + invitationId).then(res => {
+        // product.capture('$ff-invite-rejected', {
+        //     'invite-id': invitationId,
+        //     'rejected-at': (new Date()).toISOString()
+        // }, {
+        //     team: teamId
+        // })
         return res.data
     })
 }

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -3,7 +3,7 @@
         <ff-data-table data-el="table" :columns="inviteColumns" :rows="invitations">
             <template v-slot:context-menu="{row}">
                 <ff-list-item data-action="accept" label="Accept" @click="acceptInvite(row)"/>
-                <ff-list-item data-action="reject" label="Reject" kind="danger" @click="rejectInvite(row.id)"/>
+                <ff-list-item data-action="reject" label="Reject" kind="danger" @click="rejectInvite(row)"/>
             </template>
         </ff-data-table>
     </div>
@@ -35,7 +35,7 @@ export default {
     },
     methods: {
         async acceptInvite (invite) {
-            await userApi.acceptTeamInvitation(invite.id)
+            await userApi.acceptTeamInvitation(invite.id, invite.team.id)
             await this.fetchData()
             await this.$store.dispatch('account/refreshTeams')
             // navigate to team dashboad once invite accepted
@@ -46,8 +46,8 @@ export default {
                 }
             })
         },
-        async rejectInvite (inviteId) {
-            await userApi.rejectTeamInvitation(inviteId)
+        async rejectInvite (invite) {
+            await userApi.rejectTeamInvitation(invite.id, invite.team.id)
             await this.fetchData()
         },
         async fetchData () {

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -179,7 +179,7 @@ export default {
             this.loading.deleting = true
 
             try {
-                await applicationApi.deleteApplication(this.application.id)
+                await applicationApi.deleteApplication(this.application.id, this.team.id)
                 await this.$store.dispatch('account/refreshTeam')
                 this.$router.push({ name: 'Home' })
                 alerts.emit('Application successfully deleted.', 'confirmation')

--- a/frontend/src/pages/device/Settings/Danger.vue
+++ b/frontend/src/pages/device/Settings/Danger.vue
@@ -56,7 +56,7 @@ export default {
         },
         deleteDevice () {
             this.loading.deleting = true
-            deviceApi.deleteDevice(this.device.id).then(() => {
+            deviceApi.deleteDevice(this.device.id, this.team.id).then(() => {
                 this.$router.push({ name: 'TeamDevices', params: { team_slug: this.team.slug } })
             }).catch(err => {
                 console.warn(err)

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -309,7 +309,7 @@ export default {
         deleteInstance () {
             const applicationId = this.instance.application.id
             this.loading.deleting = true
-            InstanceApi.deleteInstance(this.instance.id).then(async () => {
+            InstanceApi.deleteInstance(this.instance.id, applicationId, this.team.id).then(async () => {
                 await this.$store.dispatch('account/refreshTeam')
                 this.$router.push({ name: 'Application', params: { id: applicationId } })
                 alerts.emit('Instance successfully deleted.', 'confirmation')

--- a/frontend/src/services/product.js
+++ b/frontend/src/services/product.js
@@ -1,0 +1,47 @@
+
+/**
+ *
+ * @param {String} userId - the unique identifier for the user
+ * @param {Object} set - an object containing any number of properties to bind with this user, these can be overridden
+ * @param {Object} setonce - an object containing any number of properties to bind with this user, these can never be overridden
+ */
+function identify (userId, set, setonce) {
+    window.posthog?.identify(userId, set, setonce)
+}
+
+/**
+ *
+ * @param {String} event - the name/identifier of the event
+ * @param {Object} properties - an object containing any number of properties to bind with this event, this can also contain
+ * a proeprty $set or $set_once which in turn can be an object to bind properties to the associated user
+ * @param {Object} groups - ties a given 'group' to the event. Optional keys: 'team', 'application', 'instance', 'device'
+ */
+function capture (event, properties, groups) {
+    if (!properties) {
+        properties = {}
+    }
+    if (groups) {
+        properties.$groups = groups
+    }
+    window.posthog?.capture(event, properties)
+}
+
+/**
+ *
+ * @param {String} type - team | application | instance | device
+ * @param {String} id - the associated id to this group type
+ * @param {Object} proeprties - a JSON object defining features for this group, all can be overriden
+ */
+function groupUpdate (type, id, properties) {
+    capture('$groupidentify', {
+        $group_type: type,
+        $group_key: id,
+        $group_set: properties
+    })
+}
+
+export default {
+    identify,
+    capture,
+    groupUpdate
+}


### PR DESCRIPTION
## Description

- New `product.js` service added to provide a centralised resource for calling PostHog. Also handles the case where no PostHog is configured or exists

Identify:
- Now when a user logs in, we also record a `ff-user: true` against the Person object, as currently we rely on `email` and `username` existing to infer this, which is reliable, but may not be guaranteed.

Events Added:
- `$ff-application-created`
- `$ff-application-deleted`
- `$ff-instance-created`
- `$ff-instance-deleted`
- `$ff-device-created`
- `$ff-device-deleted`
- `$ff-snapshot-created`
- `$ff-snapshot-deleted`
- `$ff-team-created`
    - Although, currently this is not triggered when a team is auto-created on sign-up as this is done server-side.
- `$ff-team-deleted`
- `$ff-invite-sent`
- `$ff-invite-removed`
- `$ff-invite-accepted`
- `$ff-invite-rejected`

Group Calls:
- `team` group is identified whenever the `getTeam` function is called, this then updates the PH group with number of instances, applications members, etc.
- `application` group is called upon instance creation, and currently only updated on deletion
- `instance` group is called upon instance creation, and currently only updated on deletion
- `device` group is called upon instance creation, and currently only updated on deletion


I have opted to architect this such that additional fields are required to pass to the services, e.g. team/application ids, then all of the PH logic is centralised to the services, rather than needing to be built on each page the functions/services are used.

## Related Issue(s)

Closes #1904

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
