### PR TITLE
Support project listing for a device being accessed over a tunnel

### DIFF
--- a/forge/routes/auth/permissions.js
+++ b/forge/routes/auth/permissions.js
@@ -5,7 +5,9 @@ const { Roles } = require('../../lib/roles.js')
 // This will allow us to add scopes to existing tokens without having to update
 // them (as that requires reprovisioning of devices and restaging of projects)
 const IMPLICIT_TOKEN_SCOPES = {
-    device: [],
+    device: [
+        'team:projects:list' // permit a device being edited via a tunnel in developer mode to list projects
+    ],
     project: [
         'user:read',
         'project:flows:view',


### PR DESCRIPTION
closes #2228

## Description

* Update pre-handler in `packages/flowforge/forge/routes/api/team.js` to allow a device with token to pass to the routes
* Update `IMPLICIT_TOKEN_SCOPES.devices` in `packages/flowforge/forge/routes/auth/permissions.js` to permit the permission `'team:projects:list'`
* Add context to the `@depreciated` comment on route `/api/v1/teams/:teamId/projects` 
* Adds tests:
    Team API
      Get list of a teams projects
        ✔ Device can get a list of team projects
        ✔ Device can not get a list of team projects without a valid token
        ✔ Device can not get a list of team projects for a different team

## Related Issue(s)

#2228 

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

