### PR TITLE
make Instance and application  names in delete popup  easily selectable

### DIFF
--- a/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
+++ b/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
@@ -14,8 +14,8 @@
                     <p>
                         Are you sure you want to delete this application? Once deleted, there is no going back.
                     </p>
-                    <p>
-                        Enter the application name <code>{{ application?.name }}</code> to continue.
+                    <p class="flex">
+                        Enter the application name <code class="block">{{ application?.name }}</code> to continue.
                     </p>
                 </div>
                 <FormRow id="projectName" v-model="input.projectName" data-form="application-name">Name</FormRow>

--- a/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
+++ b/frontend/src/pages/application/Settings/dialogs/ConfirmApplicationDeleteDialog.vue
@@ -15,7 +15,7 @@
                         Are you sure you want to delete this application? Once deleted, there is no going back.
                     </p>
                     <p class="flex">
-                        Enter the application name <code class="block">{{ application?.name }}</code> to continue.
+                        Enter the application name <code>{{ application?.name }}</code> to continue.
                     </p>
                 </div>
                 <FormRow id="projectName" v-model="input.projectName" data-form="application-name">Name</FormRow>

--- a/frontend/src/pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue
+++ b/frontend/src/pages/instance/Settings/dialogs/ConfirmInstanceDeleteDialog.vue
@@ -14,7 +14,7 @@
                     <p>
                         Are you sure you want to delete this instance and the application that contains it? Once deleted, there is no going back.
                     </p>
-                    <p>
+                    <p class="flex">
                         Enter the instance name <code>{{ instance?.name }}</code> to continue.
                     </p>
                 </div>


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
 
i have used ```flex```  on parent  instead of  using ```block``` because if we use only ```block```  it will select easily instance and application name but code block   will start from new line like below 

[
![flowforge2](https://github.com/flowforge/flowforge/assets/110285294/38eebfd0-fa6e-49b1-9c6a-6b9e47637a3a)
](url)

and popup Ui will  not broke if we use ```flex``` like below

![flowforge3](https://github.com/flowforge/flowforge/assets/110285294/fa0af5ce-b3d8-4263-b1e0-9ff3ae547f1f)





## Related Issue(s)
closes #2267 

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

