### PR TITLE
Only Generate admin stats token when asked

### DIFF
--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -246,7 +246,9 @@ export default {
         })
 
         this.platformStatsTokenEnabled = this.input['platform:stats:token']
-        this.platformStatsToken = ''
+        if (!this.platformStatsTokenEnabled) {
+            this.platformStatsToken = ''
+        }
     },
     watch: {
         platformStatsTokenEnabled: function (newValue) {
@@ -356,6 +358,7 @@ export default {
         disableStatsToken () {
             this.$refs.disablePlatformStatsToken.close()
             this.platformStatsToken = ''
+            this.platformStatsTokenEnabled = false
             adminApi.deleteStatsAccessToken().then(result => {})
         }
     },


### PR DESCRIPTION
fixes #2140

## Description

<!-- Describe your changes in detail -->
Prevents the admin stats token from being re-generated every time the admin settings general page loads

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

