### PR TITLE
Fix Build Error: byPipeline takes an ID not an object

### DIFF
--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -654,12 +654,7 @@ describe('Pipelines API', function () {
 
                 should(foundPipeline).equal(null)
 
-                const foundPipelineStages = await app.db.models.PipelineStage.byPipeline({
-                    where: {
-                        id: pipeline.id
-                    }
-                })
-
+                const foundPipelineStages = await app.db.models.PipelineStage.byPipeline(pipeline.id)
                 foundPipelineStages.length.should.equal(0)
             })
         })


### PR DESCRIPTION
## Description

Seems to only fail with PostGres driver not with SQLLite 

## Related Issue(s)

Fixes https://github.com/flowforge/flowforge/issues/2223

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

