### PR TITLE
Add copy to clipboard for credentials dialogs

### DIFF
--- a/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
@@ -11,6 +11,7 @@
             </form>
         </template>
         <template v-slot:actions>
+            <ff-button v-if="!!clipboardSupported" kind="secondary" @click="copyToClipboard()">Copy to Clipboard</ff-button>
             <ff-button kind="secondary" @click="downloadCredentials()"><template v-slot:icon-left><DocumentDownloadIcon /></template>Download device.yml</ff-button>
             <ff-button class="ml-4" @click="close()">Done</ff-button>
         </template>
@@ -20,8 +21,9 @@
 <script>
 
 import { mapState } from 'vuex'
-
 import { DocumentDownloadIcon } from '@heroicons/vue/outline'
+import Alerts from '../../../../services/alerts.js'
+
 export default {
     name: 'ProvisioningCredentialsDialog',
     components: {
@@ -30,8 +32,12 @@ export default {
     props: ['team'],
     data () {
         return {
-            token: null
+            token: null,
+            clipboardSupported: false
         }
+    },
+    mounted () {
+        this.clipboardSupported = !!navigator.clipboard
     },
     methods: {
         downloadCredentials () {
@@ -46,6 +52,19 @@ export default {
         close () {
             this.$refs.dialog.close()
             this.token = undefined
+        },
+        copyToClipboard () {
+            navigator.permissions.query({ name: 'clipboard-write' }).then((result) => {
+                if (result.state === 'granted' || result.state === 'prompt') {
+                    /* write to the clipboard now */
+                    navigator.clipboard.writeText(this.credentials)
+                    Alerts.emit('Copied to Clipboard.', 'confirmation')
+                }
+            }).catch((err) => {
+                // eslint-disable-next-line no-console
+                console.log('Clipboard write permission denied: ', err)
+                Alerts.emit('Clipboard write permission denied.', 'warning')
+            })
         }
     },
     computed: {


### PR DESCRIPTION
closes #2199

## Description

Adds a copy to clipboard button to the device credentials and provisioning credentials dialog.

This was identified during the dev demo of Device UI work as a good UX feature as it complements the UI for setting up a device via its new UI

NOTE: Since this uses `navigator.clipboard` the buttons will only be shown in [Secure Contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)

Non Secure Context:
![image](https://github.com/flowforge/flowforge/assets/44235289/f0fc1b66-8aec-47b3-8404-68530d5739ff)

Secure Context:
![image](https://github.com/flowforge/flowforge/assets/44235289/c61c5e81-100e-41d1-adb4-f8c12c830299)


## Related Issue(s)

#2199

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

