### PR TITLE
Disable the "Open Editor" button if Instance not "running"

### DIFF
--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -45,7 +45,7 @@
                                 </span>
                             </div>
                             <div class="flex justify-end">
-                                <ff-button kind="secondary" :disabled="instance.settings?.disableEditor" @click.stop="openEditor(instance)">
+                                <ff-button kind="secondary" :disabled="instance.settings?.disableEditor || instance.meta?.state !== 'running'" @click.stop="openEditor(instance)">
                                     <template #icon-right><ExternalLinkIcon /></template>
                                     {{ instance.settings?.disableEditor ? 'Editor Disabled' : 'Open Editor' }}
                                 </ff-button>


### PR DESCRIPTION
## Description

I don't believe there are any states where we'd want to open the editor, other than, when the Instance is "running". As such, even though #1931 specifies blocking on "starting" this change blocks on all states, except for "running"

## Related Issue(s)

Fixes #1931

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
