### PR TITLE
Adds verbose detailing for the nodes.install event in our Audit Log

### DIFF
--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -42,7 +42,8 @@ const iconMap = {
         'stopped',
         'settings.update',
         'flows.set',
-        'library.set'
+        'library.set',
+        'nodes.install'
     ],
     template: [
         'application.created',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -404,6 +404,10 @@
         <label>{{ AuditEvents[entry.event] }}</label>
         <span>A flow or function has been saved to the Library</span>
     </template>
+    <template v-else-if="entry.event === 'nodes.install'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <span>Nodes have been installed via the "Manage Palette" option inside Node-RED</span>
+    </template>
 
     <!-- Catch All -->
     <template v-else>

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -56,7 +56,8 @@
         "stopped": "Node-RED has stopped",
         "settings.update": "Node-RED Settings Updated",
         "flows.set": "Flow Deployed",
-        "library.set": "Saved to Library"
+        "library.set": "Saved to Library",
+        "nodes.install": "Third-Party Nodes Installed"
     },
     "platform": {
         "platform.license.applied": "License Applied",


### PR DESCRIPTION
## Description

Noticed an audit log event coming out of Node-RED that had no "nice" formatting. This adds the icon & verbose description.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)