### PR TITLE
Add initial UI for enabling HA when creating instance

### DIFF
--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -2,9 +2,9 @@
  * An application definition
  * @namespace forge.db.models.Application
  */
-const { DataTypes } = require('sequelize')
+const { DataTypes, Op } = require('sequelize')
 
-const { KEY_SETTINGS } = require('./ProjectSettings')
+const { KEY_SETTINGS, KEY_HA } = require('./ProjectSettings')
 
 module.exports = {
     name: 'Application',
@@ -60,7 +60,12 @@ module.exports = {
                                     attributes: ['hashid', 'id', 'name', 'links', 'settings', 'policy']
                                 }, {
                                     model: M.ProjectSettings,
-                                    where: { key: KEY_SETTINGS },
+                                    where: {
+                                        [Op.or]: [
+                                            { key: KEY_SETTINGS },
+                                            { key: KEY_HA }
+                                        ]
+                                    },
                                     required: false
                                 }
                             ]

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -207,7 +207,7 @@ module.exports = {
                     if (key === 'settings' && value && Array.isArray(value.env)) {
                         value.env = Controllers.Project.removePlatformSpecificEnvVars(value.env) // remove platform specific values
                     }
-                    return await M.ProjectSettings.upsert({ ProjectId: this.id, key, value }, options)
+                    return M.ProjectSettings.upsert({ ProjectId: this.id, key, value }, options)
                 },
                 async getSetting (key) {
                     const result = await M.ProjectSettings.findOne({ where: { ProjectId: this.id, key } })
@@ -220,7 +220,9 @@ module.exports = {
                     }
                     return undefined
                 },
