### PR TITLE
Show error if trying to start the editor on device

### DIFF
--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -60,7 +60,10 @@ module.exports = async function (app) {
             let err = null
             try {
                 // * Enable Device Editor (Step 4) - (forge) Enable Editor Request. This call resolves after steps 5 ~ 10
-                await app.comms.devices.enableEditor(teamId, request.device.hashid, accessToken)
+                const cmdResponse = await app.comms.devices.enableEditor(teamId, request.device.hashid, accessToken)
+                if (cmdResponse.error) {
+                    throw new Error('No Node-RED running on Device')
+                }
             } catch (error) {
                 // ensure any attempt to enable the editor is cleaned up if an error occurs
                 tunnelManager.closeTunnel(deviceId)

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -129,7 +129,7 @@
                         <div class="space-x-2 flex align-center">
                             <ff-button
                                 v-if="editorEnabled"
-                                :disabled="closingTunnel || !editorEnabled"
+                                :disabled="!editorCanBeEnabled || closingTunnel || !editorEnabled"
                                 kind="primary"
                                 size="small"
                                 @click="closeTunnel"
@@ -139,7 +139,7 @@
                             </ff-button>
                             <ff-button
                                 v-if="!editorEnabled"
-                                :disabled="openingTunnel || editorEnabled"
+                                :disabled="!editorCanBeEnabled || openingTunnel || editorEnabled"
                                 kind="danger"
                                 size="small"
                                 @click="openTunnel"
@@ -222,6 +222,9 @@ export default {
         },
         editorEnabled: function () {
             return !!this.device?.editor?.enabled
+        },
+        editorCanBeEnabled: function () {
+            return this.developerMode && this.device.status === 'running'
         }
     },
     data () {

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -272,16 +272,20 @@ export default {
             this.busy = false
         },
         async openTunnel () {
-            this.openingTunnel = true
-            try {
-                // * Enable Device Editor (Step 1) - (browser->frontendApi) User clicks button to "Enable Editor"
-                const result = await deviceApi.enableEditorTunnel(this.device.id)
-                this.updateTunnelStatus(result)
-                setTimeout(() => {
-                    this.$emit('device-updated')
-                }, 500)
-            } finally {
-                this.openingTunnel = false
+            if (this.device.status === 'running') {
+                this.openingTunnel = true
+                try {
+                    // * Enable Device Editor (Step 1) - (browser->frontendApi) User clicks button to "Enable Editor"
+                    const result = await deviceApi.enableEditorTunnel(this.device.id)
+                    this.updateTunnelStatus(result)
+                    setTimeout(() => {
+                        this.$emit('device-updated')
+                    }, 500)
+                } finally {
+                    this.openingTunnel = false
+                }
+            } else {
+                alerts.emit('The device must be in "running" state to access the editor', 'warning', 7500)
             }
         },
         async closeTunnel () {


### PR DESCRIPTION
part of #2233

## Description

<!-- Describe your changes in detail -->
Should show and error to the user when trying to start the device editor if editor is not running.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#2233 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

