### PR TITLE
"Add Instance" button on /instances

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -28,7 +28,7 @@
                 v-model="input.applicationId"
                 :options="applications"
                 :error="errors.applicationId || submitErrors?.applicationId"
-                data-form="application-name"
+                data-form="application-id"
             >
                 <template #default>
                     Application

--- a/frontend/src/pages/team/Instances.vue
+++ b/frontend/src/pages/team/Instances.vue
@@ -7,7 +7,21 @@
                 v-if="instances.length > 0"
                 data-el="instances-table" :columns="columns" :rows="instances" :show-search="true" search-placeholder="Search Instances..."
                 :rows-selectable="true" @row-selected="openInstance"
-            />
+            >
+                <template #actions>
+                    <ff-button
+                        v-if="hasPermission('project:create')"
+                        data-action="create-project"
+                        kind="primary"
+                        :to="{name: 'CreateInstance'}"
+                    >
+                        <template #icon-left>
+                            <PlusSmIcon />
+                        </template>
+                        Create Instance
+                    </ff-button>
+                </template>
+            </ff-data-table>
             <EmptyState v-else>
                 <template #header>Get Started with your First Node-RED Instance</template>
                 <template #message>
@@ -27,7 +41,7 @@
                     <ff-button
                         v-if="hasPermission('project:create')"
                         kind="primary"
