### PR TITLE
Guard against users without team edit accessing billing

### DIFF
--- a/frontend/src/pages/team/Billing.vue
+++ b/frontend/src/pages/team/Billing.vue
@@ -61,6 +61,7 @@ import Loading from '../../components/Loading.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import formatCurrency from '../../mixins/Currency.js'
 import formatDateMixin from '../../mixins/DateTime.js'
+import permissionsMixin from '../../mixins/Permissions.js'
 
 const priceCell = {
     name: 'PriceCell',
@@ -94,7 +95,7 @@ export default {
         ExternalLinkIcon,
         SectionTopMenu
     },
-    mixins: [formatDateMixin, formatCurrency],
+    mixins: [formatDateMixin, formatCurrency, permissionsMixin],
     props: ['billingUrl', 'team', 'teamMembership'],
     data () {
         return {
@@ -145,6 +146,10 @@ export default {
     async mounted () {
         if (!this.billingSetUp) {
             return
+        }
+
+        if (!this.hasPermission('team:edit')) {
+            return this.$router.push({ path: `/team/${this.team.slug}/overview` })
         }
 
         this.loading = true


### PR DESCRIPTION
## Description

Fixes two issues:
 - Prevents a request failed error when navigating to a team where a user does not have edit team access
 - Blocks the /billing pages entirely from users without team edit access (previously just hidden in the UI)

## Related Issue(s)

Fix #1845 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass - Not possible to easily test request is not being made
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

