### PR TITLE
Include ha settings in instance settings endpoint

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -798,6 +798,14 @@ module.exports = async function (app) {
             settings.env = Object.assign({}, settings.settings.env, settings.env)
             delete settings.settings.env
         }
+
+        if (app.config.features.enabled('ha')) {
+            const ha = await request.project.getHASettings()
+            if (ha && ha.replicas > 1) {
+                settings.ha = ha
+            }
+        }
+
         reply.send(settings)
     })
 

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -854,7 +854,7 @@ describe('Project API', function () {
 
             it('Check Project Settings have ha key', async function () {
                 const project = await createInstance()
-                project.updateHASettings({
+                await project.updateHASettings({
                     replicas: 2
                 })
                 const newAccessToken = (await project.refreshAuthTokens()).token

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -851,6 +851,24 @@ describe('Project API', function () {
                 result.should.have.property('ha')
                 result.ha.should.have.property('replicas', 2)
             })
+
+            it('Check Project Settings have ha key', async function () {
+                const project = await createInstance()
+                project.updateHASettings({
+                    replicas: 2
+                })
+                const newAccessToken = (await project.refreshAuthTokens()).token
+
+                const runtimeSettings = (await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/projects/${project.id}/settings`,
+                    headers: {
+                        authorization: `Bearer ${newAccessToken}`
+                    }
+                })).json()
+                runtimeSettings.should.have.property('ha')
+                runtimeSettings.ha.should.have.property('replicas', 2)
+            })
         })
     })
 


### PR DESCRIPTION
## Description

Disable editor if HA enabled.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

