### PR TITLE
Handle non-string log message payloads

### DIFF
--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -83,7 +83,7 @@ export default {
                 entries.log.forEach(l => {
                     const d = new Date(parseInt(l.ts.substring(0, l.ts.length - 4)))
                     l.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-                    if (typeof l.msg === 'object') {
+                    if (typeof l.msg !== 'string') {
                         l.msg = JSON.stringify(l.msg)
                     }
                     l.msg = l.msg.replace(/^[\n]*/, '')


### PR DESCRIPTION
## Description

This was fixed for device logs (https://github.com/flowforge/flowforge/pull/2079) but the same issue exists for hosted instances that log non-strings.

## Related Issue(s)


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

