### PR TITLE
Rework tests to minimise app reinitialisation

### DIFF
--- a/test/unit/forge/routes/storage/index_spec.js
+++ b/test/unit/forge/routes/storage/index_spec.js
@@ -8,7 +8,7 @@ describe('Storage API', function () {
     let project2
     let tokens2
 
-    beforeEach(async function () {
+    before(async function () {
         app = await setup()
         project = app.project
         tokens = await project.refreshAuthTokens()
@@ -35,7 +35,7 @@ describe('Storage API', function () {
         })
     })
 
-    afterEach(async function () {
+    after(async function () {
         await app.close()
     })
 
@@ -278,6 +278,10 @@ describe('Storage API', function () {
 
     describe('/library', function () {
         describeAuthTests('/library/functions', { name: 'test', meta: {}, body: 'foo' })
+
+        afterEach(async function () {
+            await app.db.models.StorageLibrary.destroy({ where: {} })
+        })
 
         it('Add to Library', async function () {
             this.timeout(10000)


### PR DESCRIPTION
Part of #2004 

This refactors 4 of the more 'expensive' tests to minimise the number of times they restart the forge app.

 - `test/unit/forge/routes/api/teamMembers_spec.js`
 - `test/unit/forge/routes/api/user_spec.js`
 - `test/unit/forge/routes/api/users_spec.js`
 - `test/unit/forge/routes/storage/index_spec.js`

Prior to these changes, running these four test suites took ~1m30s. With these changes they take ~25s.