### PR TITLE
Add suspended project count to telemetry ping

### DIFF
--- a/forge/monitor/metrics/004-platform.js
+++ b/forge/monitor/metrics/004-platform.js
@@ -12,10 +12,16 @@ module.exports = async (app) => {
         }
         return 'CE'
     }
+
+    const projectStateCounts = await app.db.models.Project.count({ attributes: ['state'], group: 'state' })
+    const projectStates = {}
+    projectStateCounts.forEach(state => { projectStates[state.state] = state.count })
+
     return {
         'platform.counts.users': await app.db.models.User.count(),
         'platform.counts.teams': await app.db.models.Team.count(),
         'platform.counts.projects': await app.db.models.Project.count(),
+        'platform.counts.projectsByState.suspended': projectStates.suspended || 0,
         'platform.counts.devices': await app.db.models.Device.count(),
         'platform.counts.projectSnapshots': await app.db.models.ProjectSnapshot.count(),
         'platform.counts.projectTemplates': await app.db.models.ProjectStack.count(),


### PR DESCRIPTION
Closes #2073

## Description

Adds `platform.counts.projects.byState.suspended` to the telemetry packet.

The original plan was to call this `platform.counts.projects.suspended` - but we already have `platform.counts.projects` as a number which cannot have properties in the JSON encoding over the wire.

See https://github.com/flowforge/usage-ping-collector/pull/23 for the ping collector side of the change.

There is a possibility we want to change the name of this property - so this PR should not be merged until the https://github.com/flowforge/usage-ping-collector/pull/23 is merged as confirmation of this choice.

