### PR TITLE
Redirect /team/overview to /team/applications

### DIFF
--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -117,6 +117,12 @@ export default [
                 meta: {
                     title: 'Team - Billing'
                 }
+            },
+            {
+                path: 'overview',
+                redirect: to => {
+                    return `/team/${to.params.team_slug}/applications`
+                }
             }
         ]
     },


### PR DESCRIPTION
Fixes #1993

## Description

This ensures anyone who was bookmarked their team url pre-1.6 gets redirected to the right place.