### PR TITLE
Add access token support to stats endpoint

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -14,6 +14,7 @@ navTitle: Administering FlowForge
  - [Usage Telemetry](/docs/admin/telemetry.md)
  - [Single-Sign On](/docs/admin/sso/README.md)
  - [User management](/docs/admin/user_management.md)
+ - [Platform Monitoring](/docs/admin/monitoring.md)
 
 ## Administering FlowForge
 

--- a/docs/admin/monitoring.md
+++ b/docs/admin/monitoring.md
@@ -1,0 +1,42 @@
+---
+navTitle: Monitoring
+---
+
+# Platform Monitoring
+
+FlowForge provides an API end-point that can be used to monitor statistical
+information about the platform.
+
+The end-point is accessible to any logged-in Admin user at the url (replace `example.com`
+with the domain of your FlowForge instance)
+
+ - `https://example.com/api/v1/admin/stats`
+
+By default it returns a JSON object containing key statistics such as the number
+of users, instances and other information.
+
+If the `accept` header of the http request includes `application/openmetrics-text`
+then the response is formatted as OpenMetrics text. This can be directly consumed
+by tools such as Prometheus.
+
+
+## Enabling token-based access
+
+In Admin Settings there is an option to allow token-based access to platform statistics.
+
+When enabled, the platform will generate an access token that can be used to access
+the end-point without having a full Admin login. This is useful when configuring
+tools such as Prometheus to monitor the platform.
+
+1. Under Admin Settings -> General, check the 'allow token-based access' option
+2. A dialog is shown containing the token. This is the *only* time the token
+   will be shown - make sure you record its value.
+
+The token should be provided as a bearer token in any http request to the end-point;
+
+```bash
+TOKEN=your_generated_token
+curl -H 'Authorization: Bearer $TOKEN' https://example.com/api/v1/admin/stats
+```
+
+

--- a/forge/db/controllers/AccessToken.js
+++ b/forge/db/controllers/AccessToken.js
@@ -135,6 +135,25 @@ module.exports = {
         return { token: token.id }
     },
 
+    generatePlatformStatisticsToken: async function (app, user) {
+        // Clear any existing platform:stats token
+        await app.db.controllers.AccessToken.removePlatformStatisticsToken()
+        await app.settings.set('platform:stats:token', true)
+        return app.db.controllers.AccessToken.createTokenForUser(user, null, ['platform:stats'])
+    },
+    removePlatformStatisticsToken: async function (app) {
+        // This assumes we only have this one path for creating such a token.
+        // In the future, if we support Personal Access Tokens, it will be
+        // possible to have multiple tokens with just this scope - so this
+        // logic will need changing
+        await app.db.models.AccessToken.destroy({
+            where: {
+                scope: 'platform:stats'
+            }
+        })
+        await app.settings.set('platform:stats:token', false)
+    },
+
     refreshToken: async function (app, refreshToken) {
         const existingToken = await app.db.models.AccessToken.byRefreshToken(refreshToken)
         if (existingToken) {

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -10,6 +10,7 @@ const comms = require('./comms')
 const cookie = require('@fastify/cookie')
 const csrf = require('@fastify/csrf-protection')
 const helmet = require('@fastify/helmet')
+const accepts = require('@fastify/accepts')
 const postoffice = require('./postoffice')
 const monitor = require('./monitor')
 const housekeeper = require('./housekeeper')
@@ -38,7 +39,7 @@ module.exports = async (options = {}) => {
             level: loggerLevel
         }
     })
