### PR TITLE
Fix: Elapsed time between two dates

### DIFF
--- a/frontend/src/utils/elapsedTime.js
+++ b/frontend/src/utils/elapsedTime.js
@@ -60,6 +60,10 @@ export default function (to, from) {
         parts.push(reportTime('month', periods.months))
         fineGrained = false
     }
+    if (periods.weeks > 0) {
+        parts.push(reportTime('week', periods.weeks))
+        fineGrained = false
+    }
     if (periods.days > 0) {
         parts.push(reportTime('day', periods.days))
         fineGrained = false

--- a/test/unit/frontend/utils/elapsedTime.spec.js
+++ b/test/unit/frontend/utils/elapsedTime.spec.js
@@ -9,6 +9,13 @@ describe('elapsedTime', () => {
         expect(elapsedTime(new Date(Date.UTC(2020, 0, 4, 5, 6, 7)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('3 days')
     })
 
+    test('reports the number of weeks for periods longer than seven days', () => {
+        // month is 0 indexed
+        expect(elapsedTime(new Date(Date.UTC(2021, 2, 14, 5, 6, 7)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('1 year, 2 months, 1 week, 6 days')
+        expect(elapsedTime(new Date(Date.UTC(2020, 2, 15, 5, 6, 7)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('2 months, 2 weeks')
+        expect(elapsedTime(new Date(Date.UTC(2020, 0, 30, 5, 6, 7)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('4 weeks, 1 day')
+    })
+
     test('reports the number of hours, minutes for periods less than one day apart', () => {
         expect(elapsedTime(new Date(Date.UTC(2020, 0, 1, 4, 5, 6)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('4 hours, 5 minutes')
         expect(elapsedTime(new Date(Date.UTC(2020, 0, 1, 23, 55, 6)), new Date(Date.UTC(2020, 0, 1, 0, 0, 0)))).toBe('23 hours, 55 minutes')


### PR DESCRIPTION
## Description

Fixes root cause of issue in https://github.com/flowforge/flowforge/issues/1895 where displayed days left on license displayed too different values.

Issue was the elapsed time module not including weeks in the math.

## Related Issue(s)

Fixes https://github.com/flowforge/flowforge/issues/1895

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

