### PR TITLE
Pipelines: Server side deployment state tracking

### DIFF
--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -9,6 +9,8 @@ const { KEY_SETTINGS } = require('../models/ProjectSettings')
  */
 const inflightProjectState = { }
 
+const inflightDeploys = new Set()
+
 module.exports = {
     /**
      * Get the in-flight state of a project
@@ -29,6 +31,25 @@ module.exports = {
     setInflightState: function (app, project, state) {
         inflightProjectState[project.id] = state
     },
+
+    /**
+     * Check whether an instance is currently flagged as deploying
+     * @param {*} app
+     * @param {*} instance
+     */
+    isDeploying: function (app, instance) {
+        return inflightDeploys.has(instance.id)
+    },
+
+    /**
+     * Mark an instance as currently being deployed
+     * @param {*} app
+     * @param {*} instance
+     */
+    setInDeploy: function (app, instance) {
+        inflightDeploys.add(instance.id)
+    },
+
     /**
      * Set the in-flight state of a project
      * @param {*} app
@@ -36,7 +57,9 @@ module.exports = {
      */
     clearInflightState: function (app, project) {
         delete inflightProjectState[project.id]
+        inflightDeploys.delete(project.id)
     },
+
     /**
      * Get the settings object that should be passed to nr-launcher so it can
      * start Node-RED with the proper project configuration.

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -250,6 +250,7 @@ module.exports = {
                 async liveState () {
                     const storageFlow = await M.StorageFlow.byProject(this.id)
                     const inflightState = Controllers.Project.getInflightState(this)
+                    const isDeploying = Controllers.Project.isDeploying(this)
 
                     const result = {
                         flowLastUpdatedAt: storageFlow?.updatedAt // prop not set if storageFlow not found
@@ -266,6 +267,8 @@ module.exports = {
                     } else {
                         result.meta = await app.containers.details(this) || { state: 'unknown' }
                     }
+
+                    result.meta.isDeploying = isDeploying
 
                     return result
                 }

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -382,6 +382,8 @@ module.exports = async function (app) {
             }
 
             app.db.controllers.Project.setInflightState(request.project, 'importing')
+            app.db.controllers.Project.setInDeploy(request.project)
+
             await app.auditLog.Project.project.copied(request.session.User.id, null, sourceProject, request.project)
             await app.auditLog.Project.project.imported(request.session.User.id, null, request.project, sourceProject)
 

--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -104,6 +104,9 @@ const getPipelines = async (applicationId) => {
             // In the backend, multiple instances per pipeline are supported
             // @see getPipelineStage in frontend Pipeline API
             stage.instance = stage.instances?.[0]
+            if (!stage.instances) {
+                stage.instances = []
+            }
 
             return stage
         })

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -21,17 +21,15 @@
             </div>
         </div>
         <div v-if="pipeline.stages.length" class="ff-pipeline-stages">
-            <template v-for="(stage, $index) in pipeline.stages" :key="stage.id">
+            <template v-for="(stage, $index) in stagesWithStates" :key="stage.id">
                 <PipelineStage
                     :application="application"
                     :pipeline="pipeline"
                     :stage="stage"
-                    :status="stageState(stage)"
                     :playEnabled="$index < pipeline.stages.length - 1"
                     :editEnabled="true"
-                    :deploying="nextStageStarting($index)"
-                    @stage-started="stageStarted($index)"
-                    @stage-complete="stageComplete($index)"
+                    @stage-deploy-starting="stageDeployStarting(stage)"
+                    @stage-deploy-started="stageDeployStarted(stage)"
                     @stage-deleted="stageDeleted($index)"
                 />
                 <Transition name="fade">
@@ -39,8 +37,7 @@
                         v-if="$index <= pipeline.stages.length - 1"
                         class="ff-icon mt-4 flex-shrink-0"
                         :class="{
-                            'animate-deploying':
-                                deploying === $index || nextStageStarting($index),
+                            'animate-deploying': stage.isDeploying
                         }"
                     />
                 </Transition>
@@ -81,12 +78,12 @@ export default {
             required: true,
             type: Object
         },
-        statusMap: {
+        instanceStatusMap: {
             required: true,
             type: Map
         }
     },
-    emits: ['deploy-started', 'deploy-complete', 'pipeline-deleted', 'stage-deleted'],
+    emits: ['pipeline-deleted', 'stage-deleted', 'deploy-starting', 'deploy-started', 'stage-deploy-starting', 'stage-deploy-started'],
     data () {
         const pipeline = this.pipeline
         return {
@@ -103,6 +100,18 @@ export default {
     computed: {
         saveRowEnabled () {
             return this.scopedPipeline.name?.length > 0
+        },
+        stagesWithStates () {
+            return this.pipeline.stages.map((stage) => {
+                // For now, each stage contains only one instance, so just relay that instances state
+                const stageInstance = this.instanceStatusMap.get(stage.instance.id)
+                stage.state = stageInstance.state
+
+                // If any instances inside the stage are deploying, this stage is deploying
+                stage.isDeploying = !!stageInstance?.isDeploying
+
+                return stage
+            })
         }
     },
     methods: {
@@ -138,31 +147,16 @@ export default {
             this.editing.name = false
             Alerts.emit('Pipeline successfully updated.', 'confirmation')
         },
-        stageStarted (stageIndex) {
-            this.deploying = stageIndex
-            this.$emit('deploy-started')
+        stageDeployStarting (stage) {
+            this.$emit('stage-deploy-starting', stage)
+            console.log('Starting deploy', stage)
         },
-        stageComplete (stageIndex) {
-            this.deploying = null
-            this.$emit('deploy-complete')
+        stageDeployStarted (stage) {
+            this.$emit('stage-deploy-started', stage)
+            console.log('Started deploy', stage)
         },
         stageDeleted (stageIndex) {
             this.$emit('stage-deleted', stageIndex)
-        },
-        /**
-         *
-         * @param {*} index - the index of a stage in the pipeline, returns tru if the _next_ stage is starting
-         */
-        nextStageStarting (index) {
-            if (this.pipeline.stages[index + 1]) {
-                const state = this.stageState(this.pipeline.stages[index + 1])
-                return state === 'importing' || state === 'starting'
-            } else {
-                return false
-            }
-        },
-        stageState (stage) {
-            return this.statusMap.get(stage.instance.id)?.state
         },
         deletePipeline () {
             const msg = {

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -105,6 +105,13 @@ export default {
             return this.pipeline.stages.map((stage) => {
                 // For now, each stage contains only one instance, so read state from that instance
                 const stageInstance = this.instanceStatusMap.get(stage.instance?.id)
+
+                // Instance statuses might not have finished loading yet
+                if (!stageInstance) {
+                    return stage
+                }
+
+                // Relay stage instances state to the stage
                 stage.state = stageInstance.state
 
                 // If any instances inside the stage are deploying, this stage is deploying

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -37,7 +37,7 @@
                         v-if="$index <= pipeline.stages.length - 1"
                         class="ff-icon mt-4 flex-shrink-0"
                         :class="{
-                            'animate-deploying': stage.isDeploying
+                            'animate-deploying': nextStageDeploying($index),
                         }"
                     />
                 </Transition>
@@ -148,15 +148,21 @@ export default {
             Alerts.emit('Pipeline successfully updated.', 'confirmation')
         },
         stageDeployStarting (stage) {
-            this.$emit('stage-deploy-starting', stage)
-            console.log('Starting deploy', stage)
+            const nextStage = this.pipeline.stages.find((s) => s.id === stage.NextStageId)
+            this.$emit('stage-deploy-starting', stage, nextStage)
         },
         stageDeployStarted (stage) {
             this.$emit('stage-deploy-started', stage)
-            console.log('Started deploy', stage)
         },
         stageDeleted (stageIndex) {
             this.$emit('stage-deleted', stageIndex)
+        },
+        nextStageDeploying (index) {
+            if (this.pipeline.stages[index + 1]) {
+                return this.pipeline.stages[index + 1].isDeploying
+            }
+
+            return false
         },
         deletePipeline () {
             const msg = {

--- a/frontend/src/components/pipelines/PipelineRow.vue
+++ b/frontend/src/components/pipelines/PipelineRow.vue
@@ -103,8 +103,8 @@ export default {
         },
         stagesWithStates () {
             return this.pipeline.stages.map((stage) => {
-                // For now, each stage contains only one instance, so just relay that instances state
-                const stageInstance = this.instanceStatusMap.get(stage.instance.id)
+                // For now, each stage contains only one instance, so read state from that instance
+                const stageInstance = this.instanceStatusMap.get(stage.instance?.id)
                 stage.state = stageInstance.state
 
                 // If any instances inside the stage are deploying, this stage is deploying

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -104,7 +104,6 @@ export default {
             return elapsedTime(this.stage.instance.updatedAt, new Date())
         },
         deploying () {
-            console.log('isStage deploying', this.stage)
             return this.stage.isDeploying
         }
     },

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -24,7 +24,11 @@
         <div v-if="stage.instance" class="py-3">
             <div class="ff-pipeline-stage-row">
                 <label>Instance:</label>
-                <span>{{ stage.instance.name }}</span>
+                <span>
+                    <router-link :to="{name: 'Instance', params: { id: stage.instance.id }}">
+                        {{ stage.instance.name }}
+                    </router-link>
+                </span>
             </div>
             <div class="ff-pipeline-stage-row">
                 <label>URL:</label>
@@ -40,7 +44,7 @@
             </div>
             <div class="ff-pipeline-stage-row">
                 <label>Status:</label>
-                <InstanceStatusBadge :status="status" />
+                <InstanceStatusBadge :status="stage.state" />
             </div>
         </div>
         <div v-else class="flex justify-center py-6">No Instances Bound</div>
@@ -85,14 +89,6 @@ export default {
             default: null,
             type: Object
         },
-        deploying: {
-            defaut: false,
-            type: Boolean
-        },
-        status: {
-            default: null,
-            type: String
-        },
         playEnabled: {
             default: false,
             type: Boolean
@@ -102,10 +98,14 @@ export default {
             type: Boolean
         }
     },
-    emits: ['stage-started', 'stage-complete', 'stage-deleted'],
+    emits: ['stage-deleted', 'stage-deploy-starting', 'stage-deploy-started'],
     computed: {
         lastDeployed: function () {
             return elapsedTime(this.stage.instance.updatedAt, new Date())
+        },
+        deploying () {
+            console.log('isStage deploying', this.stage)
+            return this.stage.isDeploying
         }
     },
     methods: {
@@ -128,7 +128,7 @@ export default {
             }
 
             Dialog.show(msg, async () => {
-                this.$emit('stage-started')
+                this.$emit('stage-deploy-starting')
 
                 // settings for when we deploy to a new stage
                 this.parts = {
@@ -149,7 +149,7 @@ export default {
                     sourceProject: source
                 })
 
-                this.$emit('stage-complete')
+                this.$emit('stage-deploy-started')
                 Alerts.emit(
                     `Deployment from "${this.stage.name}" to "${target.name}" has started.`,
                     'confirmation'

--- a/frontend/src/pages/application/Pipelines.vue
+++ b/frontend/src/pages/application/Pipelines.vue
@@ -139,6 +139,10 @@ export default {
     },
     methods: {
         stageDeployStarting (stage, nextStage) {
+            if (!nextStage.instance?.id) {
+                return console.warn('Deployment starting to stage without an instance.')
+            }
+
             // Optimistic flagging of deployment in progress for the single instance inside the target stage
             this.instanceStatusMap.get(nextStage.instance.id).isDeploying = true
         },


### PR DESCRIPTION
## Description

Split into two parts:

 - Refactor the existing state tracking to work based on stage deploy state (deduced from instance state)
 - Move storage of instance deploy state server side

Key advantages:
 - State persists across page reloads
 - Deploy complete alert works regardless of what starting state the instance was in

https://github.com/flowforge/flowforge/assets/507155/5a8ac2bc-0311-467e-9674-f1ac0dab698b

## Related Issue(s)

N/a

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass - Not really clear how to test this. Page already has E2E coverage.
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

