### PR TITLE
Fix snapshot rollback without credentials or storage flows

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -256,16 +256,7 @@ module.exports = {
             if (components.credentials) {
                 const projectSecret = await project.getCredentialSecret()
                 const encryptedCreds = app.db.controllers.Project.exportCredentials(JSON.parse(components.credentials), components.credsSecret, projectSecret)
-                let origCredentials = await app.db.models.StorageCredentials.byProject(project.id)
-                if (origCredentials) {
-                    origCredentials.credentials = JSON.stringify(encryptedCreds)
-                    await origCredentials.save({ transaction })
-                } else {
-                    origCredentials = await app.db.models.StorageCredentials.create({
-                        ProjectId: project.id,
-                        credentials: JSON.stringify(encryptedCreds)
-                    }, { transaction })
-                }
+                await app.db.controllers.StorageCredentials.updateOrCreateForProject(project, encryptedCreds, { transaction })
             }
             await transaction.commit()
         } catch (error) {

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -239,17 +239,7 @@ module.exports = {
         const transaction = await app.db.sequelize.transaction()
         try {
             if (components.flows) {
-                let currentProjectFlows = await app.db.models.StorageFlow.byProject(project.id)
-                if (currentProjectFlows) {
-                    // Note StorageFlow.flow not .flows
-                    currentProjectFlows.flow = components.flows
-                    await currentProjectFlows.save({ transaction })
-                } else {
-                    currentProjectFlows = await app.db.models.StorageFlow.create({
-                        ProjectId: project.id,
-                        flow: components.flows
-                    }, { transaction })
-                }
+                await app.db.controllers.StorageFlows.updateOrCreateForProject(project, components.flows, { transaction })
             }
             if (components.credentials) {
                 const projectSecret = await project.getCredentialSecret()

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -146,9 +146,7 @@ module.exports = {
                 const currentProjectFlows = await app.db.models.StorageFlow.byProject(project.id)
                 currentProjectFlows.flow = JSON.stringify(!snapshot.flows.flows ? [] : snapshot.flows.flows)
                 if (snapshot.flows.credentials) {
-                    const origCredentials = await app.db.models.StorageCredentials.byProject(project.id)
-                    origCredentials.credentials = JSON.stringify(snapshot.flows.credentials)
-                    await origCredentials.save({ transaction: t })
+                    await app.db.controllers.StorageCredentials.updateOrCreateForProject(project, snapshot.flows.credentials, { transaction: t })
                 }
                 await currentProjectFlows.save({ transaction: t })
             }

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -143,12 +143,12 @@ module.exports = {
         const t = await app.db.sequelize.transaction() // start a transaction
         try {
             if (snapshot?.flows?.flows) {
-                const currentProjectFlows = await app.db.models.StorageFlow.byProject(project.id)
-                currentProjectFlows.flow = JSON.stringify(!snapshot.flows.flows ? [] : snapshot.flows.flows)
+                const flows = JSON.stringify(!snapshot.flows.flows ? [] : snapshot.flows.flows)
+                await app.db.controllers.StorageFlows.updateOrCreateForProject(project, flows, { transaction: t })
+
                 if (snapshot.flows.credentials) {
                     await app.db.controllers.StorageCredentials.updateOrCreateForProject(project, snapshot.flows.credentials, { transaction: t })
                 }
-                await currentProjectFlows.save({ transaction: t })
             }
             if (snapshot?.settings?.settings || snapshot?.settings?.env) {
                 const snapshotSettings = JSON.parse(JSON.stringify(snapshot.settings.settings || {}))

--- a/forge/db/controllers/StorageCredentials.js
+++ b/forge/db/controllers/StorageCredentials.js
@@ -1,0 +1,17 @@
+
+module.exports = {
+    async updateOrCreateForProject (app, project, newCredentials = {}, { transaction } = {}) {
+        let origCredentials = await app.db.models.StorageCredentials.byProject(project.id)
+        if (origCredentials) {
+            origCredentials.credentials = JSON.stringify(newCredentials)
+            await origCredentials.save({ transaction })
+        } else {
+            origCredentials = await app.db.models.StorageCredentials.create({
+                ProjectId: project.id,
+                credentials: JSON.stringify(newCredentials)
+            }, { transaction })
+        }
+
+        return origCredentials
+    }
+}

--- a/forge/db/controllers/StorageFlows.js
+++ b/forge/db/controllers/StorageFlows.js
@@ -1,0 +1,18 @@
+
+module.exports = {
+    async updateOrCreateForProject (app, project, newFlows = {}, { transaction } = {}) {
+        let currentProjectFlows = await app.db.models.StorageFlow.byProject(project.id)
+        if (currentProjectFlows) {
+            // Note StorageFlow.flow not .flows
+            currentProjectFlows.flow = newFlows
+            await currentProjectFlows.save({ transaction })
+        } else {
+            currentProjectFlows = await app.db.models.StorageFlow.create({
+                ProjectId: project.id,
+                flow: newFlows
+            }, { transaction })
+        }
+
+        return currentProjectFlows
+    }
+}

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -25,8 +25,9 @@ const modelTypes = [
     'ProjectSnapshot',
     'Device',
     'BrokerClient',
-    'StorageSettings',
-    'StorageCredentials'
+    'StorageCredentials',
+    'StorageFlows',
+    'StorageSettings'
 ]
 
 async function init (app) {

--- a/forge/db/controllers/index.js
+++ b/forge/db/controllers/index.js
@@ -25,7 +25,8 @@ const modelTypes = [
     'ProjectSnapshot',
     'Device',
     'BrokerClient',
-    'StorageSettings'
+    'StorageSettings',
+    'StorageCredentials'
 ]
 
 async function init (app) {


### PR DESCRIPTION
## Description

Before this PR, if importing a snapshot with credentials or with storage flows into a project that doesn't have existing objects in the database, the import would fail.

This PR extracts the existing createOrUpdate logic into controllers for StorageFlows and StorageCredentials, and uses that logic for snapshot imports as well as project imports.

## Related Issue(s)

Fixes #2108

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

