### PR TITLE
Use application list to determine if team is empty

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -155,6 +155,7 @@
                 "test/e2e/frontend/cypress/tests/instances/snapshots.spec.js",
                 "test/e2e/frontend/cypress/tests/instances/staging.spec.js",
                 "test/e2e/frontend/cypress/tests/invitations.spec.js",
+                "test/e2e/frontend/cypress/tests/team/team.spec.js",
                 "test/e2e/frontend/cypress/tests/team/audit-log.spec.js",
                 "test/e2e/frontend/cypress/tests/team/team-membership.spec.js",
                 "test/e2e/frontend/cypress/tests/terms-and-conditions.spec.js"

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -4,7 +4,7 @@
         <div>
             <div class="max-w-sm pr-2">{{deleteDescription}}</div>
             <div class="mt-2">
-                <ff-button kind="danger" :disabled="!deleteActive" @click="showConfirmDeleteDialog()">Delete Team</ff-button>
+                <ff-button kind="danger" data-action="delete-team" :disabled="!deleteActive" @click="showConfirmDeleteDialog()">Delete Team</ff-button>
                 <ConfirmTeamDeleteDialog @deleteTeam="deleteTeam" ref="confirmTeamDeleteDialog"/>
             </div>
         </div>

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -22,16 +22,16 @@ export default {
     props: ['team'],
     data () {
         return {
-            projectCount: -1
+            applicationCount: -1
         }
     },
     computed: {
         deleteActive () {
-            return this.projectCount === 0
+            return this.applicationCount === 0
         },
         deleteDescription () {
-            if (this.projectCount > 0) {
-                return 'You cannot delete a team that still owns projects.'
+            if (this.applicationCount > 0) {
+                return 'You cannot delete a team that still owns applications.'
             } else {
                 return 'Deleting the team cannot be undone. Take care.'
             }
@@ -56,8 +56,8 @@ export default {
         },
         async fetchData () {
             if (this.team.id) {
-                const data = await teamApi.getTeamProjectList(this.team.id)
-                this.projectCount = data.count
+                const applicationList = await teamApi.getTeamApplications(this.team.id)
+                this.applicationCount = applicationList.count
             }
         }
     },

--- a/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog ref="dialog" header="Delete Team" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
+    <ff-dialog ref="dialog" data-el="delete-team-dialog" header="Delete Team" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
         <template v-slot:default>
             <form class="space-y-6" v-if="team" @submit.prevent>
                 <div class="space-y-6">
@@ -10,7 +10,7 @@
                         Enter the team name <code class="block">{{team.name}}</code> to continue.
                     </p>
                 </div>
-                <FormRow v-model="input.teamName" id="projectName">Name</FormRow>
+                <FormRow v-model="input.teamName" id="projectName" data-form="team-name">Name</FormRow>
             </form>
         </template>
     </ff-dialog>

--- a/test/e2e/frontend/cypress/tests/team/team.spec.js
+++ b/test/e2e/frontend/cypress/tests/team/team.spec.js
@@ -1,0 +1,79 @@
+describe('FlowForge - Team', () => {
+    let teamTypeId
+    beforeEach(() => {
+        cy.login('alice', 'aaPassword')
+        cy.home()
+        cy.intercept('GET', '/api/v1/teams/*/applications').as('getTeamApplications')
+        cy.intercept('DELETE', '/api/v1/teams/*').as('deleteTeam')
+    })
+
+    describe('Delete Team', () => {
+        it('can delete empty team', () => {
+            const TEAM_NAME = `new-team-${Math.random().toString(36).substring(2, 7)}`
+            let team
+            cy.request('GET', 'api/v1/team-types').then(response => {
+                teamTypeId = response.body.types[0].id
+                return cy.request('POST', 'api/v1/teams', {
+                    name: TEAM_NAME,
+                    type: teamTypeId
+                })
+            }).then((response) => {
+                team = response.body
+                cy.visit(`team/${team.slug}`)
+                cy.visit(`team/${team.slug}/settings/danger`)
+                cy.get('[data-action="delete-team"]').should('be.disabled')
+                cy.wait('@getTeamApplications')
+                cy.get('[data-action="delete-team"]').should('not.be.disabled')
+
+                cy.get('[data-action="delete-team"]').click()
+
+                cy.get('[data-el="delete-team-dialog"]')
+                    .should('be.visible')
+                    .within(() => {
+                        // Dialog is open
+                        cy.get('.ff-dialog-header').contains('Delete Team')
+
+                        // Main button should be disabled
+                        cy.get('button.ff-btn.ff-btn--danger').should('be.disabled')
+                        cy.get('[data-form="team-name"] input[type="text"]').type(TEAM_NAME)
+
+                        // Should now be enabled again
+                        cy.get('button.ff-btn.ff-btn--danger').click()
+
+                        cy.wait('@deleteTeam')
+                    })
+            }).then(() => {
+                cy.request('GET', 'api/v1/teams')
+            }).then(response => {
+                const teams = response.body.teams
+                const oldTeam = teams.find(t => t.id === team.id)
+                cy.wrap(oldTeam).should('be.a', 'undefined')
+            })
+        })
+
+        it('cannot delete non-empty team', () => {
+            let team
+            const TEAM_NAME = `new-team-${Math.random().toString(36).substring(2, 7)}`
+            const APP_NAME = `new-app-${Math.random().toString(36).substring(2, 7)}`
+            cy.request('GET', 'api/v1/team-types').then(response => {
+                teamTypeId = response.body.types[0].id
+                return cy.request('POST', 'api/v1/teams', {
+                    name: TEAM_NAME,
+                    type: teamTypeId
+                })
+            }).then((response) => {
+                team = response.body
+                return cy.request('POST', 'api/v1/applications', {
+                    name: APP_NAME,
+                    teamId: team.id
+                })
+            }).then(response => {
+                cy.visit(`team/${team.slug}`)
+                cy.visit(`team/${team.slug}/settings/danger`)
+                cy.get('[data-action="delete-team"]').should('be.disabled')
+                cy.wait('@getTeamApplications')
+                cy.get('[data-action="delete-team"]').should('be.disabled')
+            })
+        })
+    })
+})


### PR DESCRIPTION
Fixes #2031 

## Description

Uses the application list api to determine if the team is empty or not.

Adds test coverage for the team delete ui.

Note: I've had to add the new _spec file to the list of those for which the `require-data-selectors` lint rule is disabled. This is because the fix is needed upstream in ui-components to add data attributes to the ff-dialog components.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

