### PR TITLE
Remove forge/* files from promise/catch-or-return rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -166,8 +166,7 @@
                 "frontend/src/pages/instance/Settings/ChangeInstanceType.vue",
                 "frontend/src/pages/instance/Settings/Danger.vue",
                 "frontend/src/pages/team/create.vue",
-                "frontend/src/pages/team/Overview.vue",
-                "frontend/src/store/account.js"
+                "frontend/src/pages/team/Overview.vue"
             ]
         },
         {

--- a/.eslintrc
+++ b/.eslintrc
@@ -153,9 +153,6 @@
                 "promise/catch-or-return": "off"
             },
             "files": [
-                "forge/comms/index.js",
-                "forge/routes/api/project.js",
-                "forge/routes/api/projectActions.js",
                 "frontend/src/pages/account/Security/ChangePassword.vue",
                 "frontend/src/pages/account/Settings.vue",
                 "frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue",

--- a/forge/comms/index.js
+++ b/forge/comms/index.js
@@ -45,6 +45,9 @@ module.exports = fp(async function (app, _opts, next) {
         app.ready().then(async () => {
             // Once the whole platform is ready, tell the client to connect
             return await client.init()
+        }).catch(err => {
+            app.log.info('[comms] problem starting comms client')
+            throw err
         })
         app.addHook('onClose', async (_) => {
             app.log.info('Comms shutdown')

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -638,6 +638,9 @@ module.exports = async function (app) {
                     await app.auditLog.Project.project.started(request.session.User, null, request.project)
                     app.db.controllers.Project.clearInflightState(request.project)
                     return true
+                }).catch(err => {
+                    app.log.info(`Failed to restart project ${request.project.id}`)
+                    throw err
                 })
             } else {
                 app.db.controllers.Project.clearInflightState(request.project)

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -30,6 +30,9 @@ module.exports = async function (app) {
                     await app.auditLog.Project.project.started(request.session.User, null, request.project)
                     app.db.controllers.Project.clearInflightState(request.project)
                     return true
+                }).catch(err => {
+                    app.log.info(`failed to start project ${request.project.id}`)
+                    throw err
                 })
             } else {
                 app.db.controllers.Project.setInflightState(request.project, 'starting')
@@ -163,6 +166,9 @@ module.exports = async function (app) {
                 await app.auditLog.Project.project.started(request.session.User, null, request.project)
                 app.db.controllers.Project.clearInflightState(request.project)
                 return true
+            }).catch(err => {
+                app.log.info(`failed to restartStack for ${request.project.id}`)
+                throw err
             })
 
             reply.send()


### PR DESCRIPTION
Reducing the lint execptions

Added `.catch(err => {})` to promise chains.

Logging the error location and then re-throwing so as not to change behaviour