-
+    server.register(accepts)
     server.addHook('onError', async (request, reply, error) => {
         // Useful for debugging when a route goes wrong
         // console.error(error.stack)

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -1,9 +1,12 @@
 const { Roles } = require('./roles.js')
 const Permissions = {
     // User Actions
-    'user:read': { description: 'View user Information', self: true },
-    'user:edit': { description: 'Edit User Information', self: true },
-    'user:delete': { description: 'Delete User', self: true },
+    'user:create': { description: 'Create User', role: Roles.Admin },
+    'user:list': { description: 'List platform users', role: Roles.Admin },
+    'user:read': { description: 'View user Information', role: Roles.Admin, self: true },
+    'user:edit': { description: 'Edit User Information', role: Roles.Admin, self: true },
+    'user:delete': { description: 'Delete User', role: Roles.Admin, self: true },
+    'user:team:list': { description: 'List a Users teams', role: Roles.Admin, self: true },
     // Team Scoped Actions
     'team:create': { description: 'Create Team' },
     'team:read': { description: 'View a Team', role: Roles.Viewer },
@@ -68,7 +71,17 @@ const Permissions = {
     'project-type:list': { description: 'List all ProjectTypes' },
     'project-type:read': { description: 'View a ProjectType' },
     'project-type:delete': { description: 'Delete a ProjectType', role: Roles.Admin },
-    'project-type:edit': { description: 'Edit a ProjectType', role: Roles.Admin }
+    'project-type:edit': { description: 'Edit a ProjectType', role: Roles.Admin },
+
+    'settings:edit': { description: 'Edit platform settings', role: Roles.Admin },
+    'license:read': { description: 'View license information', role: Roles.Admin },
+    'license:edit': { description: 'Edit license information', role: Roles.Admin },
+
+    'invitation:list': { description: 'List all invitations', role: Roles.Admin },
+
+    'platform:debug': { description: 'View platform debug information', role: Roles.Admin },
+    'platform:stats': { description: 'View platform stats information', role: Roles.Admin },
+    'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin }
 }
 
 module.exports = {

--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -81,6 +81,7 @@ const Permissions = {
 
     'platform:debug': { description: 'View platform debug information', role: Roles.Admin },
     'platform:stats': { description: 'View platform stats information', role: Roles.Admin },
+    'platform:stats:token': { description: 'Create/Delete platform stats token', role: Roles.Admin },
     'platform:audit-log': { description: 'View platform audit log', role: Roles.Admin }
 }
 

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -83,7 +83,7 @@ module.exports = async function (app) {
      */
     function convertToOpenMetrics (stats) {
         const result = flattenObject('flowforge', stats)
-        const lines = Object.entries(result).map(m => `${m[0]} ${m[1]}`)
+        const lines = Object.entries(result).map(([key, value]) => `${key} ${value}`)
         return lines.join('\n') + '\n'
     }
 

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -193,4 +193,13 @@ module.exports = async function (app) {
         const result = app.db.views.AuditLog.auditLog(logEntries)
         reply.send(result)
     })
+
+    app.post('/stats-token', { preHandler: app.needsPermission('platform:stats:token') }, async (request, reply) => {
+        const token = await app.db.controllers.AccessToken.generatePlatformStatisticsToken(request.session.User)
+        reply.send(token)
+    })
+    app.delete('/stats-token', { preHandler: app.needsPermission('platform:stats:token') }, async (request, reply) => {
+        await app.db.controllers.AccessToken.removePlatformStatisticsToken()
+        reply.send({ status: 'okay' })
+    })
 }

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -28,6 +28,13 @@ module.exports = async function (app) {
             result.projectCount += projectState.count
             result.projectsByState[projectState.state] = projectState.count
         })
+        if (app.billing) {
+            const teamStateCounts = await app.db.models.Subscription.count({ attributes: ['status'], group: 'status' })
+            result.teamsByBillingState = {}
+            teamStateCounts.forEach(teamState => {
+                result.teamsByBillingState[teamState.status] = teamState.count
+            })
+        }
         return result
     }
 

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -40,7 +40,7 @@ module.exports = async function (app) {
 
     /**
      * Converts a JSON Object to a flattened object with key names more aligned
-     * with OpemMetrics format
+     * with OpenMetrics format
      * ```
      * {
      *    propertyOne: 1,

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -42,7 +42,7 @@ module.exports = {
             let resp
             // Check if this is trying to modify anything only admin users can touch
             if (Object.hasOwn(request.body, 'email_verified') && user.email_verified !== request.body.email_verified) {
-                resp = { code: 'invalid_request', error: 'cannot verified own email' }
+                resp = { code: 'invalid_request', error: 'cannot verify own email' }
             } else if (Object.hasOwn(request.body, 'admin') && user.admin !== request.body.admin) {
                 resp = { code: 'invalid_request', error: 'cannot change admin status' }
             }

--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -40,7 +40,7 @@ module.exports = {
 
         if (!isAdmin) {
             let resp
-            // Check if this is trying to modify anything on admin users can touch
+            // Check if this is trying to modify anything only admin users can touch
             if (Object.hasOwn(request.body, 'email_verified') && user.email_verified !== request.body.email_verified) {
                 resp = { code: 'invalid_request', error: 'cannot verified own email' }
             } else if (Object.hasOwn(request.body, 'admin') && user.admin !== request.body.admin) {

--- a/forge/routes/api/user.js
+++ b/forge/routes/api/user.js
@@ -74,7 +74,7 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.user
      */
     app.get('/teams', {
-        preHandler: app.needsPermission('user:read')
+        preHandler: app.needsPermission('user:team:list')
     }, async (request, reply) => {
         const teams = await app.db.models.Team.forUser(request.session.User)
         const result = await app.db.views.Team.userTeamList(teams)

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -47,5 +47,8 @@ module.exports = {
     'user:team:trial-mode:projectType': null, // Project type that is included in the trial - required if trials enabled
 
     'branding:account:signUpTopBanner': null,
-    'branding:account:signUpLeftBanner': null
+    'branding:account:signUpLeftBanner': null,
+
+    // Has a stats monitoring token been created?
+    'platform:stats:token': false
 }

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -45,6 +45,16 @@ const getPlatformAuditLog = async (params, cursor, limit) => {
     return client.get(url, { params }).then(res => res.data)
 }
 
+const generateStatsAccessToken = async () => {
+    return client.post('/api/v1/admin/stats-token', {}).then(res => {
+        return res.data
+    })
+}
+const deleteStatsAccessToken = async () => {
+    return client.delete('/api/v1/admin/stats-token').then(res => {
+        return res.data
+    })
+}
 /**
  * Calls api routes in admin.js
  * See [routes/api/admin.js](../../../forge/routes/api/admin.js)
@@ -54,5 +64,7 @@ export default {
     getLicenseDetails,
     updateLicense,
     getInvitations,
-    getPlatformAuditLog
+    getPlatformAuditLog,
+    generateStatsAccessToken,
+    deleteStatsAccessToken
 }

--- a/frontend/src/components/FormRow.vue
+++ b/frontend/src/components/FormRow.vue
@@ -37,11 +37,11 @@
                 </div>
             </div>
             <div v-if="error" data-el="form-row-error" class="ml-9 text-red-400 inline text-xs">{{error}}</div>
-            <div v-if="hasDescription" data-el="form-row-description" class="mt-1 text-xs text-gray-400 mb-2 ml-9 space-y-1"><slot name="description"></slot></div>
+            <div v-if="hasDescription" data-el="form-row-description" class="mt-1 ff-description mb-2 ml-9 space-y-1"><slot name="description"></slot></div>
         </template>
         <template v-else>
             <label data-el="form-row-title" v-if="hasTitle" :for="inputId" :class="(disabled ? 'text-gray-400' : 'text-gray-800')" class="block text-sm font-medium mb-1"><slot></slot></label>
-            <div v-if="hasDescription" data-el="form-row-description" class="text-xs text-gray-400 mb-2 space-y-1"><slot name="description"></slot></div>
+            <div v-if="hasDescription" data-el="form-row-description" class="ff-description mb-2 space-y-1"><slot name="description"></slot></div>
             <div :class="(wrapperClass ? wrapperClass : 'flex flex-col sm:flex-row relative')">
                 <!-- Dropdown -->
                 <template v-if="options && type !== 'uneditable'">

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -249,13 +249,13 @@ export default {
         this.platformStatsToken = ''
     },
     watch: {
-        platformStatsTokenEnabled: function (v) {
+        platformStatsTokenEnabled: function (newValue) {
             if (this.platformStatsToken === null) {
                 // This is the initial setting of the value - ignore it
                 this.platformStatsToken = ''
                 return
             }
-            if (v) {
+            if (newValue) {
                 this.showGenerateStatsToken()
             } else {
                 this.showDisableStatsToken()

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -88,7 +88,51 @@
                     sent to that email address.</p>
             </template>
         </FormRow>
-        <FormHeading v-if="!isLicensed">Platform</FormHeading>
+        <FormHeading>Platform</FormHeading>
+        <FormRow v-model="platformStatsTokenEnabled" type="checkbox">
+            Allow token-based access to platform statistics
+            <template #description>
+                <p>
+                    This can be used to enable remote monitoring of the platform
+                    without providing full access to the admin API.
+                </p>
+                <p>
+                    The token is generated when this option is enabled. Once
+                    enabled, the token cannot be retrieved.
+                </p>
+                <p>
+                    To regenerate the token, disable, then re-enable this option.
+                </p>
+            </template>
+        </FormRow>
+        <ff-dialog ref="enablePlatformStatsToken" header="Allow token-based access to platform statistics">
+            <template #default>
+                <ff-loading v-if="platformStatsTokenGenerating" message="Generating token..."/>
+                <template v-else>
+                    <p>The following token can be used to access the platform statistics api.</p>
+                    <code class="block my-2">{{platformStatsToken}}</code>
+                    <p>
+                        This is the only time this token will be shared. Make sure you save it
+                        before closing this dialog.
+                    </p>
+                </template>
+            </template>
+            <template #actions>
+                <ff-button v-if="!platformStatsTokenGenerating" @click="$refs['enablePlatformStatsToken'].close()">Close</ff-button>
+                <span v-else>&nbsp;</span>
+            </template>
+        </ff-dialog>
+        <ff-dialog ref="disablePlatformStatsToken" header="Disable token-based access to platform statistics">
+            <template #default>
+                <p>This will delete the active token used to access the platform statistics.</p>
+                <p>Are you sure?</p>
+            </template>
+            <template #actions>
+                <ff-button @click="cancelDisablePlatformStatsToken">Cancel</ff-button>
+                <ff-button @click="disableStatsToken" kind="danger">Disable</ff-button>
+            </template>
+        </ff-dialog>
+
         <FormRow v-model="input['telemetry:enabled']" type="checkbox" v-if="!isLicensed">
             Enable collection of anonymous statistics
             <template #description>
@@ -102,7 +146,8 @@
                 </p>
             </template>
         </FormRow>
-        <div>
+
+        <div class="pt-8">
             <ff-button :disabled="!saveEnabled" @click="saveChanges" data-action="save-settings">Save settings</ff-button>
         </div>
 
@@ -110,6 +155,7 @@
 </template>
 
 <script>
+import adminApi from '../../../api/admin.js'
 import settingsApi from '../../../api/settings.js'
 import instanceTypesApi from '../../../api/instanceTypes.js'
 import Dialog from '../../../services/dialog.js'
@@ -132,7 +178,8 @@ const validSettings = [
     'user:team:trial-mode:duration',
     'user:team:trial-mode:projectType',
     'branding:account:signUpTopBanner',
-    'branding:account:signUpLeftBanner'
+    'branding:account:signUpLeftBanner',
+    'platform:stats:token'
 ]
 
 export default {
@@ -142,11 +189,14 @@ export default {
             loading: false,
             input: {
             },
+            platformStatsTokenEnabled: false,
+            platformStatsToken: null,
             errors: {
                 requiresEmail: null,
                 termsAndConditions: null
             },
-            instanceTypes: []
+            instanceTypes: [],
+            platformStatsTokenGenerating: false
         }
     },
     computed: {
@@ -194,6 +244,23 @@ export default {
                 label: pt.name
             }
         })
+
+        this.platformStatsTokenEnabled = this.input['platform:stats:token']
+        this.platformStatsToken = ''
+    },
+    watch: {
+        platformStatsTokenEnabled: function (v) {
+            if (this.platformStatsToken === null) {
+                // This is the initial setting of the value - ignore it
+                this.platformStatsToken = ''
+                return
+            }
+            if (v) {
+                this.showGenerateStatsToken()
+            } else {
+                this.showDisableStatsToken()
+            }
+        }
     },
     methods: {
         validate () {
@@ -268,6 +335,28 @@ export default {
                     this.loading = false
                 }
             })
+        },
+
+        showGenerateStatsToken () {
+            this.platformStatsTokenGenerating = true
+            this.$refs.enablePlatformStatsToken.show()
+            adminApi.generateStatsAccessToken().then(result => {
+                this.platformStatsToken = result.token
+                this.platformStatsTokenGenerating = false
+            })
+        },
+        showDisableStatsToken () {
+            this.$refs.disablePlatformStatsToken.show()
+        },
+        cancelDisablePlatformStatsToken () {
+            this.$refs.disablePlatformStatsToken.close()
+            this.platformStatsToken = null
+            this.platformStatsTokenEnabled = true
+        },
+        disableStatsToken () {
+            this.$refs.disablePlatformStatsToken.close()
+            this.platformStatsToken = ''
+            adminApi.deleteStatsAccessToken().then(result => {})
         }
     },
     components: {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dependencies": {
         "@aws-sdk/client-ses": "^3.100.0",
         "@aws-sdk/credential-provider-node": "^3.100.0",
+        "@fastify/accepts": "^4.1.0",
         "@fastify/cookie": "^8.3.0",
         "@fastify/csrf-protection": "^6.3.0",
         "@fastify/formbody": "^7.3.0",

--- a/test/system/101-platform-settings_spec.js
+++ b/test/system/101-platform-settings_spec.js
@@ -156,7 +156,7 @@ describe('Platform Settings', function () {
             }
         })
 
-        put1.should.have.property('statusCode', 401) // 401: {error: 'unauthorized'} from app.verifyAdmin
+        put1.should.have.property('statusCode', 403) // 403: {error: 'unauthorized'}
 
         const pass1 = getTcsSettings()
         pass1.should.have.property('tcsRequired', true) // unchanged

--- a/test/unit/forge/routes/api/admin_spec.js
+++ b/test/unit/forge/routes/api/admin_spec.js
@@ -1,0 +1,94 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('Admin API', async function () {
+    let app
+    const TestObjects = {}
+
+    async function setupApp (license) {
+        const setupConfig = { features: { devices: true } }
+        if (license) {
+            setupConfig.license = license
+        }
+        app = await setup(setupConfig)
+
+        // Non-admin user
+        TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', password: 'ccPassword' })
+
+        // ATeam create in setup()
+        TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: app.defaultTeamType.id })
+        TestObjects.Project1 = app.project
+        TestObjects.tokens = {}
+    }
+
+    before(async function () {
+        return setupApp()
+    })
+    after(async function () {
+        await app.close()
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    describe('stats', async function () {
+        it('anonymous cannot access stats', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/admin/stats'
+            })
+            response.statusCode.should.equal(401)
+        })
+        it('non-admin cannot access stats', async function () {
+            await login('chris', 'ccPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/admin/stats',
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(401)
+        })
+        it('admin can access stats - json format', async function () {
+            await login('alice', 'aaPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/admin/stats',
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            // Not going to exhaustively check the stats.. just verify there's
+            // at least one thing we expect to be there
+            result.should.have.property('teamCount', 2)
+        })
+
+        it('admin can access stats - opemmetrics format', async function () {
+            await login('alice', 'aaPassword')
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/admin/stats',
+                headers: {
+                    accept: 'application/openmetrics-text'
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.body
+            // Not going to exhaustively check the stats.. just verify there's
+            // at least one thing we expect to be there
+            result.should.match(/flowforge_team_count 2\n/)
+
+            // Check we have a newline at the end
+            result.should.match(/\n$/)
+        })
+    })
+})

--- a/test/unit/forge/routes/auth/permissions_spec.js
+++ b/test/unit/forge/routes/auth/permissions_spec.js
@@ -1,0 +1,171 @@
+const fastify = require('fastify')
+const should = require('should') // eslint-disable-line
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+const permissions = FF_UTIL.require('forge/routes/auth/permissions.js')
+
+describe('Permissions API', async () => {
+    let app
+
+    // These constants provide mock 'request' objects for the different combinations
+    // of user/session/token/teamMembership that we handle.
+    const ADMIN_SESSION_NO_TEAM = {
+        session: { User: { id: 'u123', admin: true } }
+    }
+    const USER_SESSION_NO_TEAM = {
+        session: { User: { id: 'u123' } }
+    }
+    const USER_SESSION_TEAM_OWNER = {
+        session: { User: { id: 'u123' } },
+        teamMembership: { role: Roles.Owner }
+    }
+    const USER_SESSION_TEAM_MEMBER = {
+        session: { User: { id: 'u123' } },
+        teamMembership: { role: Roles.Member }
+    }
+    const ADMIN_TOKEN_NO_SCOPE_NO_TEAM = {
+        session: { User: { id: 'u123', admin: true }, ownerType: 'user', scope: [] }
+    }
+    const ADMIN_TOKEN_SCOPE_NO_TEAM = {
+        session: { User: { id: 'u123', admin: true }, ownerType: 'user', scope: ['project-type:create'] }
+    }
+    const USER_TOKEN_NO_SCOPE_NO_TEAM = {
+        session: { User: { id: 'u123' }, ownerType: 'user', scope: [] }
+    }
+    const USER_TOKEN_NO_SCOPE_TEAM_OWNER = {
+        session: { User: { id: 'u123' }, ownerType: 'user', scope: [] },
+        teamMembership: { role: Roles.Owner }
+    }
+    const USER_TOKEN_SCOPE_TEAM_MEMBER = {
+        session: { User: { id: 'u123' }, ownerType: 'user', scope: ['team:read'] },
+        teamMembership: { role: Roles.Member }
+    }
+    const USER_TOKEN_NO_SCOPE_TEAM_MEMBER = {
+        session: { User: { id: 'u123' }, ownerType: 'user', scope: [] },
+        teamMembership: { role: Roles.Member }
+    }
+    const PROJECT_TOKEN_NO_SCOPE = {
+        session: { ownerType: 'project', scope: [] }
+    }
+
+    before(async () => {
+        app = fastify({})
+        app.register(permissions)
+        app.decorate('settings', {
+            get: scope => true
+        })
+        await app.ready()
+    })
+
+    async function sendRequest (scope, request, options = {}) {
+        const func = app.needsPermission(scope)
+        const response = {}
+        const reply = {
+            code: code => { response.code = code; return reply },
+            send: data => { response.data = data; return reply }
+        }
+        try {
+            await func({ ...request, ...options }, reply)
+            return
+        } catch (err) {
+            return response
+        }
+    }
+
+    function verifyResponse (isAllowed, response) {
+        if (isAllowed) {
+            should.not.exist(response)
+        } else {
+            should.exist(response)
+            response.should.have.property('code', 403)
+            response.should.have.property('data')
+            response.data.should.have.property('code', 'unauthorized')
+            response.data.should.have.property('error', 'unauthorized')
+        }
+    }
+    function expectPass (response) {
+        verifyResponse(true, response)
+    }
+    function expectFail (response) {
+        verifyResponse(false, response)
+    }
+
+    describe('needsPermission', () => {
+        it('rejects invalid scope', () => {
+            should(() => {
+                app.needsPermission('test:scope')
+            }).throw()
+        })
+        describe('sessions', () => {
+            it('Allows admin to access admin-only route', async () => {
+                expectPass(await sendRequest('project-type:create', ADMIN_SESSION_NO_TEAM))
+            })
+
+            it('Prevents non-admin accessing admin-only route', async () => {
+                expectFail(await sendRequest('project-type:create', USER_SESSION_TEAM_OWNER))
+            })
+
+            it('Prevents non-team member accessing team route', async () => {
+                expectFail(await sendRequest('team:read', USER_SESSION_NO_TEAM))
+            })
+
+            it('Allows team member to access team route', async () => {
+                expectPass(await sendRequest('team:read', USER_SESSION_TEAM_MEMBER))
+            })
+
+            it('Prevents team member access team route that requires higher role', async () => {
+                expectFail(await sendRequest('team:edit', USER_SESSION_TEAM_MEMBER))
+            })
+            it('Allows user to operate on themselves', async () => {
+                expectPass(await sendRequest('user:read', USER_SESSION_TEAM_OWNER, { user: { id: 'u123' } }))
+            })
+            it('Prevents user operating on someone else', async () => {
+                expectFail(await sendRequest('user:read', USER_SESSION_TEAM_OWNER, { user: { id: 'u234' } }))
+            })
+            it('Allows user to operate on themselves without sufficient role', async () => {
+                expectPass(await sendRequest('team:user:remove', USER_SESSION_TEAM_MEMBER, { user: { id: 'u123' } }))
+            })
+            it('Allows admin to operate on any user', async () => {
+                expectPass(await sendRequest('user:read', ADMIN_SESSION_NO_TEAM, { user: { id: '234' } }))
+            })
+        })
+        describe('tokens', () => {
+            it('Allows admin to access admin-only route if token has scope', async () => {
+                expectPass(await sendRequest('project-type:create', ADMIN_TOKEN_SCOPE_NO_TEAM))
+            })
+            it('Prevents admin to access admin-only route if token missing scope', async () => {
+                // No scopes at all
+                expectFail(await sendRequest('project-type:create', ADMIN_TOKEN_NO_SCOPE_NO_TEAM))
+                // Not the scope we're looking for
+                expectFail(await sendRequest('project-type:delete', ADMIN_TOKEN_SCOPE_NO_TEAM))
+            })
+            it('Prevents admin accessing non-admin route if token has incorrect scope', async () => {
+                expectFail(await sendRequest('project:read', ADMIN_TOKEN_SCOPE_NO_TEAM))
+            })
+            it('Prevents non-admin accessing admin-only route', async () => {
+                expectFail(await sendRequest('project-type:create', USER_TOKEN_NO_SCOPE_TEAM_OWNER))
+            })
+
+            it('Prevents non-team member accessing team route', async () => {
+                expectFail(await sendRequest('team:read', USER_TOKEN_NO_SCOPE_NO_TEAM))
+            })
+
+            it('Prevents team member accessing team route if token missing scope', async () => {
+                expectFail(await sendRequest('team:read', USER_TOKEN_NO_SCOPE_TEAM_MEMBER))
+            })
+
+            it('Allows team member to access team route if token has scope', async () => {
+                expectPass(await sendRequest('team:read', USER_TOKEN_SCOPE_TEAM_MEMBER))
+            })
+
+            describe('implicit scopes', () => {
+                it('Allows a project token to access any of its implicit scopes', async () => {
+                    expectPass(await sendRequest('project:flows:view', PROJECT_TOKEN_NO_SCOPE))
+                })
+                it('Prevents project token accessing any other scope', async () => {
+                    expectFail(await sendRequest('team:delete', PROJECT_TOKEN_NO_SCOPE))
+                })
+            })
+        })
+    })
+})


### PR DESCRIPTION
Closes #2043 


## Description

This PR adds the ability to monitor the platform from tools such prometheus.

It has ended up touching lots of files, but I have structured the commits to make it easier to review.

Highlevel description:

1. Enables token-based access to the admin stats endpoint
2. Fixes up how admin access to api endpoints is managed
3. Adds api endpoint to generate/delete a dedicated stats token
4. Updates Admin Settings to allow admin to enable/disable the token
5. Adds support for openmetrics-text format response in the stats end-point

Commits in order:

1. [Ensure all admin routes have explicit permissions declared](https://github.com/flowforge/flowforge/commit/4d81646fcb436d649693ef805a98b5c737fb16cc) - we previously used `verifyAdmin` as a catch-all preHandler to ensure a request comes from an admin. But to support tokens with reduced scope, we cannot do that. So I've added explicitly `needsPermission` preHandler to all admin routes. To go alongside this, I've added much better Unit Test coverage of `needsPermission` to cater for the growing number of scenarios.
2. [Add support for OpenMetrics format on /api/v1/admin/stats](https://github.com/flowforge/flowforge/commit/630fd95993d49748e9332137b2d8188abe25e1b4) - return the new format if the `accept` header requests it
3. [Add team billing info to stats](https://github.com/flowforge/flowforge/commit/fea897331cfe89fa1d619abb5ee2e133bc095abd) - include counts of subscriptions by state. Useful to get a sense of trial/non-trial etc
4. [Add api endpoints to manage platform stats token](https://github.com/flowforge/flowforge/commit/b68ea273964a980b191c24ab4b1c0d58ab820fd6) - basic endpoints to generate/delete the token, inc unit tests
5. [Make FormRow description field more consistent](https://github.com/flowforge/flowforge/commit/d193b8536372fb715d7cdd16902d7c47a2b3a1b6) - noticed inconsistent css for the 'description' field in FormRow
6. [Add platform stats option to Admin Settings page](https://github.com/flowforge/flowforge/commit/1850f3557182cae01061b8202d2add5790401655) - Adds UI to admin settings to manage the stats token
7. [Add docs on platform monitoring](https://github.com/flowforge/flowforge/commit/8847f4ef802e9b8d72af24959437501953d7545c) - doc updates


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

