### PR TITLE
docs: Fix broken anchor in docs

### DIFF
--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -66,7 +66,7 @@ To connect a device to the platform, it needs a set of credentials.
 
 There are two types of credentials to choose from:
 
-* **Device Credentials**: for connecting a single device to the platform
+* **- Credentials**: for connecting a single device to the platform
 * **Provisioning Credentials**: for setting up one or more devices to automatically register themselves on the platform
 
 ### Generating "Device Credentials" 
@@ -112,7 +112,7 @@ file present in its working directory. There are two ways to do this:
 [Working Directory](#working-directory).
 2. Download the credentials file to the device using its built in Web UI.
 NOTE: The Device Agent must be running and the command line flag for the Web UI must be enabled.
-See [Command Line Options](#Device-Agent-Command-Line-Options) for more information.
+See [Command Line Options](#device-agent-command-line-options) for more information.
 
 ### Copy method
 

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -66,7 +66,7 @@ To connect a device to the platform, it needs a set of credentials.
 
 There are two types of credentials to choose from:
 
-* **- Credentials**: for connecting a single device to the platform
+* **Device Credentials**: for connecting a single device to the platform
 * **Provisioning Credentials**: for setting up one or more devices to automatically register themselves on the platform
 
 ### Generating "Device Credentials" 


### PR DESCRIPTION
Fixes internal links that wasn't working

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [X] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

