### PR TITLE
Ensure postoffice heartbeat interval is stopped on shutdown

### DIFF
--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -11,6 +11,11 @@ module.exports = fp(async function (app, _opts, next) {
     let poStartupCheck
     const isConfigured = EMAIL_ENABLED && (app.config.email.smtp || app.config.email.transport || app.config.email.ses)
     const mailDefaults = { from: app.config.email.from ? app.config.email.from : '"FlowForge Platform" <donotreply@flowforge.com>' }
+    app.addHook('onClose', async (_) => {
+        if (poStartupCheck) {
+            clearTimeout(poStartupCheck)
+        }
+    })
 
     // Startup initialisation
     init(false, (err, connected) => {

--- a/forge/postoffice/index.js
+++ b/forge/postoffice/index.js
@@ -13,7 +13,7 @@ module.exports = fp(async function (app, _opts, next) {
     const mailDefaults = { from: app.config.email.from ? app.config.email.from : '"FlowForge Platform" <donotreply@flowforge.com>' }
     app.addHook('onClose', async (_) => {
         if (poStartupCheck) {
-            clearTimeout(poStartupCheck)
+            clearInterval(poStartupCheck)
         }
     })
 


### PR DESCRIPTION
## Description

I had noticed for a while that running individual tests locally would generally hang after the tests completed. I have also see occasional odd behaviour when running `npm run serve` around restarts hanging.

Finally tracked it down; the postoffice health-check interval wasn't been cleared on shutdown.

This fixes that.