### PR TITLE
Fix test for kubernetes driver

### DIFF
--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -31,7 +31,7 @@ db:
 
 driver:
   ## The type of backend driver to use
-  ##  Can be: localfs/docker/stub/k8s
+  ##  Can be: localfs/docker/stub/kubernetes
   type: localfs
 
   options:

--- a/forge/ee/lib/ha/index.js
+++ b/forge/ee/lib/ha/index.js
@@ -1,7 +1,7 @@
 const { KEY_HA } = require('../../../db/models/ProjectSettings')
 
 module.exports.init = function (app) {
-    if (app.config.driver.type === 'k8s' || app.config.driver.type === 'stub') {
+    if (app.config.driver.type === 'kubernetes' || app.config.driver.type === 'stub') {
         // Register ha flag as a private flag - no requirement to expose it in public settings
         app.config.features.register('ha', true)
 


### PR DESCRIPTION
The test was looking for `k8s` when it should have been `kubernetes`

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

