### PR TITLE
ESLint: Explicitly enable no-only and set root flag

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,9 +14,9 @@
         "ecmaVersion": 2022
     },
     "ignorePatterns": ["frontend/dist/", "var/", "*.svg", "*.xml"],
-    "plugins": ["promise"],
+    "plugins": ["promise", "no-only-tests"],
     "settings": {
-        "import/core-modules": [ "lottie-web-vue", "@heroicons/vue" ]
+        "import/core-modules": [ "lottie-web-vue", "@heroicons/vue" ],
         "node": {
             "allowModules": [
                 "flowforge-test-utils", // exists at test/node_modules/flowforge-test-utils
@@ -54,6 +54,9 @@
         "n/file-extension-in-import": "error",
         "n/no-missing-import": "error",
         "n/no-missing-require": "error",
+
+        // plugin:no-only-tests
+        "no-only-tests/no-only-tests": "error",
 
         // plugin:promise
         "promise/catch-or-return": ["error", { "allowFinally": true }]

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "es2022": true,
         "commonjs": true


### PR DESCRIPTION
## Description

- Set root flag to ensure eslint doesn't inherit other rules
- Explicitly enable the no-only tests rule (previously only enabled in flowforge-dev-env

[Relevant Slack Thread](https://flowforgeworkspace.slack.com/archives/C032Q63FGG1/p1683878078586109)

## Related Issue(s)

#1990 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass - Not relevant
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

