### PR TITLE
Fix: Stripe out of sync when removing project

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -292,7 +292,7 @@ module.exports.init = async function (app) {
                     }
 
                     await setProjectBillingState(project, BILLING_STATES.BILLED)
-                    app.log.warn(`failed removing project from subscription\n${err.message}`)
+                    app.log.warn(`Failed removing project from subscription\n${err.message}`)
                     throw err
                 }
             } else {

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -287,6 +287,10 @@ module.exports.init = async function (app) {
                         metadata
                     })
                 } catch (err) {
+                    if (err.rawType === 'invalid_request_error' && err.code === 'resource_missing' && err.param === 'subscription') {
+                        return this._app.log.warn(`Subscription was not found in Stripe, but continuing removal: ${err}`)
+                    }
+
                     await setProjectBillingState(project, BILLING_STATES.BILLED)
                     app.log.warn(`failed removing project from subscription\n${err.message}`)
                     throw err


### PR DESCRIPTION
## Description

Swallow `Customer cus_M3Aypx6T6nn19k does not have a subscription with ID sub_1LL4c9J6VWAujNoL1CbsXuzb\` error from Stripe.

This means that if a subscription has been deleted in Stripe, it's still possible to delete the instance in FlowForge.

## Related Issue(s)

Fixes https://github.com/flowforge/flowforge/issues/1837

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
     - Unable to clearly add coverage 
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

