### PR TITLE
Fix link to latest release

### DIFF
--- a/docs/install/docker/README.md
+++ b/docs/install/docker/README.md
@@ -217,7 +217,7 @@ fileStore:
    ```bash
    docker-compose -p flowforge down
    ```
-- [Download](https://github.com/flowforge/docker-compose/releases/latest/download/) the latest tar
+- Download the latest Source code tar.gz [here](https://github.com/flowforge/docker-compose/releases/latest/)
 - Uncompress the tar file to a new directory
 - Pull the latest version of the containers from Docker hub
      - `docker pull flowforge/forge-docker`


### PR DESCRIPTION
Direct link to source.tar.gz doesn't appear to work any more, so pointing to the page and making the instructions more explicit

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [x] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

