### PR TITLE
Improve feedback when trying to delete non-empty application

### DIFF
--- a/forge/routes/api/application.js
+++ b/forge/routes/api/application.js
@@ -122,7 +122,7 @@ module.exports = async function (app) {
             // TODO need to stop all project containers and delete the projects
             // For now, error if there are any projects
             if (await request.application.projectCount() > 0) {
-                return reply.code(422).send({ code: 'invalid_application', error: 'All this applications projects must be deleted first' })
+                return reply.code(422).send({ code: 'invalid_application', error: 'Please delete the instances within the application first' })
             }
 
             await request.application.destroy()

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -208,7 +208,7 @@ export default {
                 alerts.emit('Application successfully deleted.', 'confirmation')
             } catch (err) {
                 if (err.response.data.error) {
-                    alerts.emit(`Application failed to delete: ${err.response.data.error}`, 'warning', 10)
+                    alerts.emit(`Application failed to delete: ${err.response.data.error}`, 'warning', 10000)
                 } else {
                     alerts.emit('Application failed to delete', 'warning')
                 }

--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -208,7 +208,7 @@ export default {
                 alerts.emit('Application successfully deleted.', 'confirmation')
             } catch (err) {
                 if (err.response.data.error) {
-                    alerts.emit(`Application failed to delete: ${err.response.data.error}`, 'warning')
+                    alerts.emit(`Application failed to delete: ${err.response.data.error}`, 'warning', 10)
                 } else {
                     alerts.emit('Application failed to delete', 'warning')
                 }

--- a/frontend/src/services/alerts.js
+++ b/frontend/src/services/alerts.js
@@ -8,7 +8,7 @@ export default {
      * Show a toast notification
      * @param {string} msg The message to show
      * @param {'info'|'confirmation'|'warning'} [type] Toast style
-     * @param {number} [countdown] How long to show (defaults to 3s)
+     * @param {number} [countdown] How long to show in ms (defaults to 3000ms)
      */
     emit: function (msg, type, countdown) {
         // type: 'info' | 'confirmation' | 'warning'


### PR DESCRIPTION
Fixes #1974

1. improves the wording that gets shown to the user
2. gives the user more than 3 seconds to read the message