### PR TITLE
Pending email change

### DIFF
--- a/forge/auditLog/user.js
+++ b/forge/auditLog/user.js
@@ -30,6 +30,12 @@ module.exports = {
                 async verifyToken (actionedBy, error) {
                     await log('account.verify.verify-token', actionedBy, generateBody({ error }))
                 }
+            },
+            async changeEmailRequest (actionedBy, error, user) {
+                await log('account.change-email-request', actionedBy, generateBody({ error, user }))
+            },
+            async changeEmailConfirmed (actionedBy, error, user) {
+                await log('account.change-email-confirmed', actionedBy, generateBody({ error, user }))
             }
         }
 

--- a/forge/db/controllers/User.js
+++ b/forge/db/controllers/User.js
@@ -95,7 +95,7 @@ module.exports = {
         const TOKEN_EXPIRY = 1000 * 60 * 60 * 24 * 2 // 48 Hours
         const expiresAt = Math.floor((Date.now() + TOKEN_EXPIRY) / 1000) // 48 hours
         const signingHash = sha256(user.password)
-        return jwt.sign({ sub: user.email, change: newEmailAddress, exp: expiresAt }, signingHash)
+        return jwt.sign({ sub: user.email, id: user.hashid, change: newEmailAddress, aud: 'update-user-email', exp: expiresAt }, signingHash)
     },
 
     sendPendingEmailChangeEmail: async function (app, user, newEmailAddress) {
@@ -104,6 +104,8 @@ module.exports = {
             user,
             'PendingEmailChange',
             {
+                oldEmail: user.email,
+                newEmail: newEmailAddress,
                 confirmEmailLink: `${app.config.base_url}/account/email_change/${pendingEmailChangeToken}`
             }
         )
@@ -112,35 +114,39 @@ module.exports = {
     applyPendingEmailChange: async function (app, user, token) {
         // Get the email from the token (.sub)
         const peekToken = jwt.decode(token)
-        if (peekToken && peekToken.sub) {
-            // Get the corresponding user from the email in the token
-            const requestingUser = await app.db.models.User.byEmail(peekToken.sub)
-            // ensure the current user is the same as the one we are trying to change the email for
-            if (!requestingUser || user?.id !== requestingUser?.id) {
-                throw new Error('Invalid link')
-            }
-            // check that the users Email is the same as it was when the token was generated
-            // and that the token contains a new email address that is different to the current one
-            if (!requestingUser.email_verified || requestingUser.email !== peekToken.sub || user.email === peekToken.change) {
-                throw new Error('Invalid link')
-            }
+        if (!peekToken?.sub || peekToken?.aud !== 'update-user-email') {
+            throw new Error('Invalid link')
+        }
 
-            // Verify the token
-            const signingHash = sha256(requestingUser.password)
-            try {
-                const decodedToken = jwt.verify(token, signingHash)
-                if (decodedToken) {
-                    requestingUser.email = decodedToken.change // apply new Email Address
-                    requestingUser.email_verified = true
-                    await requestingUser.save()
-                    return requestingUser
-                }
-            } catch (err) {
-                if (err.name === 'TokenExpiredError') {
-                    throw new Error('Link expired')
-                } else {
-                    throw new Error('Invalid link')
-                }
+        // Get the corresponding user from the email in the token
+        const requestingUser = await app.db.models.User.byEmail(peekToken.sub)
+        // ensure the current user is the same as the one we are trying to change the email for
+        if (!requestingUser || user?.id !== requestingUser?.id) {
+            throw new Error('Invalid link')
+        }
+        if (user?.hashid !== peekToken?.id) {
+            throw new Error('Invalid link')
+        }
+        // check that the users Email is the same as it was when the token was generated
+        // and that the token contains a new email address that is different to the current one
+        if (!requestingUser.email_verified || requestingUser.email !== peekToken.sub || user.email === peekToken.change) {
+            throw new Error('Invalid link')
+        }
+
+        // Verify the token
+        const signingHash = sha256(requestingUser.password)
+        try {
+            const decodedToken = jwt.verify(token, signingHash)
+            if (!decodedToken) {
+                throw new Error('Invalid link')
+            }
+            requestingUser.email = decodedToken.change // apply new Email Address
+            requestingUser.email_verified = true
+            await requestingUser.save()
+            return requestingUser
+        } catch (err) {
+            if (err.name === 'TokenExpiredError') {
+                throw new Error('Link expired')
             }
         }
         throw new Error('Invalid link')

--- a/forge/lib/validate.js
+++ b/forge/lib/validate.js
@@ -1,11 +1,24 @@
 module.exports = {
-    isFQDN (string) {
+    /**
+     * Validate a FQDN
+     * @param {String} domain Domain string to validate
+     * @returns {boolean} `true` if the string is a valid FQDN
+     */
+    isFQDN (domain) {
         // Maximum of 253 characters
         // Made up of alphanumeric+hyphen segments up 1-63 characters long that does not start/end in hyphens
         // Ends in a TLD of 2-63 alphanumeric characters
         // Optional trailing .
         const regex = /(?=^.{4,253}\.?$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)/
 
-        return regex.test(string)
+        return regex.test(domain)
+    },
+    /**
+     * Validate an email address
+     * @param {String} emailAddress Email address to validate
+     * @returns {boolean} `true` if the email address is valid
+     */
+    isEmail (emailAddress) {
+        return emailAddress && typeof emailAddress === 'string' && /.+@.+/.test(emailAddress)
     }
 }

--- a/forge/postoffice/templates/PendingEmailChange.js
+++ b/forge/postoffice/templates/PendingEmailChange.js
@@ -1,0 +1,30 @@
+module.exports = {
+    subject: 'Pending Email Change Notification for FlowForge',
+    text:
+`Hello
+
+A request to change your Email Address has been made on the FlowForge platform.
+
+* Old email address: {{{ oldEmail }}}
+* New email address: {{{ newEmail }}}
+
+Please click the following link to confirm this change:
+{{{ confirmEmailLink }}}
+
+If you did not request this, please ignore this Email.
+If this continues to occur, contact your system administrator.
+`,
+    html:
+`<p>Hello</p>
+<p>A request to change your Email Address has been made on the FlowForge platform.</p>
+<ul>
+<li>Old email address: {{{ oldEmail }}}</li>
+<li>New email address: {{{ newEmail }}}</li>
+</ul>
+<p>Please click the following link to confirm this change:
+    <a href="{{{ confirmEmailLink }}}">{{{ confirmEmailLink }}}</a>
+</p>
+<p>If you did not request this, please ignore this Email.</p>
+<p>If this continues to occur, contact your system administrator.</p>
+`
+}

--- a/frontend/src/api/user.js
+++ b/frontend/src/api/user.js
@@ -97,6 +97,27 @@ const verifyEmailToken = async (token) => {
     })
 }
 /**
+ * Helper function to call runtime API to send a new pending email
+ * address change verification email
+ * @param {string} newEmailAddress The new email address
+ * @returns {Promise}
+ */
+const triggerPendingEmailChangeVerification = async (newEmailAddress) => {
+    return client.post('/account/email_change', newEmailAddress).then(res => {
+        return res.data
+    })
+}
+/**
+ * Helper function to call 'account' 'email_change' API
+ * @param {string} token The token provided in the users email
+ * @returns {Promise}
+ */
+const verifyPendingEmailChangeToken = async (token) => {
+    return client.post(`/account/email_change/${token}`).then(res => {
+        return res.data
+    })
+}
+/**
  * Helper function to request password reset.
  * See [routes/api/account.js](../../../forge/routes/auth/index.js)
  * @param {string} email The users email address
@@ -128,5 +149,7 @@ export default {
     triggerVerification,
     verifyEmailToken,
     requestPasswordReset,
-    resetPassword
+    resetPassword,
+    verifyPendingEmailChangeToken,
+    triggerPendingEmailChangeVerification
 }

--- a/frontend/src/pages/account/Settings.vue
+++ b/frontend/src/pages/account/Settings.vue
@@ -148,7 +148,11 @@ export default {
             if (changed) {
                 userApi.updateUser(opts).then((response) => {
                     this.$store.dispatch('account/setUser', response)
-                    alerts.emit('User successfully updated.', 'confirmation')
+                    if (response?.pendingEmailChange) {
+                        alerts.emit('An Email has been sent to your inbox to verify your new Email Address.', 'confirmation', 7000)
+                    } else {
+                        alerts.emit('User successfully updated.', 'confirmation')
+                    }
                     this.user = response
                     this.teams.forEach(team => {
                         if (team.value === this.user.defaultTeam) {

--- a/frontend/src/pages/account/VerifyPendingEmailChange.vue
+++ b/frontend/src/pages/account/VerifyPendingEmailChange.vue
@@ -1,0 +1,47 @@
+<template>
+    <ff-layout-box class="ff-login">
+        <form v-if="!pending" class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
+            <div>
+                <ff-button class="m-auto" @click="verify()">Click here to verify your change of email address</ff-button>
+            </div>
+        </form>
+    </ff-layout-box>
+</template>
+
+<script>
+
+import { mapState } from 'vuex'
+
+import userApi from '../../api/user.js'
+import FFLayoutBox from '../../layouts/Box.vue'
+import alerts from '../../services/alerts.js'
+
+export default {
+    name: 'VerifyPendingEmailChange',
+    components: {
+        'ff-layout-box': FFLayoutBox
+    },
+    props: {
+        token: { type: String, required: true }
+    },
+    computed: {
+        ...mapState(['pending'])
+    },
+    methods: {
+        async verify () {
+            const timing = 4000
+            try {
+                await userApi.verifyPendingEmailChangeToken(this.$route.params.token)
+                window.location = '/'
+            } catch (err) {
+                if (err.response?.data) {
+                    alerts.emit(`Unable to confirm new email. ${err.response.data.error}`, 'warning', timing)
+                } else {
+                    alerts.emit('Unable to confirm new email. Check logs for details.', 'warning', timing)
+                    console.error(err)
+                }
+            }
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/account/VerifyPendingEmailChange.vue
+++ b/frontend/src/pages/account/VerifyPendingEmailChange.vue
@@ -1,11 +1,9 @@
 <template>
-    <ff-layout-box class="ff-login">
-        <form v-if="!pending" class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
-            <div>
-                <ff-button class="m-auto" @click="verify()">Click here to verify your change of email address</ff-button>
-            </div>
-        </form>
-    </ff-layout-box>
+    <form v-if="!pending" class="px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
+        <div>
+            <ff-button class="m-auto" @click="verify()">Click here to verify your change of email address</ff-button>
+        </div>
+    </form>
 </template>
 
 <script>
@@ -13,14 +11,10 @@
 import { mapState } from 'vuex'
 
 import userApi from '../../api/user.js'
-import FFLayoutBox from '../../layouts/Box.vue'
 import alerts from '../../services/alerts.js'
 
 export default {
     name: 'VerifyPendingEmailChange',
-    components: {
-        'ff-layout-box': FFLayoutBox
-    },
     props: {
         token: { type: String, required: true }
     },

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -102,6 +102,7 @@ export default [
         path: '/account/email_change/:token',
         props: true,
         meta: {
+            modal: true,
             requiresLogin: true
         },
         component: VerifyPendingEmailChange

--- a/frontend/src/pages/account/routes.js
+++ b/frontend/src/pages/account/routes.js
@@ -10,6 +10,7 @@ import AccessRequest from './AccessRequest.vue'
 import AccessRequestEditor from './AccessRequestEditor.vue'
 import AccountCreate from './Create.vue'
 import VerifyEmail from './VerifyEmail.vue'
+import VerifyPendingEmailChange from './VerifyPendingEmailChange.vue'
 import ForgotPassword from './ForgotPassword.vue'
 import PasswordReset from './PasswordReset.vue'
 
@@ -95,6 +96,15 @@ export default [
             requiresLogin: false
         },
         component: VerifyEmail
+    },
+    {
+        name: 'VerifyPendingEmailChange',
+        path: '/account/email_change/:token',
+        props: true,
+        meta: {
+            requiresLogin: true
+        },
+        component: VerifyPendingEmailChange
     },
     {
         profileLink: true,

--- a/test/unit/forge/db/controllers/User_spec.js
+++ b/test/unit/forge/db/controllers/User_spec.js
@@ -1,12 +1,22 @@
 const should = require('should') // eslint-disable-line
 const setup = require('../setup')
 const jwt = require('jsonwebtoken')
-
+// create jsdoc typedef for userController
+/**
+ * @typedef {import('../../../../../forge/db/controllers/User')} userController
+ * @typedef {import('flowforge-test-utils/forge/postoffice/localTransport.js')} localTransport
+ */
 describe('User controller', function () {
     // Use standard test data.
     let app
+    /** @type {userController} */
+    let userController = null
+    /** @type {localTransport} */
+    let inbox = null
     beforeEach(async function () {
         app = await setup()
+        userController = app.db.controllers.User
+        inbox = app.config.email.transport
     })
 
     afterEach(async function () {
@@ -67,6 +77,110 @@ describe('User controller', function () {
                 return
             }
             throw new Error('Password changed with invalid oldPassword')
+        })
+    })
+
+    describe('change email address', function () {
+        it('generates a token for Email Address change', async function () {
+            const newEmailAddress = 'alice2@example.com'
+            const alice = await app.db.models.User.byUsername('alice')
+            const token = await userController.generatePendingEmailChangeToken(alice, newEmailAddress)
+            const decodedToken = jwt.decode(token)
+            // decodedToken should have the following properties: sub, id, aud, change
+            decodedToken.should.have.property('sub', alice.email)
+            decodedToken.should.have.property('id', alice.hashid)
+            decodedToken.should.have.property('aud', 'update-user-email')
+            decodedToken.should.have.property('change', newEmailAddress)
+        })
+        it('sends and Email Address change Email', async function () {
+            const newEmailAddress = 'alice3@example.com'
+            const alice = await app.db.models.User.byUsername('alice')
+            await userController.sendPendingEmailChangeEmail(alice, newEmailAddress)
+            inbox.messages.should.have.length(1)
+            const email = inbox.messages[0]
+            email.should.have.property('to', alice.email)
+            email.text.should.containEql(alice.email)
+            email.text.should.containEql(newEmailAddress)
+            // email.text.includes(newEmailAddress).should.be.true('Email should contain new email address')
+            // email.text should contain a link and token
+            should(email.text).match(/account\/email_change\/[a-zA-Z0-9-_.]+/, 'Email should contain a link and token')
+        })
+        it('changes a users Email Address', async function () {
+            const newEmailAddress = 'alice4@example.com'
+            const alice = await app.db.models.User.byUsername('alice')
+            const token = await userController.generatePendingEmailChangeToken(alice, newEmailAddress)
+            await userController.applyPendingEmailChange(alice, token)
+            await alice.reload()
+            alice.email.should.equal(newEmailAddress)
+        })
+        it('fails if Email Address already in use', async function () {
+            const newEmailAddress = (await app.db.models.User.byUsername('bob')).email
+            const alice = await app.db.models.User.byUsername('alice')
+            const originalEmail = alice.email
+            const token = await userController.generatePendingEmailChangeToken(alice, newEmailAddress)
+            try {
+                await userController.applyPendingEmailChange(alice, token)
+            } catch (error) {
+                error.message.should.equal('Invalid link')
+            }
+            await alice.reload()
+            alice.email.should.eql(originalEmail) // should be unchanged
+        })
+        it('fails if Users Email Address has changed since token was issued', async function () {
+            const alice = await app.db.models.User.byUsername('alice')
+            const token = await userController.generatePendingEmailChangeToken(alice, 'alice3@example.com')
+            alice.email = 'alice2@example.com'
+            alice.email_verified = true
+            await alice.save()
+            try {
+                await userController.applyPendingEmailChange(alice, token)
+            } catch (error) {
+                error.message.should.equal('Invalid link')
+            }
+            await alice.reload()
+            alice.email.should.eql('alice2@example.com') // unchanged since before token was issued
+        })
+        it('fails if Users ID differs from the hashid embedded in the token', async function () {
+            const alice = await app.db.models.User.byUsername('alice')
+            const aliceEmail = alice.email
+            const bob = await app.db.models.User.byUsername('bob')
+            const bobEmail = bob.email
+
+            // generate pending email change token for alice (using alice's original email address)
+            const token = await userController.generatePendingEmailChangeToken(alice, 'alice3@example.com')
+
+            // swap alice and bob's email addresses
+            alice.email = 'temp@example.com'
+            alice.email_verified = true
+            await alice.save()
+
+            bob.email = aliceEmail
+            bob.email_verified = true
+            await bob.save()
+
+            alice.email = bobEmail
+            alice.email_verified = true
+            await alice.save()
+
+            // attempt to apply changes to alice (now with bob's original email) using the token
+            // should fail as alice now has a different email to what the token was generated with
+            try {
+                await userController.applyPendingEmailChange(alice, token)
+            } catch (error) {
+                error.message.should.equal('Invalid link')
+            }
+            await alice.reload()
+            alice.email.should.eql(bobEmail) // should not have changed to new email 'alice3@example.com'
+
+            // attempt to apply changes to bob (now with alice's original email) using the token
+            // should fail as bob has a different hashid to what the token was generated with
+            try {
+                await userController.applyPendingEmailChange(bob, token)
+            } catch (error) {
+                error.message.should.equal('Invalid link')
+            }
+            await bob.reload()
+            bob.email.should.eql(aliceEmail) // should not have changed to new email 'alice3@example.com'
         })
     })
 

--- a/test/unit/forge/ee/routes/sso/index_spec.js
+++ b/test/unit/forge/ee/routes/sso/index_spec.js
@@ -4,7 +4,7 @@ const { LocalTransport } = require('flowforge-test-utils/forge/postoffice/localT
 
 describe('SSO Provider APIs', function () {
     let app
-    let inbox
+    /** @type {LocalTransport} */ let inbox
     const TestObjects = { tokens: {} }
 
     async function login (username, password) {

--- a/test/unit/forge/routes/api/user_spec.js
+++ b/test/unit/forge/routes/api/user_spec.js
@@ -158,7 +158,8 @@ describe('User API', async function () {
             const result = response.json()
             result.should.not.have.property('error')
             result.should.have.property('name', 'afkae presley')
-            result.should.have.property('email', 'afkae@example.com')
+            result.should.have.property('email', 'elvis@example.com') // Email should NOT be updated, instead a pending change email is sent
+            result.should.have.property('pendingEmailChange', true)
             result.should.have.property('username', 'afkae')
             // ensure audit log entry is made
             // TODO: re-introduce audit log tests below once #1183 is complete
@@ -184,7 +185,9 @@ describe('User API', async function () {
             response.statusCode.should.equal(400)
             const result = response.json()
             result.should.have.property('code', 'invalid_email')
-            result.should.have.property('error', 'Validation isEmail on email failed')
+            // check result.error is either 'Validation isEmail on email failed' or 'Error: Invalid email address'
+            // this is because the error message is different depending on if the validation was done by DB create fail or by internal validation
+            should(result.error).equalOneOf('Validation isEmail on email failed', 'Error: Invalid email address')
         })
         const ssoUserUpdateEmailTest = it('sso_enabled user cannot change email', async function () {
             await login('bob', 'bbPassword')


### PR DESCRIPTION
closes #813

## Description

Instead of changing ones own Email Address immediately, this PR will send a Pending Change Email to the user

* When Email address is updated, an email with a token + hyperlink to the verify page is sent to the ORIGNAL user
  * This token a JWT and expires in 48h
* When the link is operated, the user is directed to the "CLICK TO CONFIRM" page
  * If the user is NOT logged in, they must first log in & then they are redirected to the "CLICK TO CONFIRM" page
* Audit log entries for change request and for change complete

<br>

* Under the hood
  * the, original Email Address must NOT have changed since the token was generated (this will be checked and the token rejected if something has changed)
  * the new Email will NOT be accepted if it would result in a duplicate Email address (someone may have created an new account in the mean time)
  * the users hashid must be identical to the one stored in token (prevent spoofing)

<br>

* Tests added
* Existing tests updated to account for changes to a user changing "own" address

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/813

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