-
+                async removeSetting (key, options) {
+                    return M.ProjectSettings.destroy({ where: { ProjectId: this.id, key } }, options)
+                },
                 async getCredentialSecret () {
                     // If this project was created at 0.6+ but then started with a <0.6 launcher
                     // (for example, in k8s with an old stack) then the project will have both
@@ -372,7 +374,12 @@ module.exports = {
 
                         include.push({
                             model: M.ProjectSettings,
-                            where: { key: KEY_SETTINGS },
+                            where: {
+                                [Op.or]: [
+                                    { key: KEY_SETTINGS },
+                                    { key: KEY_HA }
+                                ]
+                            },
                             required: false
                         })
                     }

--- a/forge/ee/lib/ha/index.js
+++ b/forge/ee/lib/ha/index.js
@@ -24,8 +24,11 @@ module.exports.init = function (app) {
             return this.getSetting(KEY_HA)
         }
         app.db.models.Project.prototype.updateHASettings = async function (haConfig) {
+            if (!haConfig) {
+                return this.removeSetting(KEY_HA)
+            }
             if (haConfig?.replicas > 0 && haConfig?.replicas < 3) {
-                await this.updateSetting(KEY_HA, {
+                return this.updateSetting(KEY_HA, {
                     replicas: haConfig.replicas
                 })
             }

--- a/forge/ee/routes/ha/index.js
+++ b/forge/ee/routes/ha/index.js
@@ -1,0 +1,107 @@
+module.exports = async function (app) {
+    app.addHook('preHandler', app.verifySession)
+    app.addHook('preHandler', async (request, reply) => {
+        if (!app.config.features.enabled('ha')) {
+            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+        }
+    })
+    app.addHook('preHandler', async (request, reply) => {
+        if (request.params.projectId !== undefined) {
+            if (request.params.projectId) {
+                try {
+                    request.project = await app.db.models.Project.byId(request.params.projectId)
+                    if (!request.project) {
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                        return
+                    }
+                    if (request.session.User) {
+                        request.teamMembership = await request.session.User.getTeamMembership(request.project.Team.id)
+                        if (!request.teamMembership && !request.session.User.admin) {
+                            reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                            return
+                        }
+                    } else if (request.session.ownerId !== request.params.projectId) {
+                        // AccesToken being used - but not owned by this project
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                        return
+                    }
+                } catch (err) {
+                    reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                }
+            } else {
+                reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+            }
+        }
+    })
+
+    app.get('/', {
+        preHandler: app.needsPermission('project:read')
+    }, async (request, reply) => {
+        reply.send(await request.project.getHASettings() || {})
+    })
+
+    app.put('/', {
+        preHandler: app.needsPermission('project:edit')
+    }, async (request, reply) => {
+        // For 1.8, only support setting replica count to 2
+        if (request.body.replicas !== 2) {
+            reply.code(409).send({ code: 'invalid_ha_configuration', error: 'Invalid HA configuration -only 2 replicas are allowed' })
+            return
+        }
+        const existingHA = await request.project.getHASettings() || {}
+        if (existingHA.replicas !== request.body.replicas) {
+            // This is a change in replica count.
+            await request.project.updateHASettings({ replicas: request.body.replicas })
+            await applyUpdatedInstanceSettings(reply, request.project, request.session.User)
+        } else {
+            reply.send(await request.project.getHASettings() || {})
+        }
+    })
+
+    app.delete('/', {
+        preHandler: app.needsPermission('project:edit')
+    }, async (request, reply) => {
+        const existingHA = await request.project.getHASettings() || {}
+        if (existingHA.replicas) {
+            // This instance already has ha configured - clear the setting
+            // and apply
+            await request.project.updateHASettings(undefined)
+            await applyUpdatedInstanceSettings(reply, request.project, request.session.User)
+        } else {
+            reply.send({})
+        }
+    })
+
+    async function applyUpdatedInstanceSettings (reply, project, user) {
+        if (project.state !== 'suspended') {
+            // This code is copy/paste with slight changes from projects.js
+            // We also have projectActions.js that does suspend logic.
+            // TODO: refactor into a Model function to suspend a project
+            app.db.controllers.Project.setInflightState(project, 'starting') // TODO: better inflight state needed
+            reply.send(await project.getHASettings() || {})
+
+            const targetState = project.state
+            app.log.info(`Stopping project ${project.id}`)
+            await app.containers.stop(project, {
+                skipBilling: true
+            })
+            await app.auditLog.Project.project.suspended(user, null, project)
+            app.log.info(`Restarting project ${project.id}`)
+            project.state = targetState
+            await project.save()
+            await project.reload()
+            const startResult = await app.containers.start(project)
+            startResult.started.then(async () => {
+                await app.auditLog.Project.project.started(user, null, project)
+                app.db.controllers.Project.clearInflightState(project)
+                return true
+            }).catch(_ => {
+                app.db.controllers.Project.clearInflightState(project)
+            })
+        } else {
+            // A suspended project doesn't need to do anything more
+            // The settings will get applied when it is next resumed
+            reply.send(await project.getHASettings() || {})
+        }
+    }
+}

--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -13,6 +13,8 @@ module.exports = async function (app) {
 
     await app.register(require('./deviceEditor'), { prefix: '/api/v1/devices/:deviceId/editor', logLevel: app.config.logging.http })
 
+    await app.register(require('./ha'), { prefix: '/api/v1/projects/:projectId/ha', logLevel: app.config.logging.http })
+
     // Important: keep SSO last to avoid its error handling polluting other routes.
     await app.register(require('./sso'), { logLevel: app.config.logging.http })
 }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -927,4 +927,10 @@ module.exports = async function (app) {
     function generateCredentialSecret () {
         return crypto.randomBytes(32).toString('hex')
     }
+
+    // app.get('/:projectId/ha', {
+    //     preHandler: app.needsPermission('project:read')
+    // }, async (request, reply) => {
+    //     reply.send(await request.project.getHASettings())
+    // })
 }

--- a/test/unit/forge/ee/routes/ha/index.js
+++ b/test/unit/forge/ee/routes/ha/index.js
@@ -1,0 +1,171 @@
+const sleep = require('util').promisify(setTimeout)
+
+const should = require('should') // eslint-disable-line
+
+const setup = require('../../setup')
+
+const FF_UTIL = require('flowforge-test-utils')
+const { START_DELAY, STOP_DELAY } = FF_UTIL.require('forge/containers/stub/index.js')
+
+describe('HA Instance API', function () {
+    let app
+    const TestObjects = { tokens: {} }
+
+    before(async function () {
+        app = await setup({ billing: null })
+        await login('alice', 'aaPassword')
+
+        const response = await app.inject({
+            method: 'POST',
+            url: '/api/v1/projects',
+            payload: {
+                name: 'test-ha-project-1',
+                applicationId: app.application.hashid,
+                projectType: app.projectType.hashid,
+                template: app.template.hashid,
+                stack: app.stack.hashid
+            },
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        TestObjects.project = await app.db.models.Project.byId(JSON.parse(response.body).id)
+        // Ensure the project is started
+        await sleep(START_DELAY)
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    it('get ha options for instance', async function () {
+        const response = await app.inject({
+            method: 'GET',
+            url: `/api/v1/projects/${TestObjects.project.id}/ha`,
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.be.empty()
+    })
+
+    it('rejects invalid ha options', async function () {
+        const testReplicaCount = async n => {
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/projects/${TestObjects.project.id}/ha`,
+                payload: {
+                    replicas: n
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(409)
+            const result = JSON.parse(response.body)
+            result.should.have.property('code', 'invalid_ha_configuration')
+        }
+        await testReplicaCount(0)
+        await testReplicaCount(1)
+        await testReplicaCount(3)
+    })
+
+    it('applies valid ha option', async function () {
+        const response = await app.inject({
+            method: 'PUT',
+            url: `/api/v1/projects/${TestObjects.project.id}/ha`,
+            payload: {
+                replicas: 2
+            },
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.have.property('replicas', 2)
+
+        await sleep(STOP_DELAY)
+        await TestObjects.project.reload()
+
+        // Project has been stopped but is presented as "starting"
+        TestObjects.project.state.should.equal('suspended')
+        app.db.controllers.Project.getInflightState(TestObjects.project).should.equal('starting')
+
+        // Wait for at least start delay as set in stub driver
+        await sleep(START_DELAY + 100)
+
+        await TestObjects.project.reload({
+            include: [
+                { model: app.db.models.ProjectType },
+                { model: app.db.models.ProjectStack }
+            ]
+        })
+
+        // Project is re-running
+        TestObjects.project.state.should.equal('running')
+        should(app.db.controllers.Project.getInflightState(TestObjects.project)).equal(undefined)
+
+        const haSetting = await TestObjects.project.getHASettings()
+        haSetting.should.have.property('replicas', 2)
+    })
+
+    it('removes ha option', async function () {
+        // NOTE: this continues using the objects from the previous test.
+        const response = await app.inject({
+            method: 'DELETE',
+            url: `/api/v1/projects/${TestObjects.project.id}/ha`,
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.not.have.property('replicas')
+
+        await sleep(STOP_DELAY)
+        await TestObjects.project.reload()
+
+        // Project has been stopped but is presented as "starting"
+        TestObjects.project.state.should.equal('suspended')
+        app.db.controllers.Project.getInflightState(TestObjects.project).should.equal('starting')
+
+        // Wait for at least start delay as set in stub driver
+        await sleep(START_DELAY + 100)
+
+        await TestObjects.project.reload({
+            include: [
+                { model: app.db.models.ProjectType },
+                { model: app.db.models.ProjectStack }
+            ]
+        })
+
+        // Project is re-running
+        TestObjects.project.state.should.equal('running')
+        should(app.db.controllers.Project.getInflightState(TestObjects.project)).equal(undefined)
+
+        const haSetting = await TestObjects.project.getHASettings()
+        should.not.exist(haSetting)
+    })
+
+    it('removing non-existent ha option no-ops', async function () {
+        // NOTE: this continues using the objects from the previous test.
+        const response = await app.inject({
+            method: 'DELETE',
+            url: `/api/v1/projects/${TestObjects.project.id}/ha`,
+            cookies: { sid: TestObjects.tokens.alice }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.not.have.property('replicas')
+
+        await sleep(STOP_DELAY)
+        await TestObjects.project.reload()
+
+        TestObjects.project.state.should.equal('running')
+        should(app.db.controllers.Project.getInflightState(TestObjects.project)).equal(undefined)
+    })
+})


### PR DESCRIPTION
## Description

Adds initial UI options to allow an instance to be created with HA enabled.

This is *very* MVP and includes more placeholders than real things - but makes it easier to see what needs updating.

#### Create Instance

<img width="700" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/f71b7c20-9337-449b-a3e1-3d6fcd942fed">


#### Team Application List

<img width="954" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/ea994f4e-9ecb-4d40-83fd-91fcac666d56">

#### Instance Details

<img width="1113" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/c5630b13-1d68-44e6-9110-1fdf219497ed">

#### Application Overview

The Instance list just disables the Editor button if HA is enabled, rather say anything about HA... will need to be made consistent with the Team Application List view.