### PR TITLE
Reduce forge app reinitialisation in model tests

### DIFF
--- a/test/unit/forge/db/models/Device_spec.js
+++ b/test/unit/forge/db/models/Device_spec.js
@@ -5,14 +5,10 @@ describe('Device model', function () {
     // Use standard test data.
     let app
 
-    afterEach(async function () {
-        if (app) {
-            await app.close()
-            app = null
-        }
-    })
-
     describe('License limits', function () {
+        afterEach(async function () {
+            await app.close()
+        })
         it('Permits overage when licensed', async function () {
             // This license has limit of 2 devices
             const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTk1MjAwLCJleHAiOjc5ODcwNzUxOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjoyLCJkZXYiOnRydWUsImlhdCI6MTY2MjY1MzkyMX0.Tj4fnuDuxi_o5JYltmVi1Xj-BRn0aEjwRPa_fL2MYa9MzSwnvJEd-8bsRM38BQpChjLt-wN-2J21U7oSq2Fp5A'
@@ -48,8 +44,13 @@ describe('Device model', function () {
         })
     })
     describe('Settings hash', function () {
-        it('is updated when the device name is changed', async function () {
+        before(async function () {
             app = await setup()
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('is updated when the device name is changed', async function () {
             const device = await app.db.models.Device.create({ name: 'D1', type: 'PI', credentialSecret: '' })
             await device.save()
             const initialSettingsHash = device.settingsHash
@@ -59,7 +60,6 @@ describe('Device model', function () {
             device.settingsHash.should.not.equal(initialSettingsHash)
         })
         it('is updated when the device type is changed', async function () {
-            app = await setup()
             const device = await app.db.models.Device.create({ name: 'D1', type: 'PI', credentialSecret: '' })
             await device.save()
             const initialSettingsHash = device.settingsHash
@@ -69,7 +69,6 @@ describe('Device model', function () {
             device.settingsHash.should.not.equal(initialSettingsHash)
         })
         it('is updated when the device env vars are changed', async function () {
-            app = await setup()
             const device = await app.db.models.Device.create({ name: 'D1', type: 'PI', credentialSecret: '' })
             await device.save()
             const initialSettingsHash = device.settingsHash

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -35,7 +35,6 @@ describe('Project model', function () {
             })
         })
         it('Does not permit overage when unlicensed', async function () {
-            app = await setup({ })
             app.license.defaults.projects = 2 // override default
             ;(await app.db.models.Project.count()).should.equal(0)
             await app.db.models.Project.create({ name: 'p1', type: '', url: '' })

--- a/test/unit/forge/db/models/Project_spec.js
+++ b/test/unit/forge/db/models/Project_spec.js
@@ -4,27 +4,35 @@ const setup = require('../setup')
 describe('Project model', function () {
     // Use standard test data.
     let app
-
-    afterEach(async function () {
-        if (app) {
-            await app.close()
-            app = null
-        }
+    before(async function () {
+        app = await setup()
+    })
+    after(async function () {
+        await app.close()
     })
 
     describe('License limits', function () {
-        it('Permits overage when licensed', async function () {
-            app = await setup({
-                // license has projects limit set to 2
-                license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjIsImRldmljZXMiOjUwLCJkZXYiOnRydWUsImlhdCI6MTY2MjQ4NDgzNn0.akS_SIeRNK_mQZyPXGVbg1odqoRRAi62xOyDS3jHnUVhSLvwZIpWBZu799PXCXRS0fV98GxVWjZm7i1YbuxlUg'
+        describe('Licensed', function () {
+            before(async function () {
+                await app.close()
+                app = await setup({
+                    // license has projects limit set to 2
+                    license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjIsImRldmljZXMiOjUwLCJkZXYiOnRydWUsImlhdCI6MTY2MjQ4NDgzNn0.akS_SIeRNK_mQZyPXGVbg1odqoRRAi62xOyDS3jHnUVhSLvwZIpWBZu799PXCXRS0fV98GxVWjZm7i1YbuxlUg'
+                })
             })
-            ;(await app.db.models.Project.count()).should.equal(0)
-            await app.db.models.Project.create({ name: 'p1', type: '', url: '' })
-            ;(await app.db.models.Project.count()).should.equal(1)
-            await app.db.models.Project.create({ name: 'p2', type: '', url: '' })
-            ;(await app.db.models.Project.count()).should.equal(2)
-            await app.db.models.Project.create({ name: 'p3', type: '', url: '' })
-            ;(await app.db.models.Project.count()).should.equal(3)
+            after(async function () {
+                await app.close()
+                app = await setup()
+            })
+            it('Permits overage when licensed', async function () {
+                ;(await app.db.models.Project.count()).should.equal(0)
+                await app.db.models.Project.create({ name: 'p1', type: '', url: '' })
+                ;(await app.db.models.Project.count()).should.equal(1)
+                await app.db.models.Project.create({ name: 'p2', type: '', url: '' })
+                ;(await app.db.models.Project.count()).should.equal(2)
+                await app.db.models.Project.create({ name: 'p3', type: '', url: '' })
+                ;(await app.db.models.Project.count()).should.equal(3)
+            })
         })
         it('Does not permit overage when unlicensed', async function () {
             app = await setup({ })
@@ -46,18 +54,14 @@ describe('Project model', function () {
     })
 
     describe('Project Type', function () {
-        beforeEach(async function () {
-            app = await setup()
-        })
-
         it('has a project type', async function () {
             const project = await app.db.models.Project.create({
-                name: 'testProject',
+                name: 'testProject-01',
                 type: '',
                 url: ''
             })
             const projectType = await app.db.models.ProjectType.create({
-                name: 'default-project-type',
+                name: 'default-project-type-01',
                 properties: {},
                 active: true
             })
@@ -66,17 +70,13 @@ describe('Project model', function () {
             const reloadedProject = await app.db.models.Project.byId(project.id)
             const pt = await reloadedProject.getProjectType()
 
-            pt.name.should.equal('default-project-type')
+            pt.name.should.equal('default-project-type-01')
         })
     })
     describe('Project Settings', function () {
-        beforeEach(async function () {
-            app = await setup()
-        })
-
         it('can get project settings in one query', async function () {
             const project = await app.db.models.Project.create({
-                name: 'testProject',
+                name: 'testProject-02',
                 type: '',
                 url: ''
             })
@@ -98,7 +98,7 @@ describe('Project model', function () {
 
         it('includes platform specific env vars', async function () {
             const project = await app.db.models.Project.create({
-                name: 'testProject',
+                name: 'testProject-03',
                 type: '',
                 url: ''
             })
@@ -108,9 +108,9 @@ describe('Project model', function () {
             settings.settings.should.have.a.property('env').of.Array()
             settings.settings.env.length.should.equal(4)
             settings.settings.env.find(e => e.name === 'FF_PROJECT_ID').should.have.a.property('value', project.id) // deprecated in favour of FF_INSTANCE_ID as of 1.6.0
-            settings.settings.env.find(e => e.name === 'FF_PROJECT_NAME').should.have.a.property('value', 'testProject') // deprecated in favour of FF_INSTANCE_NAME as of 1.6.0
+            settings.settings.env.find(e => e.name === 'FF_PROJECT_NAME').should.have.a.property('value', 'testProject-03') // deprecated in favour of FF_INSTANCE_NAME as of 1.6.0
             settings.settings.env.find(e => e.name === 'FF_INSTANCE_ID').should.have.a.property('value', project.id)
-            settings.settings.env.find(e => e.name === 'FF_INSTANCE_NAME').should.have.a.property('value', 'testProject')
+            settings.settings.env.find(e => e.name === 'FF_INSTANCE_NAME').should.have.a.property('value', 'testProject-03')
         })
     })
 })

--- a/test/unit/forge/db/models/User_spec.js
+++ b/test/unit/forge/db/models/User_spec.js
@@ -7,16 +7,12 @@ describe('User model', function () {
     // Use standard test data.
     let app
 
-    afterEach(async function () {
-        if (app) {
-            await app.close()
-            app = null
-        }
-    })
-
     describe('Model properties', function () {
-        beforeEach(async function () {
+        before(async function () {
             app = await setup()
+        })
+        after(async function () {
+            await app.close()
         })
 
         it('Username must be case-insensitive unique', async function () {
@@ -146,8 +142,11 @@ describe('User model', function () {
     })
 
     describe('Class Finders', function () {
-        beforeEach(async function () {
+        before(async function () {
             app = await setup()
+        })
+        after(async function () {
+            await app.close()
         })
 
         it('User.admins returns all admin users', async function () {
@@ -200,6 +199,10 @@ describe('User model', function () {
     })
 
     describe('License limits', function () {
+        afterEach(async function () {
+            await app.close()
+        })
+
         it('Permits overage when licensed', async function () {
             // This license has limit of 5 users (3 created by default test setup)
             const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'


### PR DESCRIPTION
Part of #2004 

Reduces forge app reinit under `test/unit/forge/db/models/`

Not as productive as the controller test changes simply due to the smaller number of tests involved.