### PR TITLE
Update link to mosquitto-go-auth

### DIFF
--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -182,7 +182,7 @@ Follow the appropriate [install instructions](https://mosquitto.org/download/) f
 your operating system.
 
 Once installed, you can download pre-built binaries for Linux platforms from 
-[here](https://github.com/hardillb/mosquitto-go-auth/releases/tag/v0.0.1) and then jump 
+[here](https://github.com/iegomez/mosquitto-go-auth/releases/latest) and then jump 
 to step 4 below.
 
 On MacOS you will need to build and install the authentication plugin.


### PR DESCRIPTION
The mosquitto-go-auth project is now shipping pre-built binaries so linking to their version rather than my fork.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

