### PR TITLE
Include 'state' as part of the Application byTeam model

### DIFF
--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -52,7 +52,7 @@ module.exports = {
                         includes.push({
                             model: M.Project,
                             as: 'Instances',
-                            attributes: ['hashid', 'id', 'name', 'slug', 'links', 'url'],
+                            attributes: ['hashid', 'id', 'name', 'slug', 'links', 'url', 'state'],
                             include: [
                                 // Need for project URL calculation (depends on httpAdminRoot)
                                 {


### PR DESCRIPTION
## Description

The list of instances within an Application shown in the Team > Applications view was not aware of `state`. This meant that the check on `line 259` of `db/model/Project.js` was not recognising that the DB recorded state as `suspended`, and therefore we should not be doing a check with the driver.

## Related Issue(s)

Closes #1973 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

