### PR TITLE
Allow instance creation after first failure

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -28,6 +28,7 @@
                 v-model="input.applicationId"
                 :options="applications"
                 :error="errors.applicationId || submitErrors?.applicationId"
+                :disabled="applicationFieldsLocked"
                 data-form="application-id"
             >
                 <template #default>
@@ -298,6 +299,14 @@ export default {
     data () {
         const instance = this.instance || this.sourceInstance
 
+        // Dropdown is locked, default to first if only one option
+        let applicationName = ''
+        let applicationId = ''
+        if (this.applicationFieldsLocked && this.applications.length === 1) {
+            applicationName = this.applications[0].label
+            applicationId = this.applications[0].value
+        }
+
         return {
             stacks: [],
             templates: [],
@@ -306,8 +315,8 @@ export default {
             input: {
                 billingConfirmation: false,
 
-                applicationName: '',
-                applicationId: '',
+                applicationName,
+                applicationId,
 
                 // Only read name from existing project, never source
                 name: this.instance?.name || NameGenerator(),

--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -26,8 +26,10 @@
             <InstanceForm
                 v-else
                 :instance="projectDetails"
+                :applications="applications"
+                :applicationSelection="applicationCreated"
                 :team="team"
-                :applicationFieldsLocked="!!application?.id"
+                :applicationFieldsLocked="applicationCreated"
                 :applicationFieldsVisible="true"
                 :billing-enabled="!!features.billing"
                 :submit-errors="errors"
@@ -73,7 +75,23 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['features', 'team'])
+        ...mapState('account', ['features', 'team']),
+
+        applicationCreated () {
+            return !!this.application?.id
+        },
+
+        // Used when application has already been created to select it from dropdown
+        applications () {
+            if (!this.applicationCreated) {
+                return []
+            }
+
+            return [{
+                label: this.application.name,
+                value: this.application.id
+            }]
+        }
     },
     async mounted () {
         this.mounted = true
@@ -86,7 +104,7 @@ export default {
             const applicationFields = { name: applicationName }
 
             try {
-                if (!this.application?.id) {
+                if (!this.applicationCreated) {
                     this.application = await this.createApplication(applicationFields)
                 }
             } catch (err) {


### PR DESCRIPTION
## Description

Regression likely introduces in https://github.com/flowforge/flowforge/pull/2054 or https://github.com/flowforge/flowforge/pull/1966.

When creating an instance fails, it should still be possible to submit this form, and skip the create application step behind the scenes. The submit button, as shown in #2221 was rendering as disabled.

Draft as test coverage is pending.

## Related Issue(s)

Fixes https://github.com/flowforge/flowforge/issues/2221

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

