### PR TITLE
Rework more tests to minimise app reinitialisation

### DIFF
--- a/test/node_modules/flowforge-test-utils/forge/postoffice/localTransport.js
+++ b/test/node_modules/flowforge-test-utils/forge/postoffice/localTransport.js
@@ -19,6 +19,9 @@
     count() {
         return this.messages.length
     }
+    empty() {
+        this.messages = []
+    }
 }
 
 module.exports = {

--- a/test/unit/forge/ee/lib/sso/index_spec.js
+++ b/test/unit/forge/ee/lib/sso/index_spec.js
@@ -5,7 +5,7 @@ const fastify = require('fastify')
 describe('SSO Providers', function () {
     let app
 
-    beforeEach(async function () {
+    before(async function () {
         app = await setup()
 
         app.samlProviders = {}
@@ -53,7 +53,7 @@ d
         })
     })
 
-    afterEach(async function () {
+    after(async function () {
         if (app) {
             await app.close()
             app = null

--- a/test/unit/forge/ee/routes/sso/index_spec.js
+++ b/test/unit/forge/ee/routes/sso/index_spec.js
@@ -18,7 +18,7 @@ describe('SSO Provider APIs', function () {
         TestObjects.tokens[username] = response.cookies[0].value
     }
 
-    beforeEach(async function () {
+    before(async function () {
         inbox = new LocalTransport()
         app = await setup({
             email: {
@@ -32,6 +32,17 @@ describe('SSO Provider APIs', function () {
         await login('bob', 'bbPassword')
 
         app.samlProviders = {}
+        await addDefaultProviders()
+    })
+
+    after(async function () {
+        await app.close()
+    })
+    afterEach(async function () {
+        await app.db.models.SAMLProvider.destroy({ where: {} })
+        await addDefaultProviders()
+    })
+    async function addDefaultProviders () {
         app.samlProviders.provider1 = await app.db.models.SAMLProvider.create({
             name: 'example.com',
             domainFilter: '@example.com',
@@ -74,14 +85,7 @@ d
     e`
             }
         })
-    })
-
-    afterEach(async function () {
-        if (app) {
-            await app.close()
-            app = null
-        }
-    })
+    }
     async function countProviders () {
         return await app.db.models.SAMLProvider.count()
     }

--- a/test/unit/forge/licensing/index_spec.js
+++ b/test/unit/forge/licensing/index_spec.js
@@ -47,197 +47,196 @@ describe('License API', async function () {
      * @returns the forge application
      */
     async function getApp (license) {
-        if (!license) {
-            return await FF_UTIL.setupApp({ license })
-        }
         return await FF_UTIL.setupApp({ license })
     }
 
-    afterEach(async function () {
-        if (app) {
+    describe('unlicensed', function () {
+        before(async function () {
+            app = await getApp()
+        })
+        after(async function () {
             await app.close()
-            app = null
-        }
+        })
+        it('Uses default limits when no license applied', async function () {
+            app.license.get('users').should.equal(app.license.defaults.users)
+            app.license.get('teams').should.equal(app.license.defaults.teams)
+            app.license.get('projects').should.equal(app.license.defaults.projects)
+            app.license.get('devices').should.equal(app.license.defaults.devices)
+        })
+
+        it('Gets all usage count and limits (unlicensed)', async function () {
+            const usage = await app.license.usage()
+            // check usage contains the correct keys
+            usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
+            // check each item has the correct keys
+            usage.users.should.only.have.keys('resource', 'count', 'limit')
+            usage.teams.should.only.have.keys('resource', 'count', 'limit')
+            usage.projects.should.only.have.keys('resource', 'count', 'limit')
+            usage.devices.should.only.have.keys('resource', 'count', 'limit')
+            // check usage values are correct
+            usage.users.count.should.equal(0)
+            usage.users.limit.should.equal(app.license.defaults.users)
+            usage.users.resource.should.equal('users')
+
+            usage.teams.count.should.equal(0)
+            usage.teams.limit.should.equal(app.license.defaults.teams)
+            usage.teams.resource.should.equal('teams')
+
+            usage.projects.count.should.equal(0)
+            usage.projects.limit.should.equal(app.license.defaults.projects)
+            usage.projects.resource.should.equal('projects')
+
+            usage.devices.count.should.equal(0)
+            usage.devices.limit.should.equal(app.license.defaults.devices)
+            usage.devices.resource.should.equal('devices')
+        })
+        it('Gets users usage count and limit only (unlicensed)', async function () {
+            const usage = await app.license.usage('users')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('users')
+            // check item has the correct keys
+            usage.users.should.only.have.keys('resource', 'count', 'limit')
+            usage.users.count.should.equal(0)
+            usage.users.limit.should.equal(app.license.defaults.users)
+            usage.users.resource.should.equal('users')
+        })
+        it('Gets teams usage count and limit only (unlicensed)', async function () {
+            const usage = await app.license.usage('teams')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('teams')
+            // check item has the correct keys
+            usage.teams.should.only.have.keys('resource', 'count', 'limit')
+            usage.teams.count.should.equal(0)
+            usage.teams.limit.should.equal(app.license.defaults.teams)
+            usage.teams.resource.should.equal('teams')
+        })
+        it('Gets projects usage count and limit only (unlicensed)', async function () {
+            const usage = await app.license.usage('projects')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('projects')
+            // check item has the correct keys
+            usage.projects.should.only.have.keys('resource', 'count', 'limit')
+            usage.projects.count.should.equal(0)
+            usage.projects.limit.should.equal(app.license.defaults.projects)
+            usage.projects.resource.should.equal('projects')
+        })
+        it('Gets devices usage count and limit only (unlicensed)', async function () {
+            const usage = await app.license.usage('devices')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('devices')
+            // check item has the correct keys
+            usage.devices.should.only.have.keys('resource', 'count', 'limit')
+            usage.devices.count.should.equal(0)
+            usage.devices.limit.should.equal(app.license.defaults.devices)
+            usage.devices.resource.should.equal('devices')
+        })
     })
 
-    it('Uses default limits when no license applied', async function () {
-        app = await FF_UTIL.setupApp({})
-        app.license.get('users').should.equal(app.license.defaults.users)
-        app.license.get('teams').should.equal(app.license.defaults.teams)
-        app.license.get('projects').should.equal(app.license.defaults.projects)
-        app.license.get('devices').should.equal(app.license.defaults.devices)
-    })
+    describe('licensed', function () {
+        before(async function () {
+            app = await getApp(TEST_LICENSE_4u_5t_6p_7d)
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Gets all usage count and limits (licensed)', async function () {
+            const usage = await app.license.usage()
+            // check usage contains the correct keys
+            usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
+            // check each item has the correct keys
+            usage.users.should.only.have.keys('resource', 'count', 'limit')
+            usage.teams.should.only.have.keys('resource', 'count', 'limit')
+            usage.projects.should.only.have.keys('resource', 'count', 'limit')
+            usage.devices.should.only.have.keys('resource', 'count', 'limit')
+            // check usage values are correct
+            usage.users.count.should.equal(0)
+            usage.users.limit.should.equal(4)
+            usage.users.resource.should.equal('users')
 
-    it('Gets all usage count and limits (unlicensed)', async function () {
-        app = await getApp() // unlicensed
-        const usage = await app.license.usage()
-        // check usage contains the correct keys
-        usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
-        // check each item has the correct keys
-        usage.users.should.only.have.keys('resource', 'count', 'limit')
-        usage.teams.should.only.have.keys('resource', 'count', 'limit')
-        usage.projects.should.only.have.keys('resource', 'count', 'limit')
-        usage.devices.should.only.have.keys('resource', 'count', 'limit')
-        // check usage values are correct
-        usage.users.count.should.equal(0)
-        usage.users.limit.should.equal(app.license.defaults.users)
-        usage.users.resource.should.equal('users')
+            usage.teams.count.should.equal(0)
+            usage.teams.limit.should.equal(5)
+            usage.teams.resource.should.equal('teams')
 
-        usage.teams.count.should.equal(0)
-        usage.teams.limit.should.equal(app.license.defaults.teams)
-        usage.teams.resource.should.equal('teams')
+            usage.projects.count.should.equal(0)
+            usage.projects.limit.should.equal(6)
+            usage.projects.resource.should.equal('projects')
 
-        usage.projects.count.should.equal(0)
-        usage.projects.limit.should.equal(app.license.defaults.projects)
-        usage.projects.resource.should.equal('projects')
+            usage.devices.count.should.equal(0)
+            usage.devices.limit.should.equal(7)
+            usage.devices.resource.should.equal('devices')
+        })
+        it('Gets users usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('users')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('users')
+            // check item has the correct keys
+            usage.users.should.only.have.keys('resource', 'count', 'limit')
+            usage.users.count.should.equal(0)
+            usage.users.limit.should.equal(4)
+            usage.users.resource.should.equal('users')
+        })
+        it('Gets teams usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('teams')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('teams')
+            // check item has the correct keys
+            usage.teams.should.only.have.keys('resource', 'count', 'limit')
+            usage.teams.count.should.equal(0)
+            usage.teams.limit.should.equal(5)
+            usage.teams.resource.should.equal('teams')
+        })
+        it('Gets projects usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('projects')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('projects')
+            // check item has the correct keys
+            usage.projects.should.only.have.keys('resource', 'count', 'limit')
+            usage.projects.count.should.equal(0)
+            usage.projects.limit.should.equal(6)
+            usage.projects.resource.should.equal('projects')
+        })
+        it('Gets devices usage count and limit only (licensed)', async function () {
+            const usage = await app.license.usage('devices')
+            // check usage contains the correct keys
+            usage.should.only.have.keys('devices')
+            // check item has the correct keys
+            usage.devices.should.only.have.keys('resource', 'count', 'limit')
+            usage.devices.count.should.equal(0)
+            usage.devices.limit.should.equal(7)
+            usage.devices.resource.should.equal('devices')
+        })
 
-        usage.devices.count.should.equal(0)
-        usage.devices.limit.should.equal(app.license.defaults.devices)
-        usage.devices.resource.should.equal('devices')
+        it('Uses license provided limits', async function () {
+            app.license.get('organisation').should.equal('FlowForge Inc.')
+            app.license.get('users').should.equal(4)
+            app.license.get('teams').should.equal(5)
+            app.license.get('projects').should.equal(6)
+            app.license.get('devices').should.equal(7)
+        })
     })
-    it('Gets users usage count and limit only (unlicensed)', async function () {
-        app = await getApp() // unlicensed
-        const usage = await app.license.usage('users')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('users')
-        // check item has the correct keys
-        usage.users.should.only.have.keys('resource', 'count', 'limit')
-        usage.users.count.should.equal(0)
-        usage.users.limit.should.equal(app.license.defaults.users)
-        usage.users.resource.should.equal('users')
-    })
-    it('Gets teams usage count and limit only (unlicensed)', async function () {
-        app = await getApp() // unlicensed
-        const usage = await app.license.usage('teams')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('teams')
-        // check item has the correct keys
-        usage.teams.should.only.have.keys('resource', 'count', 'limit')
-        usage.teams.count.should.equal(0)
-        usage.teams.limit.should.equal(app.license.defaults.teams)
-        usage.teams.resource.should.equal('teams')
-    })
-    it('Gets projects usage count and limit only (unlicensed)', async function () {
-        app = await getApp() // unlicensed
-        const usage = await app.license.usage('projects')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('projects')
-        // check item has the correct keys
-        usage.projects.should.only.have.keys('resource', 'count', 'limit')
-        usage.projects.count.should.equal(0)
-        usage.projects.limit.should.equal(app.license.defaults.projects)
-        usage.projects.resource.should.equal('projects')
-    })
-    it('Gets devices usage count and limit only (unlicensed)', async function () {
-        app = await getApp() // unlicensed
-        const usage = await app.license.usage('devices')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('devices')
-        // check item has the correct keys
-        usage.devices.should.only.have.keys('resource', 'count', 'limit')
-        usage.devices.count.should.equal(0)
-        usage.devices.limit.should.equal(app.license.defaults.devices)
-        usage.devices.resource.should.equal('devices')
-    })
+    describe('licensed - 0 claims', function () {
+        before(async function () {
+            app = await getApp(TEST_LICENSE_0_CLAIMS)
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Returns 0 as the limit property when querying usage data for a license without claims', async function () {
+            app.license.get('organisation').should.equal('FlowForge Inc.')
+            const usage = await app.license.usage()
+            usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
+            usage.users.limit.should.equal(0)
+            usage.teams.limit.should.equal(0)
+            usage.projects.limit.should.equal(0)
+            usage.devices.limit.should.equal(0)
+        })
 
-    it('Gets all usage count and limits (licensed)', async function () {
-        app = await getApp(TEST_LICENSE_4u_5t_6p_7d) // licensed
-        const usage = await app.license.usage()
-        // check usage contains the correct keys
-        usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
-        // check each item has the correct keys
-        usage.users.should.only.have.keys('resource', 'count', 'limit')
-        usage.teams.should.only.have.keys('resource', 'count', 'limit')
-        usage.projects.should.only.have.keys('resource', 'count', 'limit')
-        usage.devices.should.only.have.keys('resource', 'count', 'limit')
-        // check usage values are correct
-        usage.users.count.should.equal(0)
-        usage.users.limit.should.equal(4)
-        usage.users.resource.should.equal('users')
-
-        usage.teams.count.should.equal(0)
-        usage.teams.limit.should.equal(5)
-        usage.teams.resource.should.equal('teams')
-
-        usage.projects.count.should.equal(0)
-        usage.projects.limit.should.equal(6)
-        usage.projects.resource.should.equal('projects')
-
-        usage.devices.count.should.equal(0)
-        usage.devices.limit.should.equal(7)
-        usage.devices.resource.should.equal('devices')
-    })
-    it('Gets users usage count and limit only (licensed)', async function () {
-        app = await getApp(TEST_LICENSE_4u_5t_6p_7d) // licensed
-        const usage = await app.license.usage('users')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('users')
-        // check item has the correct keys
-        usage.users.should.only.have.keys('resource', 'count', 'limit')
-        usage.users.count.should.equal(0)
-        usage.users.limit.should.equal(4)
-        usage.users.resource.should.equal('users')
-    })
-    it('Gets teams usage count and limit only (licensed)', async function () {
-        app = await getApp(TEST_LICENSE_4u_5t_6p_7d) // licensed
-        const usage = await app.license.usage('teams')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('teams')
-        // check item has the correct keys
-        usage.teams.should.only.have.keys('resource', 'count', 'limit')
-        usage.teams.count.should.equal(0)
-        usage.teams.limit.should.equal(5)
-        usage.teams.resource.should.equal('teams')
-    })
-    it('Gets projects usage count and limit only (licensed)', async function () {
-        app = await getApp(TEST_LICENSE_4u_5t_6p_7d) // licensed
-        const usage = await app.license.usage('projects')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('projects')
-        // check item has the correct keys
-        usage.projects.should.only.have.keys('resource', 'count', 'limit')
-        usage.projects.count.should.equal(0)
-        usage.projects.limit.should.equal(6)
-        usage.projects.resource.should.equal('projects')
-    })
-    it('Gets devices usage count and limit only (licensed)', async function () {
-        app = await getApp(TEST_LICENSE_4u_5t_6p_7d)
-        const usage = await app.license.usage('devices')
-        // check usage contains the correct keys
-        usage.should.only.have.keys('devices')
-        // check item has the correct keys
-        usage.devices.should.only.have.keys('resource', 'count', 'limit')
-        usage.devices.count.should.equal(0)
-        usage.devices.limit.should.equal(7)
-        usage.devices.resource.should.equal('devices')
-    })
-
-    it('Returns 0 as the limit property when querying usage data for a license without claims', async function () {
-        app = await getApp(TEST_LICENSE_0_CLAIMS)
-        app.license.get('organisation').should.equal('FlowForge Inc.')
-        const usage = await app.license.usage()
-        usage.should.only.have.keys('users', 'teams', 'projects', 'devices')
-        usage.users.limit.should.equal(0)
-        usage.teams.limit.should.equal(0)
-        usage.projects.limit.should.equal(0)
-        usage.devices.limit.should.equal(0)
-    })
-
-    it('Uses license provided limits', async function () {
-        app = await getApp(TEST_LICENSE_4u_5t_6p_7d)
-        app.license.get('organisation').should.equal('FlowForge Inc.')
-        app.license.get('users').should.equal(4)
-        app.license.get('teams').should.equal(5)
-        app.license.get('projects').should.equal(6)
-        app.license.get('devices').should.equal(7)
-    })
-
-    it('Returns 0 for any limits if license does not include claim', async function () {
-        app = await getApp(TEST_LICENSE_0_CLAIMS)
-        app.license.get('organisation').should.equal('FlowForge Inc.')
-        app.license.get('users').should.equal(0)
-        app.license.get('teams').should.equal(0)
-        app.license.get('projects').should.equal(0)
-        app.license.get('devices').should.equal(0)
+        it('Returns 0 for any limits if license does not include claim', async function () {
+            app.license.get('organisation').should.equal('FlowForge Inc.')
+            app.license.get('users').should.equal(0)
+            app.license.get('teams').should.equal(0)
+            app.license.get('projects').should.equal(0)
+            app.license.get('devices').should.equal(0)
+        })
     })
 })

--- a/test/unit/forge/routes/api/projectSnapshots_spec.js
+++ b/test/unit/forge/routes/api/projectSnapshots_spec.js
@@ -10,19 +10,12 @@ function encryptCredentials (key, plain) {
     const cipher = crypto.createCipheriv('aes-256-ctr', key, initVector)
     return { $: initVector.toString('hex') + cipher.update(JSON.stringify(plain), 'utf8', 'base64') + cipher.final('base64') }
 }
-// function decryptCredentials (key, cipher) {
-//     let flows = cipher.$
-//     const initVector = Buffer.from(flows.substring(0, 32), 'hex')
-//     flows = flows.substring(32)
-//     const decipher = crypto.createDecipheriv('aes-256-ctr', key, initVector)
-//     const decrypted = decipher.update(flows, 'base64', 'utf8') + decipher.final('utf8')
-//     return JSON.parse(decrypted)
-// }
 
 describe('Project Snapshots API', function () {
     let app
     const TestObjects = {}
-    beforeEach(async function () {
+
+    before(async function () {
         app = await setup()
 
         TestObjects.project1 = app.project
@@ -67,7 +60,7 @@ describe('Project Snapshots API', function () {
         TestObjects.tokens[username] = response.cookies[0].value
     }
 
-    afterEach(async function () {
+    after(async function () {
         await app.close()
     })
 
@@ -399,8 +392,8 @@ describe('Project Snapshots API', function () {
             response.statusCode.should.equal(200)
 
             const snapshotList = (await listProjectSnapshots(TestObjects.project1.id, TestObjects.tokens.alice)).json()
-            snapshotList.should.have.property('snapshots')
-            snapshotList.snapshots.should.have.lengthOf(0)
+            const snapshot = snapshotList.snapshots.filter(snap => snap.id === result.id)
+            snapshot.should.have.lengthOf(0)
         })
     })
 })

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -7,7 +7,7 @@ describe('Team Invitations API', function () {
     let app
     const TestObjects = {}
 
-    beforeEach(async function () {
+    before(async function () {
         app = await setup()
 
         // alice : admin
@@ -35,6 +35,13 @@ describe('Team Invitations API', function () {
         await login('bob', 'bbPassword')
         await login('chris', 'ccPassword')
     })
+    after(async function () {
+        await app.close()
+    })
+    afterEach(async function () {
+        app.config.email.transport.empty()
+        await app.db.models.Invitation.destroy({ where: {} })
+    })
 
     async function login (username, password) {
         const response = await app.inject({
@@ -46,10 +53,6 @@ describe('Team Invitations API', function () {
         response.cookies[0].should.have.property('name', 'sid')
         TestObjects.tokens[username] = response.cookies[0].value
     }
-
-    afterEach(async function () {
-        await app.close()
-    })
 
     describe('Create an invitation', async function () {
         // POST /api/v1/teams/:teamId/invitations

--- a/test/unit/forge/routes/api/teamMembers_spec.js
+++ b/test/unit/forge/routes/api/teamMembers_spec.js
@@ -79,6 +79,8 @@ describe('Team Members API', function () {
         result.should.have.property('count', expectedMembers.length)
         result.should.have.property('members')
         result.members.should.have.lengthOf(expectedMembers.length)
+        result.members.sort((A, B) => { return A.id.localeCompare(B.id) })
+        expectedMembers.sort((A, B) => { return A.id.localeCompare(B.id) })
         for (let i = 0; i < expectedMembers.length; i++) {
             result.members[i].should.have.property('id', expectedMembers[i].id)
             result.members[i].should.have.property('role', expectedMembers[i].role)

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -5,13 +5,6 @@ describe('Accounts API', async function () {
     let app
     const TestObjects = { tokens: {} }
 
-    afterEach(async function () {
-        if (app) {
-            await app.close()
-            app = null
-        }
-    })
-
     async function registerUser (payload) {
         return app.inject({
             method: 'POST',
@@ -32,6 +25,20 @@ describe('Accounts API', async function () {
     }
 
     describe('Register User', async function () {
+        before(async function () {
+            app = await setup()
+        })
+        after(async function () {
+            await app.close()
+        })
+        afterEach(async function () {
+            // Reset settings to default
+            app.settings.set('user:signup', false)
+            app.settings.set('team:user:invite:external', false)
+            app.settings.set('user:team:auto-create', false)
+            app.license.defaults.users = 150
+        })
+
         async function expectRejection (opts, reason) {
             const response = await registerUser(opts)
             response.statusCode.should.equal(400)
@@ -39,7 +46,6 @@ describe('Accounts API', async function () {
         }
 
         it('rejects user registration if not enabled', async function () {
-            app = await setup()
             app.settings.get('user:signup').should.be.false()
             app.settings.get('team:user:invite:external').should.be.false()
             await expectRejection({
@@ -52,7 +58,6 @@ describe('Accounts API', async function () {
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
         it('allows user to register', async function () {
-            app = await setup()
             app.settings.set('user:signup', true)
 
             const response = await registerUser({
@@ -71,7 +76,6 @@ describe('Accounts API', async function () {
         })
 
         it('rejects reserved user names', async function () {
-            app = await setup()
             app.settings.set('user:signup', true)
 
             await expectRejection({
@@ -92,7 +96,6 @@ describe('Accounts API', async function () {
         })
 
         it('rejects duplicate username', async function () {
-            app = await setup()
             app.settings.set('user:signup', true)
 
             await registerUser({
@@ -112,7 +115,6 @@ describe('Accounts API', async function () {
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
         it('rejects duplicate email', async function () {
-            app = await setup()
             app.settings.set('user:signup', true)
 
             await registerUser({
@@ -132,50 +134,30 @@ describe('Accounts API', async function () {
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
 
-        it('Does not limit how many users can be created when licensed', async function () {
-            // This license has limit of 5 users (1 created by default test setup (test/unit/forge/routes/setup.js))
-            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
-            app = await setup({ license })
-            app.settings.set('user:signup', true)
-            // Register 5 more users to breach the limit
-            for (let i = 1; i <= 5; i++) {
-                const resp = await registerUser({
-                    username: `u${i}`,
-                    password: '12345678',
-                    name: `u${i}`,
-                    email: `u${i}@example.com`
-                })
-                resp.statusCode.should.equal(200)
-            }
-            // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
-        })
-
         it('Limits how many users can be created when unlicensed', async function () {
-            app = await setup({ })
-            app.license.defaults.users = 5
             app.settings.set('user:signup', true)
-            // Register 4 more users to reach the limit
-            for (let i = 2; i <= 5; i++) {
+            const currentCount = await app.db.models.User.count()
+            app.license.defaults.users = currentCount + 2
+            for (let i = currentCount; i < currentCount + 2; i++) {
                 const resp = await registerUser({
-                    username: `u${i}`,
+                    username: `u-limit-${i}`,
                     password: '12345678',
-                    name: `u${i}`,
-                    email: `u${i}@example.com`
+                    name: `u-limit-${i}`,
+                    email: `u-limit-${i}@example.com`
                 })
                 resp.statusCode.should.equal(200)
             }
             await expectRejection({
-                username: 'u6',
+                username: 'u-final',
                 password: '12345678',
-                name: 'u6',
-                email: 'u6@example.com'
+                name: 'u-final',
+                email: 'u-final@example.com'
             }, /license limit reached/)
 
             // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
         })
 
         it('allows user to register with + in email (no sso)', async function () {
-            app = await setup()
             app.settings.set('user:signup', true)
 
             const response = await registerUser({
@@ -190,7 +172,6 @@ describe('Accounts API', async function () {
         })
 
         it('auto-creates personal team if option set', async function () {
-            app = await setup()
             app.settings.set('user:signup', true)
             app.settings.set('user:team:auto-create', true)
 
@@ -224,59 +205,93 @@ describe('Accounts API', async function () {
             userTeams.teams.should.have.length(1)
         })
 
-        it('auto-creates personal team if option set - in trial mode', async function () {
-            const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
-            const TEST_TRIAL_DURATION = 5
-
-            app = await setup({ license, billing: { stripe: {} } })
-            app.settings.set('user:signup', true)
-            app.settings.set('user:team:auto-create', true)
-            app.settings.set('user:team:trial-mode', true)
-            app.settings.set('user:team:trial-mode:duration', TEST_TRIAL_DURATION)
-            app.settings.set('user:team:trial-mode:projectType', app.projectType.id)
-
-            const response = await registerUser({
-                username: 'user',
-                password: '12345678',
-                name: 'user',
-                email: 'user@example.com'
+        describe('licensed instances', function () {
+            before(async function () {
+                // close the default app
+                await app.close()
             })
-            response.statusCode.should.equal(200)
-
-            // Team is only created once they verify their email.
-            const user = await app.db.models.User.findOne({ where: { username: 'user' } })
-            const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(user)
-            await app.inject({
-                method: 'POST',
-                url: `/account/verify/${verificationToken}`,
-                payload: {},
-                cookies: { sid: TestObjects.tokens.user }
+            afterEach(async function () {
+                await app.close()
             })
-            await login('user', '12345678')
-
-            const userTeamsResponse = await app.inject({
-                method: 'GET',
-                url: '/api/v1/user/teams',
-                cookies: { sid: TestObjects.tokens.user }
+            after(async function () {
+                app = await setup()
             })
+            it('auto-creates personal team if option set - in trial mode', async function () {
+                const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
+                const TEST_TRIAL_DURATION = 5
 
-            const userTeams = userTeamsResponse.json()
-            userTeams.should.have.property('teams')
-            userTeams.teams.should.have.length(1)
+                app = await setup({ license, billing: { stripe: {} } })
+                app.settings.set('user:signup', true)
+                app.settings.set('user:team:auto-create', true)
+                app.settings.set('user:team:trial-mode', true)
+                app.settings.set('user:team:trial-mode:duration', TEST_TRIAL_DURATION)
+                app.settings.set('user:team:trial-mode:projectType', app.projectType.id)
 
-            const userTeam = await app.db.models.Team.byId(userTeams.teams[0].id)
-            const subscription = await app.db.models.Subscription.byTeamId(userTeam.id)
-            should.exist(subscription)
-            subscription.isActive().should.be.false()
-            subscription.isTrial().should.be.true()
-            subscription.isTrialEnded().should.be.false()
-            subscription.trialStatus.should.equal(app.db.models.Subscription.TRIAL_STATUS.CREATED)
+                const response = await registerUser({
+                    username: 'user',
+                    password: '12345678',
+                    name: 'user',
+                    email: 'user@example.com'
+                })
+                response.statusCode.should.equal(200)
+
+                // Team is only created once they verify their email.
+                const user = await app.db.models.User.findOne({ where: { username: 'user' } })
+                const verificationToken = await app.db.controllers.User.generateEmailVerificationToken(user)
+                await app.inject({
+                    method: 'POST',
+                    url: `/account/verify/${verificationToken}`,
+                    payload: {},
+                    cookies: { sid: TestObjects.tokens.user }
+                })
+                await login('user', '12345678')
+
+                const userTeamsResponse = await app.inject({
+                    method: 'GET',
+                    url: '/api/v1/user/teams',
+                    cookies: { sid: TestObjects.tokens.user }
+                })
+
+                const userTeams = userTeamsResponse.json()
+                userTeams.should.have.property('teams')
+                userTeams.teams.should.have.length(1)
+
+                const userTeam = await app.db.models.Team.byId(userTeams.teams[0].id)
+                const subscription = await app.db.models.Subscription.byTeamId(userTeam.id)
+                should.exist(subscription)
+                subscription.isActive().should.be.false()
+                subscription.isTrial().should.be.true()
+                subscription.isTrialEnded().should.be.false()
+                subscription.trialStatus.should.equal(app.db.models.Subscription.TRIAL_STATUS.CREATED)
+            })
+            it('Does not limit how many users can be created when licensed', async function () {
+                // This license has limit of 5 users (1 created by default test setup (test/unit/forge/routes/setup.js))
+                const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTA4ODAwLCJleHAiOjc5ODY5ODg3OTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjo1LCJ0ZWFtcyI6NTAsInByb2plY3RzIjo1MCwiZGV2aWNlcyI6NTAsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNTQ4NjAyfQ.vvSw6pm-NP5e0NUL7yMOG-w0AgB8H3NRGGN7b5Dw_iW5DiIBbVQ4HVLEi3dyy9fk7WgKnloiCCkIFJvN79fK_g'
+                app = await setup({ license })
+                app.settings.set('user:signup', true)
+                // Register 5 more users to breach the limit
+                for (let i = 1; i <= 5; i++) {
+                    const resp = await registerUser({
+                        username: `u${i}`,
+                        password: '12345678',
+                        name: `u${i}`,
+                        email: `u${i}@example.com`
+                    })
+                    resp.statusCode.should.equal(200)
+                }
+                // TODO: check user audit logs - expect 'account.xxx-yyy' { code: '', error, '' }
+            })
         })
     })
 
     describe('Verify FF Tokens', async function () {
-        it('Test token belongs to a project', async function () {
+        before(async function () {
             app = await setup()
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Test token belongs to a project', async function () {
             const authTokens = await app.project.refreshAuthTokens()
             const response = await app.inject({
                 method: 'GET',
@@ -289,7 +304,6 @@ describe('Accounts API', async function () {
         })
 
         it('Fail to verify with random project id', async function () {
-            app = await setup()
             const authTokens = await app.project.refreshAuthTokens()
             const response = await app.inject({
                 method: 'GET',
@@ -302,7 +316,6 @@ describe('Accounts API', async function () {
         })
 
         it('Fail to verify with random project id', async function () {
-            app = await setup()
             const authTokens = await app.project.refreshAuthTokens()
             const response = await app.inject({
                 method: 'GET',


### PR DESCRIPTION
Part of #2004 

Some more test refactoring to minimise reinitialisation of the forge app.

When running these tests locally, it reduces the runtime from 60s to 12s.
