### PR TITLE
Rename target to NextStageId and NextStage for clarity

### DIFF
--- a/forge/db/migrations/20230504-01-add-pipelines.js
+++ b/forge/db/migrations/20230504-01-add-pipelines.js
@@ -31,7 +31,14 @@ module.exports = {
                 autoIncrement: true
             },
             name: { type: DataTypes.STRING, allowNull: false },
-            target: { type: DataTypes.INTEGER, allowNull: true }, // @TODO: this is the next stage ID in the pipeline, needs relations declaring...
+
+            NextStageId: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+                references: { model: 'PipelineStages', key: 'id' },
+                onDelete: 'SET NULL ',
+                onUpdate: 'SET NULL '
+            },
 
             PipelineId: {
                 type: DataTypes.INTEGER,

--- a/forge/ee/db/controllers/Pipeline.js
+++ b/forge/ee/db/controllers/Pipeline.js
@@ -18,7 +18,7 @@ module.exports = {
 
         if (source) {
             const sourceStage = await app.db.models.PipelineStage.byId(source)
-            sourceStage.target = stage.id
+            sourceStage.NextStageId = stage.id
             await sourceStage.save()
         }
 

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -10,7 +10,7 @@ module.exports = {
             allowNull: false
         },
 
-        target: {
+        NextStageId: {
             type: DataTypes.INTEGER,
             allowNull: true
         }
@@ -35,7 +35,7 @@ module.exports = {
     associations: function (M) {
         this.belongsTo(M.Pipeline)
         this.belongsToMany(M.Project, { through: M.PipelineStageInstance, as: 'Instances', otherKey: 'InstanceId' })
-        this.hasOne(M.PipelineStage, { as: 'NextStage', foreignKey: 'target', allowNull: true })
+        this.hasOne(M.PipelineStage, { as: 'NextStage', foreignKey: 'NextStageId', allowNull: true })
     },
     finders: function (M) {
         const self = this
@@ -82,13 +82,13 @@ module.exports = {
                         ]
                     })
                 },
-                byTarget: async function (idOrHash) {
+                byNextStage: async function (idOrHash) {
                     let id = idOrHash
                     if (typeof idOrHash === 'string') {
                         id = M.PipelineStage.decodeHashid(idOrHash)
                     }
                     return this.findOne({
-                        where: { target: id }
+                        where: { NextStageId: id }
                     })
                 }
             }

--- a/forge/ee/db/views/PipelineStage.js
+++ b/forge/ee/db/views/PipelineStage.js
@@ -10,10 +10,11 @@ module.exports = {
             filtered.instances = await app.db.views.Project.instancesList(stage.Instances)
         }
 
-        if (stage.target) {
-            const target = await app.db.models.PipelineStage.byId(result.target)
-            if (target) {
-                filtered.targetStage = target.hashid
+        if (stage.NextStageId) {
+            // Check stage actually exists before including it in response
+            const nextStage = await app.db.models.PipelineStage.byId(stage.NextStageId)
+            if (nextStage) {
+                filtered.NextStageId = nextStage.hashid
             }
         }
 

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -149,12 +149,12 @@ module.exports = async function (app) {
 
             // Update the previous stage to point to the next stage when this model is deleted
             // e.g. A -> B -> C to A -> C when B is deleted
-            const previousStage = await app.db.models.PipelineStage.byTarget(stageId)
+            const previousStage = await app.db.models.PipelineStage.byNextStage(stageId)
             if (previousStage) {
-                if (stage.target) {
-                    previousStage.target = stage.target
+                if (stage.NextStageId) {
+                    previousStage.NextStageId = stage.NextStageId
                 } else {
-                    previousStage.target = null
+                    previousStage.NextStageId = null
                 }
 
                 await previousStage.save()

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -113,7 +113,7 @@ export default {
             // get target stage
             const target = await PipelineAPI.getPipelineStage(
                 this.pipeline.id,
-                this.stage.targetStage
+                this.stage.NextStageId
             )
             if (!target) {
                 Alerts.emit(

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -113,7 +113,7 @@ describe('Pipelines API', function () {
                 const stageOne = await TestObjects.stageOne.reload()
                 const stageTwo = await app.db.models.PipelineStage.byId(body.id)
 
-                stageOne.target.should.equal(stageTwo.id)
+                stageOne.NextStageId.should.equal(stageTwo.id)
 
                 response.statusCode.should.equal(200)
             })
@@ -390,8 +390,8 @@ describe('Pipelines API', function () {
                 TestObjects.stageThree = await TestObjects.factory.createPipelineStage({ name: 'stage-three', instanceId: instanceThree.id, source: TestObjects.stageTwo.hashid }, TestObjects.pipeline)
                 await TestObjects.stageTwo.reload()
 
-                should(TestObjects.stageOne.target).equal(TestObjects.stageTwo.id)
-                should(TestObjects.stageTwo.target).equal(TestObjects.stageThree.id)
+                should(TestObjects.stageOne.NextStageId).equal(TestObjects.stageTwo.id)
+                should(TestObjects.stageTwo.NextStageId).equal(TestObjects.stageThree.id)
 
                 const response = await app.inject({
                     method: 'DELETE',
@@ -407,7 +407,7 @@ describe('Pipelines API', function () {
 
                 const stageOne = await TestObjects.stageOne.reload()
 
-                should(stageOne.target).equal(TestObjects.stageThree.id)
+                should(stageOne.NextStageId).equal(TestObjects.stageThree.id)
             })
         })
 
@@ -419,7 +419,7 @@ describe('Pipelines API', function () {
                 TestObjects.stageTwo = await TestObjects.factory.createPipelineStage({ name: 'stage-two', instanceId: TestObjects.instanceTwo.id, source: TestObjects.stageOne.hashid }, TestObjects.pipeline)
                 await TestObjects.stageOne.reload()
 
-                should(TestObjects.stageOne.target).equal(TestObjects.stageTwo.id)
+                should(TestObjects.stageOne.NextStageId).equal(TestObjects.stageTwo.id)
 
                 const response = await app.inject({
                     method: 'DELETE',
@@ -433,7 +433,7 @@ describe('Pipelines API', function () {
 
                 const stageOne = await TestObjects.stageOne.reload()
 
-                should(stageOne.target).equal(null)
+                should(stageOne.NextStageId).equal(null)
             })
         })
     })


### PR DESCRIPTION
## Description

Renames PipelineStage.target to PipelineStage.NextStageId for developer quality of life.

## Related Issue(s)

Fixes #2165

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

