### PR TITLE
Bump ui-components to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@fastify/passport": "^2.3.0",
         "@fastify/static": "^6.5.0",
         "@fastify/websocket": "^7.2.0",
-        "@flowforge/forge-ui-components": "^0.6.1",
+        "@flowforge/forge-ui-components": "^0.6.2",
         "@flowforge/localfs": "^1.7.0",
         "@headlessui/vue": "1.7.13",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
## Description

Update to 0.6.2 in order to push the fix for https://github.com/flowforge/flowforge/issues/2143

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

## Labels

 - [ ] Backport needed? -> add the `backport` label

