### PR TITLE
Add instructions to run agent as a service on a Pi

### DIFF
--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -215,3 +215,41 @@ device, and then copy the modules on to your device.
 <br>
 
 [^global-install]: Starting the agent via the command `flowforge-device-agent` assumes it was installed as a global npm module and your path is properly configured to pick that up.
+
+## Running the device agent as a service on a Raspberry Pi
+
+Can can run the device agent as a service, this means it can run in the background and be enabled to automatically start on boot.
+
+### Creating a Service File
+
+The first step is creating the systemd unit file for your service. You can start by creating a new file in the /etc/systemd/system directory with a .service file extension:
+
+```sudo nano /etc/systemd/system/flowforge-device-agent.service```
+
+In the service file, you'll need to define the following parameters:
+
+The recommended content for the service file can be found here [this Github page](https://github.com/flowforge/flowforge-device-agent/blob/main/service/flowforge-device.service).
+
+### Starting the service on boot (optional)
+
+If you want Node-RED to run when the device is turned on, or re-booted, you can enable the service to autostart by running the command:
+
+```sudo systemctl enable flowforge-device-agent.service```
+
+To disable the service, run the command:
+
+```sudo systemctl disable flowforge-device-agent.service```
+
+### Controlling the service
+
+You can start the service with the command:
+
+```sudo systemctl start flowforge-device-agent```
+
+You can check the current status with the command:
+
+```sudo systemctl status flowforge-device-agent```
+
+You can stop your with the command:
+
+```sudo systemctl stop flowforge-device-agent```


### PR DESCRIPTION
## Description

Added details of how to run the FlowForge device agent as a service on a Raspberry Pi