### PR TITLE
Refresh Instance state after Suspend and prevent redirect

### DIFF
--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -329,7 +329,8 @@ export default {
             }, () => {
                 this.loading.suspend = true
                 InstanceApi.suspendInstance(this.instance.id).then(() => {
-                    this.$router.push({ name: 'Home' })
+                    // this.$router.push({ name: 'Home' })
+                    this.updateInstance()
                     alerts.emit('Instance successfully suspended.', 'confirmation')
                 }).catch(err => {
                     console.warn(err)


### PR DESCRIPTION
## Description

No need to redirect to the "home" view after a suspension of an Instance, instead we now just reload the Instance such that we get the latest "state" to reflect "suspended"

## Related Issue(s)

Fixes #1938 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)