### PR TITLE
Add "Last Seen" chart for filtering Devices

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -16,7 +16,7 @@
             message="Deleting Device..."
         />
         <template v-else>
-            <DevicesStatusBar :devices="Array.from(devices.values())" property="lastSeenSince" @filter-selected="applyFilter" />
+            <DevicesStatusBar :devices="Array.from(devices.values())" property="status" @filter-selected="applyFilter" />
             <ff-data-table
                 v-if="devices.size > 0"
                 data-el="devices-browser"

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -16,7 +16,8 @@
             message="Deleting Device..."
         />
         <template v-else>
-            <DevicesStatusBar :devices="Array.from(devices.values())" property="status" @filter-selected="applyFilter" />
+            <DevicesStatusBar data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
+            <DevicesStatusBar data-el="devicestatus-status" label="Last Known Status" :devices="Array.from(devices.values())" property="status" :filter="filter" @filter-selected="applyFilter" />
             <ff-data-table
                 v-if="devices.size > 0"
                 data-el="devices-browser"

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -16,8 +16,8 @@
             message="Deleting Device..."
         />
         <template v-else>
-            <DevicesStatusBar data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
-            <DevicesStatusBar data-el="devicestatus-status" label="Last Known Status" :devices="Array.from(devices.values())" property="status" :filter="filter" @filter-selected="applyFilter" />
+            <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
+            <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-status" label="Last Known Status" :devices="Array.from(devices.values())" property="status" :filter="filter" @filter-selected="applyFilter" />
             <ff-data-table
                 v-if="devices.size > 0"
                 data-el="devices-browser"
