### PR TITLE
Pipelines: Backend re-work

### DIFF
--- a/forge/db/migrations/20230504-01-add-pipelines.js
+++ b/forge/db/migrations/20230504-01-add-pipelines.js
@@ -44,6 +44,22 @@ module.exports = {
             createdAt: { type: DataTypes.DATE },
             updatedAt: { type: DataTypes.DATE }
         })
+
+        await context.createTable('PipelineStageInstances', {
+            InstanceId: {
+                type: DataTypes.UUID,
+                allowNull: false,
+                references: { model: 'Projects', key: 'id' },
+                onDelete: 'cascade',
+                onUpdate: 'cascade'
+            },
+            PipelineStageId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: { model: 'PipelineStages', key: 'id' },
+                onDelete: 'cascade',
+                onUpdate: 'cascade'
+            }
         })
     },
     down: async (context) => {

--- a/forge/db/migrations/20230504-01-add-pipelines.js
+++ b/forge/db/migrations/20230504-01-add-pipelines.js
@@ -5,11 +5,45 @@ const { DataTypes } = require('sequelize')
 
 module.exports = {
     up: async (context) => {
-        await context.addColumn('Projects', 'PipelineStageId', {
-            type: DataTypes.INTEGER,
-            references: { model: 'PipelineStages', key: 'id' },
-            onDelete: 'set null',
-            onUpdate: 'cascade'
+        await context.createTable('Pipelines', {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            name: { type: DataTypes.STRING, allowNull: false },
+
+            createdAt: { type: DataTypes.DATE },
+            updatedAt: { type: DataTypes.DATE },
+
+            ApplicationId: {
+                type: DataTypes.INTEGER,
+                references: { model: 'Applications', key: 'id' },
+                onDelete: 'cascade',
+                onUpdate: 'cascade'
+            }
+        })
+
+        await context.createTable('PipelineStages', {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            name: { type: DataTypes.STRING, allowNull: false },
+            target: { type: DataTypes.INTEGER, allowNull: true }, // @TODO: this is the next stage ID in the pipeline, needs relations declaring...
+
+            PipelineId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: { model: 'Pipelines', key: 'id' },
+                onDelete: 'cascade',
+                onUpdate: 'cascade'
+            },
+
+            createdAt: { type: DataTypes.DATE },
+            updatedAt: { type: DataTypes.DATE }
+        })
         })
     },
     down: async (context) => {

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -10,10 +10,7 @@ module.exports = {
             delete options.source
         }
         const stage = await app.db.models.PipelineStage.create(options)
-
-        const project = await app.db.models.Project.byId(options.instance)
-        project.PipelineStageId = stage.id
-        await project.save()
+        stage.addInstanceId(options.instance)
 
         if (source) {
             const sourceStage = await app.db.models.PipelineStage.byId(source)

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -1,6 +1,10 @@
 
 module.exports = {
     addPipelineStage: async function (app, pipeline, options) {
+        if (!options.instance) {
+            throw new Error('instance id is required')
+        }
+
         let source
         options.PipelineId = pipeline.id
         if (options.source) {

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -16,12 +16,17 @@ module.exports = {
     },
     associations: function (M) {
         this.belongsTo(M.Pipeline)
-        this.hasMany(M.Project)
+        this.belongsToMany(M.Project, { through: M.PipelineStageInstance, as: 'Instances', otherKey: 'InstanceId' })
     },
     finders: function (M) {
         const self = this
         return {
-            instance: { },
+            instance: {
+                async addInstanceId (instanceId) {
+                    const instance = await M.Project.byId(instanceId)
+                    await this.addInstance(instance)
+                }
+            },
             static: {
                 byId: async function (idOrHash) {
                     let id = idOrHash
@@ -32,7 +37,7 @@ module.exports = {
                         where: { id },
                         include: [
                             {
-                                model: M.Project,
+                                association: 'Instances',
                                 attributes: ['hashid', 'id', 'name', 'url', 'updatedAt']
                             }
                         ]
@@ -48,7 +53,7 @@ module.exports = {
                         },
                         include: [
                             {
-                                model: M.Project,
+                                association: 'Instances',
                                 attributes: ['hashid', 'id', 'name', 'url', 'updatedAt']
                             }
                         ]

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -9,9 +9,27 @@ module.exports = {
             type: DataTypes.STRING,
             allowNull: false
         },
-        target: {
+
+        target: { // @TODO: this is the next stage ID in the pipeline, needs relations declaring..
             type: DataTypes.INTEGER,
             allowNull: true
+        }
+    },
+    options: {
+        validate: {
+            async instancesHaveSameApplication () {
+                const instancesPromise = this.getInstance()
+                const pipelinePromise = this.getPipeline()
+
+                const instances = await instancesPromise
+                const pipeline = await pipelinePromise
+
+                instances.forEach((instance) => {
+                    if (instance.applicationId !== pipeline.applicationId) {
+                        throw new Error(`All instances on a pipeline stage, must be a member of the same application as the pipeline. ${instance.name} is not a member of application ${pipeline.applicationId}.`)
+                    }
+                })
+            }
         }
     },
     associations: function (M) {

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -18,7 +18,7 @@ module.exports = {
     options: {
         validate: {
             async instancesHaveSameApplication () {
-                const instancesPromise = this.getInstance()
+                const instancesPromise = this.getInstances()
                 const pipelinePromise = this.getPipeline()
 
                 const instances = await instancesPromise

--- a/forge/ee/db/models/PipelineStageInstance.js
+++ b/forge/ee/db/models/PipelineStageInstance.js
@@ -1,0 +1,20 @@
+/**
+ * This is the many:1 association model between a Project and a PipelineStage
+ * @namespace forge.db.models.PipelineStageInstance
+ */
+
+module.exports = {
+    name: 'PipelineStageInstance',
+    options: {
+        timestamps: false
+    },
+    associations: function (M) {
+        this.belongsTo(M.PipelineStage)
+        this.belongsTo(M.Project, { as: 'Instance' }) // @TODO: need to guard that the instance is part of the same application that owns the stage
+    },
+    meta: {
+        slug: false,
+        hashid: false,
+        links: false
+    }
+}

--- a/forge/ee/db/models/index.js
+++ b/forge/ee/db/models/index.js
@@ -8,7 +8,8 @@ const modelTypes = [
     'StorageSharedLibrary',
     'UserBillingCode',
     'Pipeline',
-    'PipelineStage'
+    'PipelineStage',
+    'PipelineStageInstance'
 ]
 
 async function init (app) {

--- a/forge/ee/db/models/index.js
+++ b/forge/ee/db/models/index.js
@@ -54,7 +54,7 @@ async function init (app) {
         if (!m.model) {
             m.model = class model extends Model {}
         }
-        if (!m.schema.slug && (!m.meta || m.meta.slug !== false)) {
+        if (!m.schema?.slug && (!m.meta || m.meta.slug !== false)) {
             m.schema.slug = {
                 type: DataTypes.VIRTUAL,
                 get () {
@@ -81,7 +81,7 @@ async function init (app) {
             }
         }
 
-        if (!m.schema.links && (!m.meta || m.meta.links !== false)) {
+        if (!m.schema?.links && (!m.meta || m.meta.links !== false)) {
             m.schema.links = {
                 type: DataTypes.VIRTUAL,
                 get () {

--- a/forge/ee/db/views/PipelineStage.js
+++ b/forge/ee/db/views/PipelineStage.js
@@ -6,9 +6,8 @@ module.exports = {
             name: result.name
         }
 
-        if (stage.Projects && stage.Projects.length > 0) {
-            const project = stage.Projects[0]
-            filtered.instance = await app.db.views.Project.project(project, { includeSettings: false })
+        if (stage.Instances?.length > 0) {
+            filtered.instances = await app.db.views.Project.instancesList(stage.Instances)
         }
 
         if (stage.target) {
@@ -19,10 +18,6 @@ module.exports = {
         return filtered
     },
     async stageList (app, stages) {
-        const list = await Promise.all(stages.map(async (stage) => {
-            const s = app.db.views.PipelineStage.stage(stage)
-            return s
-        }))
-        return list
+        return await Promise.all(stages.map(app.db.views.PipelineStage.stage))
     }
 }

--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -97,9 +97,20 @@ const getApplicationInstancesStatuses = async (applicationId, cursor, limit) => 
  */
 const getPipelines = async (applicationId) => {
     const result = await client.get(`/api/v1/applications/${applicationId}/pipelines`)
-    const instances = result.data.pipelines
+    const pipelines = result.data.pipelines
 
-    return instances
+    return pipelines.map((pipeline) => {
+        pipeline.stages = pipeline.stages.map((stage) => {
+            // For now, in the UI, a pipeline stage can only have one instance/
+            // In the backend, multiple instances per pipeline are supported
+            // @see getPipelineStage in frontend Pipeline API
+            stage.instance = stage.instances?.[0]
+
+            return stage
+        })
+
+        return pipeline
+    })
 }
 
 /**

--- a/frontend/src/api/pipeline.js
+++ b/frontend/src/api/pipeline.js
@@ -10,6 +10,11 @@ import client from './client.js'
 const getPipelineStage = async (pipelineId, stageId) => {
     return client.get(`/api/v1/pipelines/${pipelineId}/stages/${stageId}`)
         .then(res => {
+            // For now, in the UI, a pipeline stage can only have one instance/
+            // In the backend, multiple instances per pipeline are supported
+            // @see getPipelines in frontend Application API
+            res.instance = res.instances?.[0]
+
             return res.data
         })
 }

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -90,7 +90,6 @@ export default {
     mounted () {
         if (this.features['devops-pipelines']) {
             this.loadPipelines()
-            this.loadInstanceStatus()
         } else {
             this.$router.push({
                 name: 'Application',

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -70,6 +70,7 @@ export default {
     beforeRouteLeave () {
         clearInterval(this.polling)
     },
+    inheritAttrs: false,
     props: {
         instances: {
             type: Array,

--- a/test/unit/frontend/api/pipelines.spec.js
+++ b/test/unit/frontend/api/pipelines.spec.js
@@ -6,7 +6,8 @@ import { expect, vi } from 'vitest'
 const mockGet = vi.fn().mockImplementation().mockReturnValue(Promise.resolve({
     data: {
         teams: [],
-        devices: []
+        devices: [],
+        pipelines: []
     }
 }))
 const mockPost = vi.fn().mockImplementation().mockReturnValue(Promise.resolve({ data: {} }))


### PR DESCRIPTION
Merge target is feature branch `2075-application-pipelines` (https://github.com/flowforge/flowforge/pull/2094)

## Description

All behind the scenes changes, the front-end presents exactly the same as in #2094, bugs and all.

- Re-works the backend to use a through table to connect instances to pipeline stages
- Explicitly creates all the required tables as part of a migration
- Updates the backend to allow **multiple** instances per pipeline stage
- Updates the frontend to only allow one instance per pipeline stage (for now)
- Adds some validations for instances and guards against instance being null at pipeline stage creation time
- Small misc cleanup

<img width="1193" alt="Screenshot 2023-05-11 at 15 31 35" src="https://github.com/flowforge/flowforge/assets/507155/bf04de9f-31d0-4a63-9bfb-214397775f42">

## Related Issue(s)

Part of #2124

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
    - Full unit coverage coming as a follow up
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

