### PR TITLE
Add shared subscriptions to broker ACL for project nodes

### DIFF
--- a/forge/ee/lib/projectComms/index.js
+++ b/forge/ee/lib/projectComms/index.js
@@ -25,17 +25,11 @@ module.exports.init = function (app) {
         )
         // Receive link-call response messages sent to this project
         // - ff/v1/<team>/p/<project>/res/+/#
-        app.comms.aclManager.addACL(
-            'project',
-            'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
-        )
-        // Receive link-call response messages sent to this replica of a project
         // - ff/v1/<team>/p/<project>/res-<id>/+/#
         app.comms.aclManager.addACL(
             'project',
             'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res-[^/]+\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res(?:-[^/]+)?\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
         )
         // Send message to other project
         // - ff/v1/<team>/p/+/in/+/#
@@ -49,7 +43,7 @@ module.exports.init = function (app) {
         app.comms.aclManager.addACL(
             'project',
             'pub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/[^/]+\/res\/[^/]+($|\/.*$)/, verify: 'checkTeamId' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/[^/]+\/res(?:-[^/]+)?\/[^/]+($|\/.*$)/, verify: 'checkTeamId' }
         )
         // Send broadcast messages
         // - ff/v1/<team>/p/<project>/out/+/#

--- a/forge/ee/lib/projectComms/index.js
+++ b/forge/ee/lib/projectComms/index.js
@@ -6,20 +6,22 @@ module.exports.init = function (app) {
         // Register the broker comms ACLs for inter-project communication
 
         // Project ACL
+        // Any project subscription topic needs to support both the plain subscription
+        // and its shared-subscription equivalent for HA mode
 
         // Receive broadcasts from other projects in the team
         // - ff/v1/<team>/p/+/out/+/#
         app.comms.aclManager.addACL(
             'project',
             'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/[^/]+\/out\/[^/]+($|\/.*$)/, verify: 'checkTeamId' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/[^/]+\/out\/[^/]+($|\/.*$)/, verify: 'checkTeamId', shared: true }
         )
         // Receive messages sent to this project
         // - ff/v1/<team>/p/<project>/in/+/#
         app.comms.aclManager.addACL(
             'project',
             'sub',
-            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/in\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds', shared: true }
         )
         // Receive link-call response messages sent to this project
         // - ff/v1/<team>/p/<project>/res/+/#
@@ -27,6 +29,13 @@ module.exports.init = function (app) {
             'project',
             'sub',
             { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
+        )
+        // Receive link-call response messages sent to this replica of a project
+        // - ff/v1/<team>/p/<project>/res-<id>/+/#
+        app.comms.aclManager.addACL(
+            'project',
+            'sub',
+            { topic: /^ff\/v1\/([^/]+)\/p\/([^/]+)\/res-[^/]+\/[^/]+($|\/.*$)$/, verify: 'checkTeamAndObjectIds' }
         )
         // Send message to other project
         // - ff/v1/<team>/p/+/in/+/#

--- a/test/unit/forge/comms/authRoutes_spec.js
+++ b/test/unit/forge/comms/authRoutes_spec.js
@@ -382,6 +382,12 @@ describe('Broker Auth API', async function () {
                 after(async function () {
                     await app.close()
                 })
+                it('prevents project using incorrect shared subscription group', async function () {
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: '$share/wrong-project/ff/v1/abc/p/another-project/out/foo/bar'
+                    })
+                })
                 // Inter-project comms
                 it('allows project to publish to own broadcast topic', async function () {
                     await denyWrite({
@@ -425,6 +431,10 @@ describe('Broker Auth API', async function () {
                     await allowRead({
                         username: 'project:abc:xyz',
                         topic: 'ff/v1/abc/p/another-project/out/foo/bar'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: '$share/xyz/ff/v1/abc/p/another-project/out/foo/bar'
                     })
                 })
                 it('prevents project from publishing to other broadcast topic', async function () {
@@ -470,6 +480,10 @@ describe('Broker Auth API', async function () {
                         username: 'project:abc:xyz',
                         topic: 'ff/v1/abc/p/xyz/in/#'
                     })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: '$share/xyz/ff/v1/abc/p/xyz/in/foo/bar'
+                    })
                 })
                 it('prevents project from subscribing to another projects inbox', async function () {
                     await denyRead({
@@ -491,6 +505,10 @@ describe('Broker Auth API', async function () {
                     await denyRead({
                         username: 'project:abc:xyz',
                         topic: 'ff/v1/abc/p/another-project/in/#'
+                    })
+                    await denyRead({
+                        username: 'project:abc:xyz',
+                        topic: '$share/xyz/ff/v1/abc/p/another-project/in/#'
                     })
                 })
                 it('allows project to publish to another projects inbox', async function () {
@@ -535,6 +553,10 @@ describe('Broker Auth API', async function () {
                     await allowRead({
                         username: 'project:abc:xyz',
                         topic: 'ff/v1/abc/p/xyz/res/#'
+                    })
+                    await allowRead({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/xyz/res-random/#'
                     })
                 })
                 it('allows project to publish to another projects response topic', async function () {

--- a/test/unit/forge/comms/authRoutes_spec.js
+++ b/test/unit/forge/comms/authRoutes_spec.js
@@ -580,6 +580,10 @@ describe('Broker Auth API', async function () {
                         username: 'project:abc:xyz',
                         topic: 'ff/v1/abc/p/another-project/res/foo/bar'
                     })
+                    await allowWrite({
+                        username: 'project:abc:xyz',
+                        topic: 'ff/v1/abc/p/another-project/res-random/foo/bar'
+                    })
                 })
             })
         })


### PR DESCRIPTION
## Description

Part of #2156 

See also https://github.com/flowforge/flowforge-nr-project-nodes/issues/28


Adds support for using shared subscription topics on certain project-node topics.

Given we need to support both shared and non-shared versions of the topics, rather than copy/paste the rules, this adds a flag to indicate a topic can be handled as either plain or shared.

The share group id is required to the project/instance id.

It also adds a new rule for the response topic, to provide the ability for individual replicas to have a randomly generated component of the response topic.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