@@ -328,8 +328,8 @@ export default {
             if (!this.filter) {
                 filteredDevices = Array.from(this.devices.values())
             } else {
-                this.filter.devices.forEach((device) => {
-                    filteredDevices.push(this.devices.get(device.id))
+                this.filter.devices.forEach((deviceId) => {
+                    filteredDevices.push(this.devices.get(deviceId))
                 })
             }
             return filteredDevices

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -328,8 +328,8 @@ export default {
             if (!this.filter) {
                 filteredDevices = Array.from(this.devices.values())
             } else {
-                filteredDevices = Array.from(this.devices.values()).filter((d) => {
-                    return this.filter.devices.includes(d.id)
+                this.filter.devices.forEach((device) => {
+                    filteredDevices.push(this.devices.get(device.id))
                 })
             }
             return filteredDevices

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -359,6 +359,16 @@ export default {
         clearInterval(this.checkInterval)
     },
     methods: {
+        /**
+         * filter: Object containing keys:
+         *  - devices: an array of device ids
+         *  - property: which filter row is being applied, e.g. status or lastseen
+         *  - bucket: which value of this property are we filtering on from the buckets in the status bar
+         *
+         * We store these in order to apply the filter of devices to the table, and handle
+         * the situation where we switch between filters, property/bucket are checked against local
+         * values inside the StatusBar
+        */
         applyFilter (filter) {
             this.filter = filter
         },

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -264,14 +264,14 @@ export default {
             deletingDevice: false,
             nextCursor: null,
             devices: new Map(),
-            filteredDevices: null,
             checkInterval: null
         }
     },
     computed: {
         columns () {
             const columns = [
-                { label: 'Device', key: 'name', class: ['w-64'], sortable: true, component: { is: markRaw(DeviceLink) } }
+                { label: 'Device', key: 'name', class: ['w-64'], sortable: true, component: { is: markRaw(DeviceLink) } },
+                { label: 'Type', key: 'type', class: ['w-48'], sortable: true }
             ]
 
             const statusColumns = [
@@ -284,7 +284,7 @@ export default {
                     ...statusColumns,
                     {
                         label: 'Application',
-                        class: ['w-64'],
+                        class: ['w-48'],
                         key: 'application',
                         sortable: true,
                         component: {
@@ -302,7 +302,7 @@ export default {
                 columns.push({
                     label: 'Instance',
                     key: 'instance',
-                    class: ['w-64'],
+                    class: ['w-48'],
                     sortable: true,
                     component: {
                         is: markRaw(InstanceInstancesLink),
@@ -322,6 +322,17 @@ export default {
             }
 
             return columns
+        },
+        filteredDevices () {
+            let filteredDevices = []
+            if (!this.filter) {
+                filteredDevices = Array.from(this.devices.values())
+            } else {
+                filteredDevices = Array.from(this.devices.values()).filter((d) => {
+                    return this.filter.devices.includes(d.id)
+                })
+            }
+            return filteredDevices
         },
         displayingInstance () {
             return this.instance !== null
@@ -350,16 +361,6 @@ export default {
     methods: {
         applyFilter (filter) {
             this.filter = filter
-
-            let filteredDevices = []
-            if (!this.filter) {
-                filteredDevices = Array.from(this.devices.values())
-            } else {
-                filteredDevices = Array.from(this.devices.values()).filter((d) => {
-                    return filter.devices.includes(d.id)
-                })
-            }
-            this.filteredDevices = filteredDevices
         },
         showCreateDeviceDialog () {
             this.$refs.teamDeviceCreateDialog.show(null, this.instance, this.application)
@@ -384,6 +385,7 @@ export default {
                     this.$refs.deviceCredentialsDialog.show(device)
                 }, 500)
                 this.devices.set(device.id, device)
+                this.applyFilter()
             }
         },
 

--- a/frontend/src/components/charts/DeviceStatusBar.vue
+++ b/frontend/src/components/charts/DeviceStatusBar.vue
@@ -53,21 +53,26 @@ export default {
     },
     computed: {
         buckets () {
-            const devices = this.devices.map((d) => {
-                return {
-                    id: d.id,
-                    status: DeviceStatus.lastSeenStatus(d.lastSeenAt, d.lastSeenMs)
-                }
-            })
+            let devices = []
+            if (this.property === 'status') {
+                devices = this.devices.map((d) => {
+                    return {
+                        id: d.id,
+                        bucket: DeviceStatus.lastSeenStatus(d.lastSeenAt, d.lastSeenMs)
+                    }
+                })
+            } else {
+                throw Error(`Do not know how to filter on the property '${this.property}'`)
+            }
             const buckets = {}
             devices.forEach((d) => {
-                if (!buckets[d.status.class]) {
-                    buckets[d.status.class] = {
-                        label: d.status.label,
+                if (!buckets[d.bucket.class]) {
+                    buckets[d.bucket.class] = {
+                        label: d.bucket.label,
                         devices: []
                     }
                 }
-                buckets[d.status.class].devices.push(d.id)
+                buckets[d.bucket.class].devices.push(d.id)
             })
             return buckets
         }

--- a/frontend/src/components/charts/DeviceStatusBar.vue
+++ b/frontend/src/components/charts/DeviceStatusBar.vue
@@ -1,0 +1,92 @@
+<template>
+    <div class="ff-chart space-y-2">
+        <div class="flex items-center justify-between">
+            <h3>Last Seen</h3>
+            <button class="ff-btn ff-btn--tertiary" @click="toggle()">
+                <EyeIcon v-if="visible" class="ff-icon" />
+                <EyeOffIcon v-else class="ff-icon" />
+            </button>
+        </div>
+        <div v-if="visible" class="ff-chart-device-status">
+            <div
+                v-for="(bucket, b) in buckets" :key="b"
+                :class="'ff-chart-bar ff-chart-bar--' + b + ' ' + ((activeFilter.bucket && activeFilter.bucket !== b) ? 'ghost' : '')"
+                :style="{width: 100 * (bucket.devices.length/devices.length) + '%'}"
+                @click="selected(b, bucket.devices)"
+            >
+                <div>{{ bucket.devices.length }}</div>
+                <label>{{ bucket.label }}</label>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { EyeIcon, EyeOffIcon } from '@heroicons/vue/outline'
+
+import DeviceStatus from '../../services/device-status.js'
+
+export default {
+    name: 'DeviceStatusBar',
+    components: {
+        EyeIcon,
+        EyeOffIcon
+    },
+    props: {
+        devices: {
+            required: true,
+            type: Array
+        },
+        property: {
+            required: true,
+            type: String
+        }
+    },
+    emits: ['filter-selected'],
+    data () {
+        return {
+            visible: true,
+            activeFilter: {
+                bucket: null
+            }
+        }
+    },
+    computed: {
+        buckets () {
+            const devices = this.devices.map((d) => {
+                return {
+                    id: d.id,
+                    status: DeviceStatus.lastSeenStatus(d.lastSeenAt, d.lastSeenMs)
+                }
+            })
+            const buckets = {}
+            devices.forEach((d) => {
+                if (!buckets[d.status.class]) {
+                    buckets[d.status.class] = {
+                        label: d.status.label,
+                        devices: []
+                    }
+                }
+                buckets[d.status.class].devices.push(d.id)
+            })
+            return buckets
+        }
+    },
+    methods: {
+        selected (bucket, devices) {
+            if (this.activeFilter.bucket === bucket) {
+                this.activeFilter.bucket = null
+                this.$emit('filter-selected', null)
+            } else {
+                this.activeFilter.bucket = bucket
+                this.$emit('filter-selected', {
+                    bucket, devices
+                })
+            }
+        },
+        toggle () {
+            this.visible = !this.visible
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
+++ b/frontend/src/pages/device/components/DeviceLastSeenBadge.vue
@@ -11,30 +11,15 @@
 <script>
 import { ExclamationCircleIcon } from '@heroicons/vue/outline'
 
+import DeviceStatus from '../../../services/device-status.js'
+
 export default {
     name: 'DeviceLastSeenBadge',
     props: ['lastSeenAt', 'lastSeenMs', 'lastSeenSince'],
     computed: {
-        since: function () {
-            if (!this.lastSeenAt) {
-                return -1
-            } else if (typeof this.lastSeenMs === 'number') {
-                return this.lastSeenMs / 1000.0 / 60.0
-            } else {
-                return -1
-            }
-        },
         status: function () {
             // re-uses the status from last known status in order to get respective colour styling
-            if (!this.lastSeenAt) {
-                return 'never'
-            } else if (this.since < 1.5) {
-                return 'running' // green
-            } else if (this.since < 3) {
-                return 'safe' // yellow
-            } else {
-                return 'error' // red
-            }
+            return DeviceStatus.lastSeenStatus(this.lastSeenAt, this.lastSeenMs).class
         },
         label: function () {
             if (!this.lastSeenAt) {

--- a/frontend/src/services/device-status.js
+++ b/frontend/src/services/device-status.js
@@ -1,0 +1,39 @@
+function since (lastSeenAt, lastSeenMs) {
+    if (!lastSeenAt) {
+        return -1
+    } else if (typeof lastSeenMs === 'number') {
+        return lastSeenMs / 1000.0 / 60.0
+    } else {
+        return -1
+    }
+}
+
+function lastSeenStatus (lastSeenAt, lastSeenMs) {
+    const s = since(lastSeenAt, lastSeenMs)
+    if (!lastSeenAt) {
+        return {
+            class: 'never',
+            label: 'Never Seen'
+        }
+    } else if (s < 1.5) {
+        return {
+            class: 'running', // green
+            label: '< 1.5 mins'
+        }
+    } else if (s < 3) {
+        return {
+            class: 'safe', // yellow
+            label: '1.5 - 3 mins'
+        }
+    } else {
+        return {
+            class: 'error', // red
+            label: '> 3 mins'
+        }
+    }
+}
+
+export default {
+    since,
+    lastSeenStatus
+}

--- a/frontend/src/stylesheets/common.scss
+++ b/frontend/src/stylesheets/common.scss
@@ -1,6 +1,7 @@
 @import '~@flowforge/forge-ui-components/dist/scss/forge-colors.scss';
 
 @import "./layouts.scss";
+@import "./components/charts.scss";
 
 #ff-app {
     background-color: $ff-grey-300;

--- a/frontend/src/stylesheets/components/charts.scss
+++ b/frontend/src/stylesheets/components/charts.scss
@@ -1,0 +1,59 @@
+
+@import '~@flowforge/forge-ui-components/dist/scss/forge-colors.scss';
+
+.ff-chart {
+    padding: 12px 18px;
+    border: 1px solid $ff-grey-300;
+    border-radius: 6px;
+    background-color: white;
+    h3 {
+        margin: 0;
+    }
+}
+
+.ff-chart-device-status {
+    display: flex;
+    gap: 4px;
+    label {
+        display: block;
+    }
+    .ff-chart-bar {
+        text-align: right;
+        border-right: 1px solid;
+        >div, >label {
+            padding: 3px 6px;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }
+        &:hover {
+            cursor: pointer;
+        }
+        &--error {
+            > div {
+                background-color: $ff-red-200;
+            }
+            border-color: $ff-red-400;
+            color: $ff-red-600;
+            &:hover {
+                > div {
+                    background-color: $ff-red-300;
+                }
+            }
+        }
+        &--never {
+            > div {
+                background-color: $ff-grey-200;
+            }
+            border-color: $ff-grey-400;
+            color: $ff-grey-600;
+            &:hover {
+                > div {
+                    background-color: $ff-grey-300;
+                }
+            }
+        }
+        &.ghost {
+            opacity: 0.15;
+        }
+    }
+}   

--- a/frontend/src/stylesheets/components/charts.scss
+++ b/frontend/src/stylesheets/components/charts.scss
@@ -62,11 +62,11 @@
             --bar-border: #{$ff-grey-300};
             --text-color: #{$ff-grey-600};
         }
-        // &--safe {
-        //     --bar-bg: #{$ff-yellow-200};
-        //     --bar-border: #{$ff-yellow-300};
-        //     --text-color: #{$ff-yellow-600};
-        // }
+        &--safe {
+            --bar-bg: #{$ff-yellow-200};
+            --bar-border: #{$ff-yellow-300};
+            --text-color: #{$ff-yellow-600};
+        }
         &--running {
             --bar-bg: #{$ff-green-200};
             --bar-border: #{$ff-green-300};

--- a/frontend/src/stylesheets/components/charts.scss
+++ b/frontend/src/stylesheets/components/charts.scss
@@ -20,37 +20,57 @@
     .ff-chart-bar {
         text-align: right;
         border-right: 1px solid;
+        border-color: var(--bar-border);
+        color: var(--text-color);
+        transition: 0.3s opacity;
         >div, >label {
             padding: 3px 6px;
             font-size: 0.875rem;
             font-weight: 600;
         }
+        > div {
+            border-width: 1px 0px 1px 1px;
+            border-style: solid;
+            background-color: var(--bar-bg);
+            border-color: var(--bar-border);
+            transition: 0.3s background-color, 0.3s color, 0.3s opacity;
+        }
+        &:hover {
+            >div {
+                background-color: var(--bar-border);
+            }
+        }
+        label {
+            text-transform: capitalize;
+        }
         &:hover {
             cursor: pointer;
         }
         &--error {
-            > div {
-                background-color: $ff-red-200;
-            }
-            border-color: $ff-red-400;
-            color: $ff-red-600;
-            &:hover {
-                > div {
-                    background-color: $ff-red-300;
-                }
-            }
+            --bar-bg: #{$ff-red-200};
+            --bar-border: #{$ff-red-300};
+            --text-color: #{$ff-red-600};
         }
-        &--never {
-            > div {
-                background-color: $ff-grey-200;
-            }
-            border-color: $ff-grey-400;
-            color: $ff-grey-600;
-            &:hover {
-                > div {
-                    background-color: $ff-grey-300;
-                }
-            }
+        &--never,
+        &--stopped {
+            --bar-bg: #{$ff-grey-200};
+            --bar-border: #{$ff-grey-300};
+            --text-color: #{$ff-grey-600};
+        }
+        &--offline {
+            --bar-bg: #{$ff-grey-50};
+            --bar-border: #{$ff-grey-300};
+            --text-color: #{$ff-grey-600};
+        }
+        // &--safe {
+        //     --bar-bg: #{$ff-yellow-200};
+        //     --bar-border: #{$ff-yellow-300};
+        //     --text-color: #{$ff-yellow-600};
+        // }
+        &--running {
+            --bar-bg: #{$ff-green-200};
+            --bar-border: #{$ff-green-300};
+            --text-color: #{$ff-green-600};
         }
         &.ghost {
             opacity: 0.15;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@fastify/passport": "^2.3.0",
         "@fastify/static": "^6.5.0",
         "@fastify/websocket": "^7.2.0",
-        "@flowforge/forge-ui-components": "^0.5.5",
+        "@flowforge/forge-ui-components": "^0.6.0",
         "@flowforge/localfs": "^1.6.0",
         "@headlessui/vue": "1.7.12",
         "@heroicons/vue": "1.0.6",

--- a/test/e2e/frontend/cypress/fixtures/device-running.json
+++ b/test/e2e/frontend/cypress/fixtures/device-running.json
@@ -1,0 +1,22 @@
+{
+  "id": "2",
+  "name": "device-2",
+  "type": "type-1",
+  "createdAt": "2022-11-07T10:44:22.336Z",
+  "updatedAt": "2022-11-10T15:09:16.619Z",
+  "lastSeenAt": null,
+  "activeSnapshot": null,
+  "targetSnapshot": null,
+  "links": {
+      "self": "http://localhost:3000/api/v1/devices/2"
+  },
+  "status": "running",
+  "team": {
+      "id": "1",
+      "name": "Team-1",
+      "slug": "team-1",
+      "links": {
+          "self": "http://localhost:3000/api/v1/teams/1"
+      }
+  }
+}

--- a/test/e2e/frontend/cypress/tests/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices.spec.js
@@ -1,4 +1,5 @@
 import deviceOffline from '../fixtures/device-offline.json'
+import deviceRunning from '../fixtures/device-running.json'
 
 describe('FlowForge - Devices', () => {
     describe('team with no devices', () => {
@@ -113,6 +114,64 @@ describe('FlowForge - Devices', () => {
                     cy.visit(`/team/${team.slug}/devices`)
                     cy.wait('@getDevices')
                 })
+        })
+
+        it('can filter the device browser by "last seen" values', () => {
+            // ensure we have something "last seen" in the past 1.5 mins
+            deviceRunning.lastSeenAt = (new Date()).toISOString()
+            cy.intercept('GET', '/api/v1/teams/*/devices', {
+                count: 2,
+                meta: { next_cursor: 'next' },
+                devices: [deviceOffline, deviceRunning]
+            }).as('getDevicesNextPage')
+
+            cy.visit('/team/bteam/devices')
+            cy.contains('device-1')
+            cy.contains('device-2')
+
+            // apply filter
+            cy.get('[data-el="devicestatus-lastseen"] .ff-chart-bar.ff-chart-bar--never').click()
+            cy.contains('device-1')
+            cy.contains('device-2').should('not.exist')
+
+            // select different filter value
+            cy.get('[data-el="devicestatus-lastseen"] .ff-chart-bar.ff-chart-bar--running').click()
+            cy.contains('device-1').should('not.exist')
+            cy.contains('device-2')
+
+            // reverse the filter
+            cy.get('[data-el="devicestatus-lastseen"] .ff-chart-bar.ff-chart-bar--running').click()
+            cy.contains('device-1')
+            cy.contains('device-2')
+        })
+
+        it('can filter the device browser by "status" values', () => {
+            // ensure we have something "last seen" in the past 1.5 mins
+            deviceRunning.lastSeenAt = (new Date()).toISOString()
+            cy.intercept('GET', '/api/v1/teams/*/devices', {
+                count: 2,
+                meta: { next_cursor: 'next' },
+                devices: [deviceOffline, deviceRunning]
+            }).as('getDevicesNextPage')
+
+            cy.visit('/team/bteam/devices')
+            cy.contains('device-1')
+            cy.contains('device-2')
+
+            // apply filter
+            cy.get('[data-el="devicestatus-status"] .ff-chart-bar.ff-chart-bar--offline').click()
+            cy.contains('device-1')
+            cy.contains('device-2').should('not.exist')
+
+            // select different filter value
+            cy.get('[data-el="devicestatus-status"] .ff-chart-bar.ff-chart-bar--running').click()
+            cy.contains('device-1').should('not.exist')
+            cy.contains('device-2')
+
+            // reverse the filter
+            cy.get('[data-el="devicestatus-status"] .ff-chart-bar.ff-chart-bar--running').click()
+            cy.contains('device-1')
+            cy.contains('device-2')
         })
 
         it('can assign and unassign devices to instances', () => {


### PR DESCRIPTION
## Description

- Moves some of the Device Status bucketing logic into a service, as this is now shared across multiple screens. This contains logic to bucket to a css class & label pair.
- Adds a new "DeviceStatusBar" component which is driven by a `property` and list of all `devices`.

https://user-images.githubusercontent.com/99246719/235135164-5c2b9611-b244-4181-8234-a6d8d634e28c.mov

### Considerations:

- Driven by the existing devices API call, which will hit device pagination, may need separate API call. Currently, we are dependent upon having the device id's in order to set the filter at the top level. This is because (in the example of `status` this is not a property on the `device` object directly, but computed within the filtering)

## Related Issue(s)

First part of #1937

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] E2E Tests

