### PR TITLE
1586 audit log team create delete

### DIFF
--- a/forge/auditLog/platform.js
+++ b/forge/auditLog/platform.js
@@ -57,6 +57,14 @@ module.exports = {
                     const info = { resource, count, limit }
                     await log('platform.license.overage', actionedBy, generateBody({ error, info }))
                 }
+            },
+            team: {
+                async created (actionedBy, error, team) {
+                    await log('platform.team.created', actionedBy, generateBody({ error, team }))
+                },
+                async deleted (actionedBy, error, team) {
+                    await log('platform.team.deleted', actionedBy, generateBody({ error, team }))
+                }
             }
         }
 

--- a/forge/routes/api/users.js
+++ b/forge/routes/api/users.js
@@ -121,6 +121,7 @@ module.exports = async function (app) {
                     slug: request.body.username,
                     TeamTypeId: (await app.db.models.TeamType.byName('starter')).id
                 }, newUser)
+                await app.auditLog.Platform.platform.team.created(request.session.User, null, team)
                 await app.auditLog.User.users.teamAutoCreated(request.session.User, null, team, logUserInfo)
             }
             reply.send(await app.db.views.User.userProfile(newUser))

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -418,6 +418,7 @@ module.exports = fp(async function (app, opts, done) {
                     TeamTypeId: (await app.db.models.TeamType.byName('starter')).id
                 }
                 const team = await app.db.controllers.Team.createTeamForUser(teamProperties, verifiedUser)
+                await app.auditLog.Platform.platform.team.created(request.session?.User || verifiedUser, null, team)
                 await app.auditLog.User.account.verify.autoCreateTeam(request.session?.User || verifiedUser, null, team)
 
                 if (app.license.active() && app.billing && app.settings.get('user:team:trial-mode')) {

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -125,6 +125,8 @@ const iconMap = {
     users: [
         'team.created',
         'team.deleted',
+        'platform.team.created',
+        'platform.team.deleted',
         'users.auto-created-team'
     ],
     mail: [

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -4,12 +4,12 @@
         <label>Error: </label>
     </template>
     <!-- Team Scoped Events -->
-    <template v-if="entry.event === 'team.created'">
+    <template v-if="entry.event === 'team.created' || entry.event === 'platform.team.created'">
         <label>{{ AuditEvents[entry.event] }}</label>
         <span v-if="!error && entry.body?.team">Team '{{ entry.body.team?.name }}' has been created.</span>
         <span v-else-if="!error">Team data not found in audit entry.</span>
     </template>
-    <template v-else-if="entry.event === 'team.deleted'">
+    <template v-else-if="entry.event === 'team.deleted' || entry.event === 'platform.team.deleted'">
         <label>{{ AuditEvents[entry.event] }}</label>
         <span v-if="!error && entry.body?.team">Team '{{ entry.body.team?.name }}' has been deleted.</span>
         <span v-else-if="!error">Team data not found in audit entry.</span>

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -103,6 +103,9 @@
         "user.deleted": "User Deleted Account",
         "users.deleted-user": "User Deleted",
         "users.updated-user": "User Updated",
-        "users.auto-created-team": "Team Created"
+        "users.auto-created-team": "Team Created",
+        "platform.team.created": "New Team Created",
+        "platform.team.deleted": "Team Deleted"
+
     }
 }

--- a/test/unit/forge/auditLog/platform_spec.js
+++ b/test/unit/forge/auditLog/platform_spec.js
@@ -202,4 +202,42 @@ describe('Audit Log > Platform', async function () {
         logEntry.should.have.property('body').and.be.an.Object()
         logEntry.body.should.have.property('info', overage)
     })
+
+    // #region Team Tests
+    it('Provides a logger for a platform team created', async function () {
+        // platform - team - created
+        const defaultTeamType = await app.db.models.TeamType.findOne()
+        const TEAM = await app.db.models.Team.create({ name: 'temp-team1', active: true, TeamTypeId: defaultTeamType.id })
+        await platformLogger.platform.team.created(ACTIONED_BY, null, TEAM)
+
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'platform.team.created')
+        logEntry.should.have.property('scope', { id: null, type: 'platform' })
+        logEntry.should.have.property('trigger')
+        logEntry.trigger.should.have.property('id', ACTIONED_BY.hashid)
+        logEntry.trigger.should.have.property('type', 'user')
+        logEntry.trigger.should.have.property('name', ACTIONED_BY.username)
+        logEntry.should.have.property('body')
+        logEntry.body.should.have.property('team')
+        logEntry.body.team.should.have.property('id', TEAM.hashid)
+        logEntry.body.team.should.have.property('name', TEAM.name)
+    })
+    it('Provides a logger for a platform team deleted', async function () {
+        // platform - team - deleted
+        const defaultTeamType = await app.db.models.TeamType.findOne()
+        const TEAM = await app.db.models.Team.create({ name: 'temp-team2', active: true, TeamTypeId: defaultTeamType.id })
+        await platformLogger.platform.team.deleted(ACTIONED_BY, null, TEAM)
+
+        const logEntry = await getLog()
+        logEntry.should.have.property('event', 'platform.team.deleted')
+        logEntry.should.have.property('scope', { id: null, type: 'platform' })
+        logEntry.should.have.property('trigger')
+        logEntry.trigger.should.have.property('id', ACTIONED_BY.hashid)
+        logEntry.trigger.should.have.property('type', 'user')
+        logEntry.trigger.should.have.property('name', ACTIONED_BY.username)
+        logEntry.should.have.property('body')
+        logEntry.body.should.have.property('team')
+        logEntry.body.team.should.have.property('id', TEAM.hashid)
+        logEntry.body.team.should.have.property('name', TEAM.name)
+    })
 })


### PR DESCRIPTION
## Description

* [Add loggers for platform - team.created/deleted](https://github.com/flowforge/flowforge/commit/2c454b8a2a659e96ef16a30b0b41974b1bc29b0a)
* [Update api logic to audit log events](https://github.com/flowforge/flowforge/commit/837e357793766571a8ee2341429e4385cf05f15c)
* [Updates ui to display new audit entries](https://github.com/flowforge/flowforge/commit/5289f12b8140639df81c4715d37242372b3af839)
* [Adds test coverage for new loggers](https://github.com/flowforge/flowforge/commit/652d7f36e731a043892effb15595b3e9d6898f3f)

![image](https://github.com/flowforge/flowforge/assets/44235289/1460ae23-5207-4e8d-82ee-e036d6cbbd43)



## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

