### PR TITLE
Ensure instance logs refresh after unsuspending an instance

### DIFF
--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -48,8 +48,6 @@ export default {
         this.checkInterval = setInterval(() => {
             if (this.instance.meta && this.instance.meta.state !== 'suspended') {
                 this.loadNext()
-            } else {
-                clearInterval(this.checkInterval)
             }
         }, 5000)
     },
@@ -63,7 +61,8 @@ export default {
                     await this.loadItems(this.instance.id)
                     this.loading = false
                 } else {
-                    clearInterval(this.checkInterval)
+                    this.logEntries = []
+                    this.prevCursor = null
                 }
             }
         },
@@ -76,6 +75,7 @@ export default {
         loadItems: async function (instanceId, cursor) {
             const entries = await InstanceApi.getInstanceLogs(instanceId, cursor)
             if (!cursor) {
+                this.prevCursor = null
                 this.logEntries = []
             }
             const toPrepend = []


### PR DESCRIPTION
Fixes #2083

## Description

The logs view was clearing the refresh interval when an instance was in suspended state. However if the instance came out of suspended state it wasn't restoring the refresh interval so the logs would never update.

This keeps the interval running all the time the view is mounted - but only polls for logs if the state is not suspended.

It also clears the log history when we detect the instance is suspended; with the existing behaviour, when you suspended then started an instance the previous logs would be shown for a couple of seconds whilst it retrieved the new logs.

## Related Issue(s)

#2083 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

