### PR TITLE
Update device/project api tests to minimise app reinitialisation

### DIFF
--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -102,7 +102,7 @@ module.exports = {
                 },
                 async getAccessToken () {
                     return M.AccessToken.findOne({
-                        where: { ownerId: '' + this.id }
+                        where: { ownerId: '' + this.id, ownerType: 'device' }
                     })
                 },
                 async updateSettingsHash (settings) {


### PR DESCRIPTION
Updates the following two files to minimise how many times they reinitialise the forge app.
 - `test/unit/forge/routes/api/device_spec.js`
 - `test/unit/forge/routes/api/project_spec.js`


Running locally this has reduced the run time for these two suites from 1m to 20s.

It also fixes a bug discovered as part of the refactoring around retrieving a device's access token.