### PR TITLE
Add dashboard-only team role

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -9,7 +9,7 @@ const Permissions = {
     'user:team:list': { description: 'List a Users teams', role: Roles.Admin, self: true },
     // Team Scoped Actions
     'team:create': { description: 'Create Team' },
-    'team:read': { description: 'View a Team', role: Roles.Viewer },
+    'team:read': { description: 'View a Team', role: Roles.Dashboard },
     'team:edit': { description: 'Edit Team', role: Roles.Owner },
     'team:delete': { description: 'Delete Team', role: Roles.Owner },
     'team:audit-log': { description: 'Access Team Audit Log', role: Roles.Owner },
@@ -38,6 +38,7 @@ const Permissions = {
     // Project Editor
     'project:flows:view': { description: 'View Project Flows', role: Roles.Viewer },
     'project:flows:edit': { description: 'Edit Project Flows', role: Roles.Member },
+    'project:flows:http': { description: 'Access http endpoints of an Instance', role: Roles.Dashboard },
     // Snapshots
     'project:snapshot:create': { description: 'Create Project Snapshot', role: Roles.Member },
     'project:snapshot:list': { description: 'List Project Snapshots', role: Roles.Viewer },

--- a/forge/lib/roles.js
+++ b/forge/lib/roles.js
@@ -1,5 +1,6 @@
 const Roles = {
     None: 0,
+    Dashboard: 5,
     Viewer: 10,
     Member: 30,
     Owner: 50,
@@ -7,6 +8,7 @@ const Roles = {
 }
 const RoleNames = {
     [Roles.None]: 'none',
+    [Roles.Dashboard]: 'dashboard',
     [Roles.Viewer]: 'viewer',
     [Roles.Member]: 'member',
     [Roles.Owner]: 'owner',
@@ -14,6 +16,7 @@ const RoleNames = {
 }
 
 const TeamRoles = [
+    Roles.Dashboard,
     Roles.Viewer,
     Roles.Member,
     Roles.Owner

--- a/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
+++ b/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
@@ -63,15 +63,19 @@ export default {
             roleOptions: [{
                 label: 'Owner',
                 value: Roles.Owner,
-                description: 'Owners can add and remove members to the team and create projects'
+                description: 'Owners can add and remove members to the team and create applications and instances'
             }, {
                 label: 'Member',
                 value: Roles.Member,
-                description: 'Members can access the team projects'
+                description: 'Members can access the team instances'
             }, {
                 label: 'Viewer',
                 value: Roles.Viewer,
-                description: 'Viewers can access the team projects, but not make any changes'
+                description: 'Viewers can access the team instances, but not make any changes'
+            }, {
+                label: 'Dashboard Only',
+                value: Roles.Dashboard,
+                description: 'Dashboard users can only access the dashboards or HTTP endpoints created by the Node-RED instances when FlowForge authentication is enabled'
             }],
             show (team, user, ownerCount) {
                 this.$refs.dialog.show()

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -110,15 +110,19 @@ export default {
             roleOptions: [{
                 label: 'Owner',
                 value: Roles.Owner,
-                description: 'Owners can add and remove members to the team and create projects'
+                description: 'Owners can add and remove members to the team and create applications and instances'
             }, {
                 label: 'Member',
                 value: Roles.Member,
-                description: 'Members can access the team projects'
+                description: 'Members can access the team instances'
             }, {
                 label: 'Viewer',
                 value: Roles.Viewer,
-                description: 'Viewers can access the team projects, but not make any changes'
+                description: 'Viewers can access the team instances, but not make any changes'
+            }, {
+                label: 'Dashboard Only',
+                value: Roles.Dashboard,
+                description: 'Dashboard users can only access the dashboards or HTTP endpoints created by the Node-RED instances when FlowForge authentication is enabled'
             }],
             show () {
                 this.$refs.dialog.show()

--- a/test/system/110-editor-login.js
+++ b/test/system/110-editor-login.js
@@ -171,6 +171,7 @@ describe('Node-RED Editor Login', function () {
         const result = JSON.parse(response.body)
         result.should.have.property('username', 'alice')
     })
+
     it('editor login via oauth flow - read-only access', async function () {
         const tokens = await doEditorLogin(TestObjects.tokens.bob, 'editor-0.18', false)
         tokens.should.have.property('scope', 'read')
@@ -203,6 +204,7 @@ describe('Node-RED Editor Login', function () {
         const result = JSON.parse(response.body)
         result.should.have.property('username', 'alice')
     })
+
     it('httpAuth login via oauth flow - read-only access', async function () {
         const tokens = await doEditorLogin(TestObjects.tokens.bob, 'httpAuth-0.18', false)
         const response = await app.inject({

--- a/test/system/110-editor-login.js
+++ b/test/system/110-editor-login.js
@@ -1,0 +1,233 @@
+const crypto = require('node:crypto')
+
+const should = require('should') // eslint-disable-line no-unused-vars
+
+const { base64URLEncode } = require('../../forge/db/utils')
+const TestModelFactory = require('../lib/TestModelFactory')
+
+const FF_UTIL = require('flowforge-test-utils')
+
+const { Roles } = FF_UTIL.require('forge/lib/roles')
+
+describe('Node-RED Editor Login', function () {
+    // forge - this will be the running FF application we are testing
+    let app
+
+    const TestObjects = {}
+
+    before(async function () {
+        // Create the FF application with a suitable test configuration
+        app = await FF_UTIL.setupApp({
+            telemetry: { enabled: false },
+            logging: {
+                level: 'warn'
+            },
+            driver: {
+                type: 'stub'
+            },
+            db: {
+                type: 'sqlite',
+                storage: ':memory:'
+            }
+        })
+
+        const factory = new TestModelFactory(app)
+
+        // Setup the database with basic artefacts
+        await app.db.models.PlatformSettings.upsert({ key: 'setup:initialised', value: true })
+        TestObjects.userAlice = await factory.createUser({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', password: 'aaPassword' })
+        TestObjects.ATeam = await factory.createTeam({ name: 'ATeam' })
+        await TestObjects.ATeam.addUser(TestObjects.userAlice, { through: { role: Roles.Owner } })
+
+        TestObjects.userBob = await factory.createUser({ username: 'bob', name: 'Bob', email: 'bob@example.com', password: 'bbPassword' })
+        await TestObjects.ATeam.addUser(TestObjects.userBob, { through: { role: Roles.Viewer } })
+
+        TestObjects.userChris = await factory.createUser({ username: 'chris', name: 'Chris', email: 'chris@example.com', password: 'ccPassword' })
+        await TestObjects.ATeam.addUser(TestObjects.userChris, { through: { role: Roles.Dashboard } })
+
+        TestObjects.Application1 = await factory.createApplication({ name: 'application1' }, TestObjects.ATeam)
+        TestObjects.Application2 = await factory.createApplication({ name: 'application2' }, TestObjects.ATeam)
+
+        TestObjects.ProjectType1 = await factory.createProjectType({ name: 'projectType1' })
+
+        TestObjects.Stack1 = await factory.createStack({ name: 'stack1', properties: { foo: 'bar' } }, TestObjects.ProjectType1)
+        TestObjects.Stack2 = await factory.createStack({ name: 'stack2', properties: { foo: 'bar' } }, TestObjects.ProjectType1)
+
+        TestObjects.Template1 = await factory.createProjectTemplate({ name: 'template1' })
+
+        TestObjects.Instance1 = await factory.createInstance(
+            { name: 'instance1' },
+            TestObjects.Application1,
+            TestObjects.Stack1,
+            TestObjects.template,
+            TestObjects.ProjectType1,
+            { start: false }
+        )
+        TestObjects.tokens = {}
+        TestObjects.tokens.Instance1 = (await TestObjects.Instance1.refreshAuthTokens())
+
+        await login('alice', 'aaPassword')
+        await login('bob', 'bbPassword')
+        await login('chris', 'ccPassword')
+    })
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    after(function () {
+        return app.close()
+    })
+
+    async function doEditorLogin (userToken, scope, dashboardOnly = false) {
+        const state = base64URLEncode(crypto.randomBytes(16))
+        const verifier = base64URLEncode(crypto.randomBytes(32))
+        const redirectCallback = 'http://example.com/auth/callback'
+        const params = {}
+        params.client_id = TestObjects.tokens.Instance1.clientID
+        params.scope = scope
+        params.response_type = 'code'
+        params.state = state
+        params.code_challenge = base64URLEncode(crypto.createHash('sha256').update(verifier).digest())
+        params.code_challenge_method = 'S256'
+        params.redirect_uri = redirectCallback
+        const response = await app.inject({
+            method: 'GET',
+            url: `/account/authorize?${new URLSearchParams(params)}`,
+            headers: {
+                authorization: `Bearer ${userToken}`
+            }
+        })
+        response.statusCode.should.equal(302)
+        response.headers.should.have.property('location')
+
+        // http://localhost:3000/account/request/z7TucmJ-avnR1eyJLUII5wccsNn3EiU3CpBbpdxx9wg/editor
+
+        const parts = response.headers.location.split('/')
+        const token = parts[parts.length - 2]
+
+        const response2 = await app.inject({
+            method: 'GET',
+            url: `/account/complete/${token}`,
+            cookies: {
+                sid: userToken
+            }
+        })
+
+        if (dashboardOnly) {
+            response2.statusCode.should.equal(400)
+            response2.body.should.equal('Access Denied: you do not have access to the editor')
+            return
+        }
+        response2.statusCode.should.equal(302)
+        response2.headers.should.have.property('location')
+        // http://example.com/flowforge-nr-tools/auth/callback?code=eANs21GUv7OqN99S2QxJ4tS1BD5RYEzOEfb-lhLUciw&state=YMbFnV1E_2aPwz_Ktca1DQ
+        const callbackURL = new URL(response2.headers.location)
+        callbackURL.pathname.should.equal('/auth/callback')
+        callbackURL.host.should.equal('example.com')
+        should.exist(callbackURL.searchParams.get('code'))
+        should.exist(callbackURL.searchParams.get('state'))
+        callbackURL.searchParams.get('state').should.equal(state)
+
+        const params2 = {}
+        params2.grant_type = 'authorization_code'
+        params2.code = callbackURL.searchParams.get('code')
+        params2.redirect_uri = redirectCallback
+        params2.client_id = TestObjects.tokens.Instance1.clientID
+        params2.code_verifier = verifier
+
+        const response3 = await app.inject({
+            url: '/account/token',
+            method: 'POST',
+            payload: params2,
+            headers: {
+                authorization: `Bearer ${userToken}`
+            }
+        })
+        response3.statusCode.should.equal(200)
+        const body = JSON.parse(response3.body)
+        body.should.have.property('state', state)
+        return body
+    }
+
+    it('editor login via oauth flow - full access', async function () {
+        const tokens = await doEditorLogin(TestObjects.tokens.alice, 'editor-0.18', false)
+        tokens.should.have.property('scope', '*')
+        const response = await app.inject({
+            url: '/api/v1/user',
+            method: 'GET',
+            headers: {
+                authorization: `Bearer ${tokens.access_token}`
+            }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.have.property('username', 'alice')
+    })
+    it('editor login via oauth flow - read-only access', async function () {
+        const tokens = await doEditorLogin(TestObjects.tokens.bob, 'editor-0.18', false)
+        tokens.should.have.property('scope', 'read')
+        const response = await app.inject({
+            url: '/api/v1/user',
+            method: 'GET',
+            headers: {
+                authorization: `Bearer ${tokens.access_token}`
+            }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.have.property('username', 'bob')
+    })
+
+    it('editor login via oauth flow - dashboard-only access', async function () {
+        await doEditorLogin(TestObjects.tokens.chris, 'editor-0.18', true)
+    })
+
+    it('httpAuth login via oauth flow - full access', async function () {
+        const tokens = await doEditorLogin(TestObjects.tokens.alice, 'httpAuth-0.18', false)
+        const response = await app.inject({
+            url: '/api/v1/user',
+            method: 'GET',
+            headers: {
+                authorization: `Bearer ${tokens.access_token}`
+            }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.have.property('username', 'alice')
+    })
+    it('httpAuth login via oauth flow - read-only access', async function () {
+        const tokens = await doEditorLogin(TestObjects.tokens.bob, 'httpAuth-0.18', false)
+        const response = await app.inject({
+            url: '/api/v1/user',
+            method: 'GET',
+            headers: {
+                authorization: `Bearer ${tokens.access_token}`
+            }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.have.property('username', 'bob')
+    })
+
+    it('httpAuth login via oauth flow - dashboard-only access', async function () {
+        const tokens = await doEditorLogin(TestObjects.tokens.chris, 'httpAuth-0.18', false)
+        const response = await app.inject({
+            url: '/api/v1/user',
+            method: 'GET',
+            headers: {
+                authorization: `Bearer ${tokens.access_token}`
+            }
+        })
+        response.statusCode.should.equal(200)
+        const result = JSON.parse(response.body)
+        result.should.have.property('username', 'chris')
+    })
+})


### PR DESCRIPTION
Closes #1924 

## Description

This adds a new 'dashboard' team role that gives a user access to the http endpoints (including dashboard) of the team's node-red instances, but no access to the FF team settings or the editor.

This requires the 'FlowForge Authentication' option to be enabled in the Instance settings.

It also requires `nr-launcher` to have some changes applied:
 - https://github.com/flowforge/flowforge-nr-launcher/pull/132

When a Dashboard user views the team they are shown this:

<img width="1183" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/78160a9b-5a0f-4adb-8734-a742dfec2338">


The dashboard role has been added to the list of options in the 'change role' and 'invite member' dialogs:

<img width="595" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/dc6b7c77-aed9-4749-962e-b9b874392ad5">


If a dashboard-only user attempts to access the editor they see this error. This isn't the prettiest, but our options are somewhat limited here as we have to avoid sending them into an infinite redirect loop as Node-RED tries to get them logged in. We will be able to improve this in a future NR release to better handle auth failures when `autoLogin` is enabled.

<img width="559" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/64f7eefa-69d4-418e-b07b-a7ec66983f2d">


### Remaining Tasks

 - [ ] https://github.com/flowforge/flowforge/issues/2293
 - [ ] Raise upstream issue on Node-RED login loops with `autoLogin` enabled


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

