### PR TITLE
Add deviceEditor feature flag in place of license check

### DIFF
--- a/forge/ee/lib/deviceEditor/index.js
+++ b/forge/ee/lib/deviceEditor/index.js
@@ -1,6 +1,8 @@
 const { DeviceTunnelManager } = require('./DeviceTunnelManager')
 
 module.exports.init = function (app) {
+    app.config.features.register('deviceEditor', true, true)
+
     // Add the tunnelManager to app.comms.devices
     app.comms.devices.tunnelManager = new DeviceTunnelManager(app)
 }

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -33,7 +33,7 @@
                         </div>
                     </div>
                 </template>
-                <template v-if="isLicensed" #tools>
+                <template v-if="isDevModeAvailable" #tools>
                     <div class="space-x-2 flex align-center">
                         <a v-if="editorAvailable && !isVisitingAdmin" class="ff-btn ff-btn--secondary" :href="deviceEditorURL" :target="`device-editor-${device.id}`" data-action="device-editor">
                             Device Editor
@@ -124,14 +124,14 @@ export default {
             // return true
             return this.teamMembership.role === Roles.Admin
         },
-        isLicensed: function () {
-            return !!this.settings['platform:licensed']
+        isDevModeAvailable: function () {
+            return !!this.features.deviceEditor
         },
         developerMode: function () {
             return this.device && this.agentSupportsDeviceAccess && this.device.mode === 'developer'
         },
         editorAvailable: function () {
-            return this.isLicensed && this.device && this.agentSupportsDeviceAccess && this.developerMode && this.device.status === 'running' && this.deviceEditorURL
+            return this.isDevModeAvailable && this.device && this.agentSupportsDeviceAccess && this.developerMode && this.device.status === 'running' && this.deviceEditorURL
         },
         deviceEditorURL: function () {
             return this.device.editor?.url || ''


### PR DESCRIPTION
## Description

The existing license check only works for admin users as regular uses don't get visibility of that setting.

This PR switches over to a deviceEditor feature flag which is how we manage access to licensable features elsewhere in the UI.