### PR TITLE
Ensure device-agent 0.7.0 messages are displayed

### DIFF
--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -63,7 +63,7 @@ export default {
                             }
                             const d = new Date(parseInt(m.ts.substring(0, m.ts.length - 4)))
                             m.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-                            if (typeof m.msg === 'object') {
+                            if (typeof m.msg !== 'string') {
                                 m.msg = JSON.stringify(m.msg)
                             }
                             this.logEntries.push(m)

--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -74,7 +74,7 @@ export default {
                                 }
                                 const d = new Date(parseInt(row.ts.substring(0, row.ts.length - 4)))
                                 row.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-                                if (typeof row.msg === 'object') {
+                                if (typeof row.msg !== 'string') {
                                     row.msg = JSON.stringify(row.msg)
                                 }
                                 this.logEntries.push(row)

--- a/frontend/src/pages/device/components/DeviceLog.vue
+++ b/frontend/src/pages/device/components/DeviceLog.vue
@@ -63,6 +63,9 @@ export default {
                             }
                             const d = new Date(parseInt(m.ts.substring(0, m.ts.length - 4)))
                             m.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
+                            if (typeof m.msg === 'object') {
+                                m.msg = JSON.stringify(m.msg)
+                            }
                             this.logEntries.push(m)
                         } else {
                             m.forEach(row => {
@@ -71,6 +74,9 @@ export default {
                                 }
                                 const d = new Date(parseInt(row.ts.substring(0, row.ts.length - 4)))
                                 row.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
+                                if (typeof row.msg === 'object') {
+                                    row.msg = JSON.stringify(row.msg)
+                                }
                                 this.logEntries.push(row)
                             })
                         }


### PR DESCRIPTION
part of flowforge/flowforge#2074

## Description

<!-- Describe your changes in detail -->
ensure we convert any log message payload to a string before trying to display it, this should only be needed for device agent v0.7.0

## Related Issue(s)

<!-- What issue does this PR relate to? -->
 flowforge/flowforge#2074

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

