### PR TITLE
Update Stripe redirect & add holding message

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -109,8 +109,8 @@ module.exports.init = async function (app) {
                 },
                 client_reference_id: team.hashid,
                 payment_method_types: ['card'],
-                success_url: `${app.config.base_url}/team/${team.slug}/overview?billing_session={CHECKOUT_SESSION_ID}`,
-                cancel_url: `${app.config.base_url}/team/${team.slug}/overview`
+                success_url: `${app.config.base_url}/team/${team.slug}/applications?billing_session={CHECKOUT_SESSION_ID}`,
+                cancel_url: `${app.config.base_url}/team/${team.slug}/applications`
             }
 
             let userBillingCode

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -62,6 +62,12 @@
                 </li>
             </ul>
         </template>
+        <div v-else-if="justSetupBilling">
+            <div class=" mt-8 text-center text-lg">
+                <strong class="mb-2 block">Thank you for signing up to FlowForge!</strong>
+                You are now able to create applications, instances & devices.
+            </div>
+        </div>
         <div v-else class="ff-no-data">
             No Applications Created
         </div>
@@ -95,6 +101,7 @@ export default {
     props: ['team', 'teamMembership'],
     data () {
         return {
+            justSetupBilling: false,
             loading: false,
             applications: new Map(),
             columns: [
@@ -107,6 +114,7 @@ export default {
     },
     mounted () {
         this.fetchData()
+        this.checkBillingSession()
     },
     methods: {
         async fetchData () {
@@ -187,6 +195,9 @@ export default {
                     id: instance.id
                 }
             })
+        },
+        async checkBillingSession () {
+            this.justSetupBilling = 'billing_session' in this.$route.query
         }
     }
 }

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -101,7 +101,6 @@ export default {
     props: ['team', 'teamMembership'],
     data () {
         return {
-            justSetupBilling: false,
             loading: false,
             applications: new Map(),
             columns: [
@@ -109,12 +108,16 @@ export default {
             ]
         }
     },
+    computed: {
+        justSetupBilling () {
+            return 'billing_session' in this.$route.query
+        }
+    },
     watch: {
         team: 'fetchData'
     },
     mounted () {
         this.fetchData()
-        this.checkBillingSession()
     },
     methods: {
         async fetchData () {
@@ -195,9 +198,6 @@ export default {
                     id: instance.id
                 }
             })
-        },
-        async checkBillingSession () {
-            this.justSetupBilling = 'billing_session' in this.$route.query
         }
     }
 }

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -42,8 +42,8 @@ describe('Billing', function () {
 
             result.should.have.property('mode', 'subscription')
             result.should.have.property('client_reference_id', newTeam.hashid)
-            result.should.have.property('success_url', 'http://localhost:3000/team/new-team/overview?billing_session={CHECKOUT_SESSION_ID}')
-            result.should.have.property('cancel_url', 'http://localhost:3000/team/new-team/overview')
+            result.should.have.property('success_url', 'http://localhost:3000/team/new-team/applications?billing_session={CHECKOUT_SESSION_ID}')
+            result.should.have.property('cancel_url', 'http://localhost:3000/team/new-team/applications')
             result.should.have.property('subscription_data')
             result.subscription_data.should.have.property('metadata')
             result.subscription_data.metadata.should.have.property('team', newTeam.hashid)


### PR DESCRIPTION
## Description

- Directs users to `/applications` instead of `/overview` which no longer exists
- Adds a holding message which is _very_ unlikely to be seen, as they join in trial, and setup an Application (for free) as part of the onboarding, but it's nice to be nice just in case this state does arise.

<img width="1426" alt="Screenshot 2023-04-11 at 18 45 46" src="https://user-images.githubusercontent.com/99246719/231246391-5cf79428-dd52-45d6-9900-04ceb82e0975.png">

## Related Issue(s)

Close #1955 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

