### PR TITLE
Redirect /project/xyz/* to /instance/xyz/*

### DIFF
--- a/frontend/src/pages/instance/routes.js
+++ b/frontend/src/pages/instance/routes.js
@@ -13,6 +13,15 @@ import Instance from './index.vue'
 
 export default [
     {
+        path: '/project/:id/:remaining*',
+        redirect: to => {
+            if (to.params.remaining) {
+                return `/instance/${to.params.id}/${to.params.remaining.join('/')}`
+            }
+            return `/instance/${to.params.id}`
+        }
+    },
+    {
         path: '/instance/:id',
         redirect: to => {
             return `/instance/${to.params.id}/overview`


### PR DESCRIPTION
## Description

Adds a redirect for all `/project/xyz` routes to `/instance/xyz` routes. This is ensures existing stacks that redirect back to `/project/xyz` are taken to the right place.