### PR TITLE
Do not enable device editor if comms are unavailable

### DIFF
--- a/forge/ee/lib/deviceEditor/index.js
+++ b/forge/ee/lib/deviceEditor/index.js
@@ -1,8 +1,10 @@
 const { DeviceTunnelManager } = require('./DeviceTunnelManager')
 
 module.exports.init = function (app) {
-    app.config.features.register('deviceEditor', true, true)
+    if (app.comms) {
+        app.config.features.register('deviceEditor', true, true)
 
-    // Add the tunnelManager to app.comms.devices
-    app.comms.devices.tunnelManager = new DeviceTunnelManager(app)
+        // Add the tunnelManager to app.comms.devices
+        app.comms.devices.tunnelManager = new DeviceTunnelManager(app)
+    }
 }

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -9,6 +9,9 @@ const { Roles } = require('../../../lib/roles.js')
  * @memberof forge.ee
  */
 module.exports = async function (app) {
+    if (!app.comms) {
+        return
+    }
     registerPermissions({
         'device:editor': { description: 'Access the Device Editor', role: Roles.Member }
     })


### PR DESCRIPTION
## Description

If running without comms (ie no broker config), but with a license applied, FF doesn't start up as the deviceEditor feature assumes comms will be available.

We guard against that on other EE features so should do so here.