-                        :to="{name: 'CreateTeamApplication'}"
+                        :to="{name: 'CreateInstance'}"
                     >
                         <template #icon-left>
                             <PlusSmIcon />

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -127,7 +127,6 @@ export default {
 
             try {
                 const instance = await this.createInstance(applicationId, instanceFields, copyParts)
-                console.log(instance)
 
                 await this.$store.dispatch('account/refreshTeam')
 

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -1,0 +1,162 @@
+<template>
+    <Teleport
+        v-if="mounted"
+        to="#platform-sidenav"
+    >
+        <SideNavigation>
+            <template #options>
+                <a @click="$router.back()">
+                    <nav-item
+                        :icon="icons.chevronLeft"
+                        label="Back"
+                    />
+                </a>
+            </template>
+        </SideNavigation>
+    </Teleport>
+    <main>
+        <div class="max-w-2xl m-auto">
+            <ff-loading
+                v-if="loading"
+                message="Creating instance..."
+            />
+            <ff-loading
+                v-else-if="sourceInstanceId && !sourceInstance"
+                message="Loading instance to Copy From..."
+            />
+            <InstanceForm
+                v-else
+                :instance="instanceDetails"
+                :source-instance="sourceInstance"
+                :team="team"
+                :applicationSelection="true"
+                :applications="applications"
+                :billing-enabled="!!features.billing"
+                :submit-errors="errors"
+                @on-submit="handleFormSubmit"
+            />
+        </div>
+    </main>
+</template>
+
+<script>
+import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
+
+import instanceApi from '../../api/instances.js'
+import teamApi from '../../api/team.js'
+
+import NavItem from '../../components/NavItem.vue'
+import SideNavigation from '../../components/SideNavigation.vue'
+import Alerts from '../../services/alerts.js'
+import InstanceForm from '../instance/components/InstanceForm.vue'
+
+export default {
+    name: 'CreateInstance',
+    components: {
+        InstanceForm,
+        NavItem,
+        SideNavigation
+    },
+    beforeRouteEnter (to, from, next) {
+        // we've got a user pressing "back" from the Create Application page,
+        // but this page will very likely just bounce them back as they have
+        // no applications. This breaks the cycle and redirects them back to Team > Applications
+        if (from.name === 'CreateTeamApplication') {
+            next('/')
+        } else {
+            next()
+        }
+    },
+    inheritAttrs: false,
+    data () {
+        return {
+            applications: null,
+            icons: {
+                chevronLeft: ChevronLeftIcon
+            },
+            loading: false,
+            sourceInstance: null,
+            mounted: false,
+            errors: {
+                name: ''
+            },
+            instanceDetails: null
+        }
+    },
+    computed: {
+        ...mapState('account', ['features', 'team'])
+    },
+    async created () {
+        if (this.sourceInstanceId) {
+            instanceApi.getInstance(this.sourceInstanceId).then(instance => {
+                this.sourceInstance = instance
+            }).catch(err => {
+                console.error('Failed to load source instance', err)
+            })
+        }
+        const data = await teamApi.getTeamApplications(this.team.id)
+        this.applications = data.applications.map((a) => {
+            return {
+                label: a.name,
+                value: a.id
+            }
+        })
+
+        if (!this.applications.length) {
+            // need to also create an Application
+            this.$router.push({
+                name: 'CreateTeamApplication',
+                params: {
+                    team_slug: this.team.slug
+                }
+            })
+        }
+    },
+    async mounted () {
+        this.mounted = true
+    },
+    methods: {
+        async handleFormSubmit (formData, copyParts) {
+            this.loading = true
+
+            // Drop applicationId & applicationName from the payload
+            const { applicationId, applicationName, ...instanceFields } = formData
+
+            // if we have applicationName, a new application needs to be created first
+
+            try {
+                const instance = await this.createInstance(applicationId, instanceFields, copyParts)
+                console.log(instance)
+
+                await this.$store.dispatch('account/refreshTeam')
+
+                this.$router.push({ name: 'Instance', params: { id: instance.id } })
+            } catch (err) {
+                this.instanceDetails = instanceFields
+                if (err.response?.status === 409) {
+                    this.errors.name = err.response.data.error
+                } else if (err.response?.status === 400) {
+                    Alerts.emit('Failed to create instance: ' + err.response.data.error, 'warning', 7500)
+                } else {
+                    Alerts.emit('Failed to create instance')
+                    console.error(err)
+                }
+            }
+
+            this.loading = false
+        },
+        createInstance (applicationId, instanceDetails, copyParts) {
+            const createPayload = { ...instanceDetails, applicationId }
+            if (this.sourceInstance?.id) {
+                createPayload.sourceProject = {
+                    id: this.sourceInstanceId,
+                    options: { ...copyParts }
+                }
+            }
+
+            return instanceApi.create(createPayload)
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/team/createInstance.vue
+++ b/frontend/src/pages/team/createInstance.vue
@@ -123,8 +123,6 @@ export default {
             // Drop applicationId & applicationName from the payload
             const { applicationId, applicationName, ...instanceFields } = formData
 
-            // if we have applicationName, a new application needs to be created first
-
             try {
                 const instance = await this.createInstance(applicationId, instanceFields, copyParts)
 

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -14,6 +14,7 @@ import TeamSettingsDevices from './Settings/Devices.vue'
 // import TeamSettingsPermissions from './Settings/Permissions.vue'
 import CreateTeam from './create.vue'
 import CreateApplication from './createApplication.vue'
+import CreateInstance from './createInstance.vue'
 
 // EE Only
 import TeamBilling from './Billing.vue'
@@ -132,6 +133,14 @@ export default [
         component: CreateApplication,
         meta: {
             title: 'Team - Create Application'
+        }
+    },
+    {
+        path: '/team/:team_slug/instances/create',
+        name: 'CreateInstance',
+        component: CreateInstance,
+        meta: {
+            title: 'Team - Create Instance'
         }
     }
 ]

--- a/test/e2e/frontend/cypress/tests/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances.spec.js
@@ -37,7 +37,7 @@ describe('FlowForge - Instances', () => {
         cy.wait('@getInstanceTypes')
     })
 
-    it.skip('can be navigated to from team page', () => {
+    it('can be navigated to from team page', () => {
         cy.intercept('GET', '/api/*/projects/*').as('getInstance')
         cy.intercept('GET', '/api/*/applications/*').as('getApplication')
 
@@ -61,7 +61,7 @@ describe('FlowForge - Instances', () => {
         cy.get('[data-el="editor-link"]').should('exist')
     })
 
-    it.skip('can be deleted', () => {
+    it('can be deleted', () => {
         const INSTANCE_NAME = `new-instance-${Math.random().toString(36).substring(2, 7)}`
 
         cy.intercept('DELETE', '/api/*/projects/*').as('deleteInstance')
@@ -127,7 +127,7 @@ describe('FlowForge - Instances', () => {
             })
     })
 
-    it.skip('can be updated', () => {
+    it('can be updated', () => {
         cy.intercept('GET', '/api/*/projects/*').as('getInstance')
 
         navigateToInstance('ATeam', 'instance-1-1')
@@ -185,7 +185,7 @@ describe('FlowForge - Instances', () => {
         cy.contains('type1 / stack1')
     })
 
-    it.skip('can be copied', () => {
+    it('can be copied', () => {
         // TODO needs work as currently lands user on Project Overview rather than Index View
         cy.intercept('GET', '/api/*/projects/*').as('getInstance')
         cy.intercept('POST', '/api/*/projects').as('createProject')


### PR DESCRIPTION
## Description

- "Add Instance" button put onto `/instances`
- New `/instances/create` page - which uses the `InstancesForm.vue`
- `InstanceForm` now has the option to pass `applications` array and `applicationSelection` boolean which will display the dropdown, with provided options. Needed to pass the bool, as it's valid to not pass `applications`, so that check on it's own to fall back ot the text input, wasn't enough.
- Adds E2E tests for instance creation & checking the reidrect.

## Related Issue(s)

Closes #2052

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->

