### PR TITLE
Use gh token for release process

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.MAINTENANCE_SYNC_TOKEN }}
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This allows the sync to maintenance to bypass the branch protections by using a token associated with a repo owner (me).