### PR TITLE
Initial UI support for HA mode

### DIFF
--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -35,9 +35,9 @@ module.exports = {
             const settingsHostnameRow = proj.ProjectSettings?.find((projectSettingsRow) => projectSettingsRow.key === KEY_HOSTNAME)
             result.hostname = settingsHostnameRow?.value || ''
         }
-        const settingsHARow = proj.ProjectSettings?.find(row => row.key === KEY_HA)
-        if (settingsHARow) {
-            result.ha = settingsHARow.value
+        if (app.config.features.enabled('ha')) {
+            const settingsHARow = proj.ProjectSettings?.find(row => row.key === KEY_HA)
+            result.ha = settingsHARow?.value || { disabled: true }
         }
 
         if (proj.Application) {

--- a/frontend/src/api/instances.js
+++ b/frontend/src/api/instances.js
@@ -136,6 +136,15 @@ const rollbackInstance = async (instanceId, snapshotId) => {
     }
     return client.post(`/api/v1/projects/${instanceId}/actions/rollback`, data).then(res => res.data)
 }
+
+const enableHAMode = async (instanceId) => {
+    const haConfig = { replicas: 2 }
+    return client.put(`/api/v1/projects/${instanceId}/ha`, haConfig)
+}
+const disableHAMode = async (instanceId) => {
+    return client.delete(`/api/v1/projects/${instanceId}/ha`)
+}
+
 export default {
     create,
     getInstance,
@@ -151,5 +160,7 @@ export default {
     getInstanceDevices,
     getInstanceDeviceSettings,
     updateInstanceDeviceSettings,
-    rollbackInstance
+    rollbackInstance,
+    enableHAMode,
+    disableHAMode
 }

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -34,7 +34,7 @@ import {
 } from '@heroicons/vue/outline'
 
 export default {
-    name: 'InstanceStatusBadge',
+    name: 'StatusBadge',
     components: {
         CloudDownloadIcon,
         CloudUploadIcon,

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -141,8 +141,8 @@ export default {
             return this.instances.map((instance) => {
                 instance.running = instance.meta?.state === 'running'
                 instance.notSuspended = instance.meta?.state !== 'suspended'
-
-                instance.disabled = !instance.running || this.isVisitingAdmin
+                instance.isHA = instance.ha?.replicas !== undefined
+                instance.disabled = !instance.running || this.isVisitingAdmin || instance.isHA
 
                 return instance
             })

--- a/frontend/src/pages/application/createInstance.vue
+++ b/frontend/src/pages/application/createInstance.vue
@@ -134,6 +134,10 @@ export default {
                     options: { ...copyParts }
                 }
             }
+            if (this.features.ha && createPayload.isHA) {
+                createPayload.ha = { replicas: 2 }
+            }
+            delete createPayload.isHA
 
             return instanceApi.create(createPayload)
         }

--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -17,7 +17,14 @@
                                     <ExternalLinkIcon class="w-4 ml-3" />
                                 </a>
                             </div>
-                            <div v-else class="my-2">Unavailable</div>
+                            <div v-else class="my-2">
+                                <router-link v-if="isHA" :to="{name: 'InstanceSettingsHA', params: { id: instance.id }}" @click.stop>
+                                    <StatusBadge class="text-gray-400 hover:text-blue-600" status="high-availability" />
+                                </router-link>
+                                <template v-else>
+                                    Unavailable
+                                </template>
+                            </div>
                         </td>
                     </tr>
                     <tr class="border-b">
@@ -84,6 +91,7 @@ import { mapState } from 'vuex'
 
 import InstanceApi from '../../api/instances.js'
 import FormHeading from '../../components/FormHeading.vue'
+import StatusBadge from '../../components/StatusBadge.vue'
 import AuditLog from '../../components/audit-log/AuditLog.vue'
 import permissionsMixin from '../../mixins/Permissions.js'
 
@@ -96,6 +104,7 @@ export default {
         ExternalLinkIcon,
         FormHeading,
         InstanceStatusBadge,
+        StatusBadge,
         TemplateIcon,
         TrendingUpIcon
     },
@@ -122,7 +131,10 @@ export default {
             return this.instance?.meta?.state === 'running'
         },
         editorAvailable () {
-            return this.instanceRunning
+            return !this.isHA && this.instanceRunning
+        },
+        isHA () {
+            return this.instance?.ha.replicas !== undefined
         }
     },
     watch: {

--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -134,7 +134,7 @@ export default {
             return !this.isHA && this.instanceRunning
         },
         isHA () {
-            return this.instance?.ha.replicas !== undefined
+            return this.instance?.ha?.replicas !== undefined
         }
     },
     watch: {

--- a/frontend/src/pages/instance/Settings/General.vue
+++ b/frontend/src/pages/instance/Settings/General.vue
@@ -13,6 +13,14 @@
             Instance Type
         </FormRow>
 
+        <FormRow v-if="features.ha && input.haConfig" v-model="input.haConfig" type="uneditable">
+            <template #default>High Availability</template>
+            <template #input>
+                <div class="w-full uneditable undefined text-gray-800">
+                    {{ input.haConfig.replicas }} x instances
+                </div>
+            </template>
+        </FormRow>
         <FormRow v-model="input.stackDescription" type="uneditable">
             Stack
         </FormRow>
@@ -20,7 +28,7 @@
             Template
         </FormRow>
         <DangerSettings
-            :instance="project"
+            :instance="instance"
             @instance-confirm-delete="$emit('instance-confirm-delete')"
             @instance-confirm-suspend="$emit('instance-confirm-suspend')"
         />
@@ -28,6 +36,8 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
+
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
 
@@ -42,7 +52,7 @@ export default {
     },
     inheritAttrs: false,
     props: {
-        project: {
+        instance: {
             type: Object,
             required: true
         }
@@ -58,11 +68,18 @@ export default {
                 projectName: '',
                 projectTypeName: '',
                 stackDescription: '',
-                templateName: ''
+                templateName: '',
+                haConfig: {}
             },
             original: {
                 projectName: ''
             }
+        }
+    },
+    computed: {
+        ...mapState('account', ['features']),
+        isHA () {
+            return !!this.instance?.ha
         }
     },
     watch: {
@@ -73,25 +90,30 @@ export default {
     },
     methods: {
         fetchData () {
-            this.input.projectId = this.project.id
-            if (this.project.stack) {
-                this.input.stackDescription = this.project.stack.label || this.project.stack.name
+            this.input.projectId = this.instance.id
+            if (this.instance.stack) {
+                this.input.stackDescription = this.instance.stack.label || this.instance.stack.name
             } else {
                 this.input.stackDescription = 'none'
             }
-            if (this.project.projectType) {
-                this.input.projectTypeName = this.project.projectType.name
+            if (this.instance.projectType) {
+                this.input.projectTypeName = this.instance.projectType.name
             } else {
                 this.input.projectTypeName = 'none'
             }
 
-            if (this.project.template) {
-                this.input.templateName = this.project.template.name
+            if (this.instance.template) {
+                this.input.templateName = this.instance.template.name
             } else {
                 this.input.templateName = 'none'
             }
 
-            this.input.projectName = this.project.name
+            this.input.projectName = this.instance.name
+            if (this.instance.ha?.replicas !== undefined) {
+                this.input.haConfig = this.instance.ha
+            } else {
+                this.input.haConfig = undefined
+            }
         }
     }
 }

--- a/frontend/src/pages/instance/Settings/HighAvailability.vue
+++ b/frontend/src/pages/instance/Settings/HighAvailability.vue
@@ -67,7 +67,7 @@ export default {
     },
     computed: {
         isHA () {
-            return this.instance?.ha.replicas !== undefined
+            return this.instance?.ha?.replicas !== undefined
         }
     },
     methods: {

--- a/frontend/src/pages/instance/Settings/HighAvailability.vue
+++ b/frontend/src/pages/instance/Settings/HighAvailability.vue
@@ -1,0 +1,113 @@
+<template>
+    <ff-loading v-if="updating" message="Updating Instance..." />
+    <template v-else>
+        <FormHeading>High Availability (preview)</FormHeading>
+        <FormRow>
+            <template #description>
+                <p class="mb-3">
+                    High Availability mode allows you to run multiple copies
+                    of your Node-RED instance, with incoming work distributed
+                    between them.
+                </p>
+                <p>
+                    This Preview Feature is currently free to use, but
+                    will become a chargable feature in a future release.
+                </p>
+                <p>
+                    When HA mode is enabled the following restrictions currently apply:
+                </p>
+                <ul class="list-disc pl-6">
+                    <li>Enabling or disabling HA mode requires a restart of the Instance.</li>
+                    <li>Flows cannot be directly modified in an HA Instance; the editor is disabled.</li>
+                    <li>A DevOps Pipeline should be created to deploy new flows to the instance.</li>
+                    <li>Any internal state of the flows is not shared between the HA copies.</li>
+                </ul>
+                <p>
+                    Check the documentation for more information about the <a class="underline" href="#">High Availability preview feature</a>.
+                </p>
+            </template>
+            <template #input>&nbsp;</template>
+        </FormRow>
+        <template v-if="!isHA">
+            <ff-button kind="secondary" data-nav="enable-ha" @click="enableHA()">Enable HA mode</ff-button>
+        </template>
+        <template v-else>
+            <ff-button kind="secondary" data-nav="disable-ha" @click="disableHA()">Disable HA mode</ff-button>
+        </template>
+    </template>
+</template>
+
+<script>
+
+import InstanceApi from '../../../api/instances.js'
+
+import FormHeading from '../../../components/FormHeading.vue'
+import FormRow from '../../../components/FormRow.vue'
+import Alerts from '../../../services/alerts.js'
+import Dialog from '../../../services/dialog.js'
+
+export default {
+    name: 'InstanceSettingsStages',
+    components: {
+        FormHeading,
+        FormRow
+    },
+    inheritAttrs: false,
+    props: {
+        instance: {
+            type: Object,
+            required: true
+        }
+    },
+    emits: ['instance-updated'],
+    data: function () {
+        return {
+            updating: false
+        }
+    },
+    computed: {
+        isHA () {
+            return this.instance?.ha.replicas !== undefined
+        }
+    },
+    methods: {
+        async enableHA () {
+            const msg = {
+                header: 'Enable High Availability mode',
+                html: `<p>Enabling HA mode will require a restart of the instance.</p>
+                       <p>Once enabled, the editor will be disabled. The flows can only
+                          be updated by using a DevOps Pipeline to deploy to this instance
+                          from another one, or by disabling HA mode first.</p>`
+            }
+            Dialog.show(msg, async () => {
+                this.updating = true
+                await InstanceApi.enableHAMode(this.instance.id)
+                this.updating = false
+                if (this.instance.meta?.state === 'suspended') {
+                    Alerts.emit('High Availability mode enabled', 'confirmation')
+                } else {
+                    Alerts.emit('High Availability mode enabled. The Instance will now be restarted', 'confirmation')
+                }
+                this.$emit('instance-updated')
+            })
+        },
+        async disableHA () {
+            const msg = {
+                header: 'Disable High Availability mode',
+                html: '<p>Disabling HA mode will require a restart of the instance.</p>'
+            }
+            Dialog.show(msg, async () => {
+                this.updating = true
+                await InstanceApi.disableHAMode(this.instance.id)
+                this.updating = false
+                if (this.instance.meta?.state === 'suspended') {
+                    Alerts.emit('High Availability mode disabled', 'confirmation')
+                } else {
+                    Alerts.emit('High Availability mode disabled. The Instance will now be restarted', 'confirmation')
+                }
+                this.$emit('instance-updated')
+            })
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/instance/Settings/index.vue
+++ b/frontend/src/pages/instance/Settings/index.vue
@@ -44,7 +44,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'teamMembership'])
+        ...mapState('account', ['team', 'teamMembership', 'features'])
     },
     watch: {
         teamMembership: 'checkAccess'
@@ -60,6 +60,9 @@ export default {
             ]
             if (this.hasPermission('project:edit')) {
                 this.sideNavigation.push({ name: 'DevOps', path: './devops' })
+                if (this.features.ha) {
+                    this.sideNavigation.push({ name: 'High Availability', path: './ha' })
+                }
                 this.sideNavigation.push({ name: 'Editor', path: './editor' })
                 this.sideNavigation.push({ name: 'Security', path: './security' })
                 this.sideNavigation.push({ name: 'Palette', path: './palette' })

--- a/frontend/src/pages/instance/Settings/routes.js
+++ b/frontend/src/pages/instance/Settings/routes.js
@@ -4,6 +4,7 @@ import InstanceSettingsDevOps from './DevOps.vue'
 import InstanceSettingsEditor from './Editor.vue'
 import InstanceSettingsEnvVar from './Environment.vue'
 import InstanceSettingsGeneral from './General.vue'
+import InstanceSettingsHA from './HighAvailability.vue'
 import InstanceSettingsPalette from './Palette.vue'
 import InstanceSettingsSecurity from './Security.vue'
 
@@ -15,6 +16,7 @@ export default [
     { path: 'security', component: InstanceSettingsSecurity },
     { path: 'palette', component: InstanceSettingsPalette },
     { path: 'danger', component: InstanceSettingsDanger },
+    { path: 'ha', name: 'InstanceSettingsHA', component: InstanceSettingsHA },
     {
         name: 'ChangeInstanceType',
         path: 'change-type',

--- a/frontend/src/pages/instance/components/InstanceEditorLink.vue
+++ b/frontend/src/pages/instance/components/InstanceEditorLink.vue
@@ -1,6 +1,7 @@
 <template>
     <ff-button
         v-if="!isVisitingAdmin"
+        v-ff-tooltip:left="disabledReason"
         kind="secondary"
         data-action="open-editor"
         :disabled="editorDisabled || disabled || !url"
@@ -11,7 +12,7 @@
         </template>
         {{ editorDisabled ? 'Editor Disabled' : 'Open Editor' }}
     </ff-button>
-    <button v-else title="Unable to open editor when visiting as an admin" class="ff-btn ff-btn--secondary" disabled>
+    <button v-else v-ff-tooltip:left="'Unable to open editor when visiting as an admin'" class="ff-btn ff-btn--secondary" disabled>
         {{ editorDisabled ? 'Editor Disabled' : 'Open Editor' }}
         <span class="ff-btn--icon ff-btn--icon-right">
             <ExternalLinkIcon />
@@ -38,6 +39,10 @@ export default {
         disabled: {
             default: false,
             type: Boolean
+        },
+        disabledReason: {
+            default: null,
+            type: String
         },
         url: {
             default: '',

--- a/frontend/src/pages/instance/components/cells/InstanceEditorLink.vue
+++ b/frontend/src/pages/instance/components/cells/InstanceEditorLink.vue
@@ -1,17 +1,25 @@
 <template>
     <div class="flex justify-end">
-        <InstanceEditorLink :disabled="disabled" :editorDisabled="editorDisabled" :url="url" />
+        <InstanceEditorLink v-if="!isHA" :disabled="disabled" :editorDisabled="editorDisabled" :url="url" />
+        <router-link v-else :to="{name: 'InstanceSettingsHA', params: { id }}" @click.stop>
+            <StatusBadge class="text-gray-400 hover:text-blue-600" status="high-availability" />
+        </router-link>
     </div>
 </template>
 
 <script>
+import StatusBadge from '../../../../components/StatusBadge.vue'
 import InstanceEditorLink from '../InstanceEditorLink.vue'
 
 export default {
     name: 'InstanceEditorLinkCell',
-    components: { InstanceEditorLink },
+    components: { InstanceEditorLink, StatusBadge },
     inheritAttrs: false,
     props: {
+        id: {
+            default: '',
+            type: String
+        },
         disabled: {
             default: false,
             type: Boolean
@@ -23,6 +31,10 @@ export default {
         url: {
             default: '',
             type: String
+        },
+        isHA: {
+            default: false,
+            type: Boolean
         }
     }
 }

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -35,8 +35,9 @@
                     <div class="space-x-2 flex align-center">
                         <InstanceEditorLink
                             :url="instance.url"
-                            :editorDisabled="instance.settings.disableEditor"
+                            :editorDisabled="instance.settings.disableEditor || isHA"
                             :disabled="!editorAvailable"
+                            :disabled-reason="disabledReason"
                         />
                         <DropdownMenu v-if="hasPermission('project:change-status')" buttonClass="ff-btn ff-btn--primary" :options="actionsDropdownOptions">Actions</DropdownMenu>
                     </div>
@@ -162,6 +163,16 @@ export default {
             }
 
             return result
+        },
+        disabledReason () {
+            if (this.isHA) {
+                return 'Cannot access the editor on a HA Instance'
+            } else if (this.instance.settings.disableEditor) {
+                return 'Access to the editor has been disabled in Settings > Editor'
+            } else if (!this.instanceRunning) {
+                return 'Instance is not running'
+            }
+            return null
         }
     },
     watch: {

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -22,7 +22,9 @@
                             {{ instance.name }}
                         </div>
                         <InstanceStatusBadge :status="instance.meta?.state" :optimisticStateChange="instance.optimisticStateChange" :pendingStateChange="instance.pendingStateChange" />
-                        <StatusBadge v-if="instance.ha?.replicas !== undefined" class="ml-1" status="high-availability" />
+                        <router-link v-if="instance.ha?.replicas !== undefined" :to="{name: 'InstanceSettingsHA', params: { id: instance.id }}" @click.stop>
+                            <StatusBadge class="ml-2 text-gray-400 hover:text-blue-600" status="high-availability" />
+                        </router-link>
                         <div class="w-full text-sm mt-1">
                             Application:
                             <router-link :to="{name: 'Application', params: {id: instance.application.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ instance.application.name }}</router-link>

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -22,6 +22,7 @@
                             {{ instance.name }}
                         </div>
                         <InstanceStatusBadge :status="instance.meta?.state" :optimisticStateChange="instance.optimisticStateChange" :pendingStateChange="instance.pendingStateChange" />
+                        <StatusBadge v-if="instance.ha?.replicas !== undefined" class="ml-1" status="high-availability" />
                         <div class="w-full text-sm mt-1">
                             Application:
                             <router-link :to="{name: 'Application', params: {id: instance.application.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ instance.application.name }}</router-link>
@@ -74,6 +75,7 @@ import InstanceStatusHeader from '../../components/InstanceStatusHeader.vue'
 import InstanceStatusPolling from '../../components/InstanceStatusPolling.vue'
 import NavItem from '../../components/NavItem.vue'
 import SideNavigationTeamOptions from '../../components/SideNavigationTeamOptions.vue'
+import StatusBadge from '../../components/StatusBadge.vue'
 import SubscriptionExpiredBanner from '../../components/banners/SubscriptionExpired.vue'
 import TeamTrialBanner from '../../components/banners/TeamTrial.vue'
 
@@ -98,6 +100,7 @@ export default {
         InstanceStatusBadge,
         InstanceStatusHeader,
         SideNavigationTeamOptions,
+        StatusBadge,
         SubscriptionExpiredBanner,
         TeamTrialBanner,
         InstanceEditorLink
@@ -130,8 +133,11 @@ export default {
         instanceRunning () {
             return this.instance?.meta?.state === 'running'
         },
+        isHA () {
+            return this.instance?.ha.replicas !== undefined
+        },
         editorAvailable () {
-            return this.instanceRunning
+            return !this.isHA && this.instanceRunning
         },
         actionsDropdownOptions () {
             const flowActionsDisabled = !(this.instance.meta && this.instance.meta.state !== 'suspended')

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -136,7 +136,7 @@ export default {
             return this.instance?.meta?.state === 'running'
         },
         isHA () {
-            return this.instance?.ha.replicas !== undefined
+            return this.instance?.ha?.replicas !== undefined
         },
         editorAvailable () {
             return !this.isHA && this.instanceRunning

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -54,14 +54,13 @@
                                     flows never deployed
                                 </span>
                             </div>
-                            <div class="flex justify-end">
-                                <InstanceEditorLink
-                                    :url="instance.url"
-                                    :editorDisabled="instance.settings.disableEditor"
-                                    :disabled="instance.meta?.state !== 'running'"
-                                />
-                            </div>
-
+                            <InstanceEditorLinkCell
+                                :id="instance.id"
+                                :url="instance.url"
+                                :editorDisabled="instance.settings.disableEditor"
+                                :disabled="instance.meta?.state !== 'running'"
+                                :isHA="instance.ha?.replicas !== undefined"
+                            />
                             <InstanceStatusPolling :instance="instance" @instance-updated="instanceUpdated" />
                         </li>
                     </ul>
@@ -125,14 +124,13 @@ import InstanceStatusPolling from '../../components/InstanceStatusPolling.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import ProjectIcon from '../../components/icons/Projects.js'
 import permissionsMixin from '../../mixins/Permissions.js'
-import InstanceEditorLink from '../instance/components/InstanceEditorLink.vue'
 import InstanceStatusBadge from '../instance/components/InstanceStatusBadge.vue'
-
+import InstanceEditorLinkCell from '../instance/components/cells/InstanceEditorLink.vue'
 export default {
     name: 'TeamApplications',
     components: {
         EmptyState,
-        InstanceEditorLink,
+        InstanceEditorLinkCell,
         InstanceStatusBadge,
         InstanceStatusPolling,
         PlusSmIcon,


### PR DESCRIPTION
## Description

Second attempt as UI elements for introducing HA mode.

### Enabling HA mode

HA mode can be enabled/disabled on an instance. This is done via a new Settings/HA page:

<img width="1160" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/14d42108-5d88-4782-af40-a030a76ba518">

(Link to docs is currently empty as the docs need writing)

Clicking enable shows confirmation dialog:

<img width="605" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/3105eaeb-0572-4cf3-a356-b389de44ec9f">

When enabled, an HA badge is shown in the header. The badge, when clicked on, takes the user to the HA Settings page for the instance.

<img width="876" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/2e55433e-ec2f-4d99-bb99-667955cd2e7c">


This same badge is used consistently through-out:

#### Team Applications

<img width="1087" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/d13d79eb-88f8-48e2-afff-31dd34e5b247">

### Application Instances

<img width="1148" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/6daa7c46-eb5d-4617-908b-78ac8c71853d">

