### PR TITLE
Improved "last updated" labelling

### DIFF
--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -22,8 +22,19 @@
                     </tr>
                     <tr class="border-b">
                         <td class="font-medium">Status</td>
-                        <td><div class="py-2">
-                            <InstanceStatusBadge :status="instance.meta.state" :pendingStateChange="instance.pendingStateChange" :optimisticStateChange="instance.optimisticStateChange" /></div>
+                        <td class="py-2">
+                            <InstanceStatusBadge :status="instance.meta.state" :pendingStateChange="instance.pendingStateChange" :optimisticStateChange="instance.optimisticStateChange" />
+                        </td>
+                    </tr>
+                    <tr class="border-b">
+                        <td class="font-medium">Last Updated</td>
+                        <td class="py-2">
+                            <template v-if="instance.flowLastUpdatedSince">
+                                {{ instance.flowLastUpdatedSince }}
+                            </template>
+                            <span v-else class="text-gray-400 italic">
+                                flows never deployed
+                            </span>
                         </td>
                     </tr>
                     <tr class="border-b">

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -37,11 +37,12 @@
                             </div>
                             <div><InstanceStatusBadge :status="instance.meta?.state" :optimisticStateChange="instance.optimisticStateChange" :pendingStateChange="instance.pendingStateChange" /></div>
                             <div class="text-sm">
-                                <span v-if="instance.flowLastUpdatedSince">
-                                    {{ instance.flowLastUpdatedSince }}
+                                <span v-if="instance.flowLastUpdatedSince" class="flex flex-col">
+                                    <label class="text-xs text-gray-400">Last Updated: </label>
+                                    {{ instance.flowLastUpdatedSince || 'never' }}
                                 </span>
-                                <span v-else class="text-gray-400">
-                                    never
+                                <span v-else class="text-gray-400 italic">
+                                    flows never deployed
                                 </span>
                             </div>
                             <div class="flex justify-end">

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -48,7 +48,7 @@ export default {
             columns: [
                 { label: 'Name', class: ['flex-grow'], key: 'name', sortable: true },
                 { label: 'Status', class: ['w-44'], key: 'status', sortable: true, component: { is: markRaw(InstanceStatusBadge) } },
-                { label: 'Updated', class: ['w-60'], key: 'flowLastUpdatedSince', sortable: true },
+                { label: 'Last Updated', class: ['w-60'], key: 'flowLastUpdatedSince', sortable: true },
                 { label: 'Application', class: ['flex-grow-[0.25]'], key: 'application.name', sortable: true }
             ]
         }


### PR DESCRIPTION
## Description

Explicit labelling added to the Team > Applications view.

<img width="1386" alt="Screenshot 2023-04-11 at 10 59 49" src="https://user-images.githubusercontent.com/99246719/231127038-15ee743d-31f1-4ff8-9d19-60c632209c5e.png">

Added row into the Instance > Overview to include the "last updated" data too.

<img width="694" alt="Screenshot 2023-04-11 at 11 00 02" src="https://user-images.githubusercontent.com/99246719/231127031-f4d72899-c222-4045-a1bc-fd2a91dd5df1.png">

## Related Issue(s)

Closes #1951 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

