### PR TITLE
Guard against a container not existing and still allow removal

### DIFF
--- a/forge/containers/stub/index.js
+++ b/forge/containers/stub/index.js
@@ -156,7 +156,7 @@ module.exports = {
                 }, 250)
             })
         } else {
-            throw new Error({ error: project.id + ' not found' })
+            throw new Error(`${project.id} not found`)
         }
     },
     /**

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -335,7 +335,7 @@ module.exports = async function (app) {
             } catch (err) {
                 // Swallow no such container error code (as it may have been removed from wrapper already)
                 // https://github.com/apocas/dockerode/blob/edf29ccb2c2c7bfcdd1cf3cacbe861bd0f4bc87a/lib/network.js#L67
-                if (err.statusCode !== 404) {
+                if (err?.statusCode !== 404) {
                     throw err
                 }
             }

--- a/test/lib/TestModelFactory.js
+++ b/test/lib/TestModelFactory.js
@@ -138,7 +138,8 @@ module.exports = class TestModelFactory {
             ]
         })
         if (start) {
-            await this.forge.containers.start(instance) // ensure project is initialized
+            const result = await this.forge.containers.start(instance) // ensure project is initialized
+            await result.started
         }
         return instance
     }

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -1877,6 +1877,23 @@ describe('Project API', function () {
 
             response.statusCode.should.equal(200)
         })
+
+        it('Handles trying to delete an already deleted container without error', async function () {
+            const aTeamInstance = await createInstance({ start: true })
+
+            sinon.stub(app.containers, 'remove').throws({ statusCode: 404, message: 'container not found' })
+
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/projects/${aTeamInstance.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+
+            const result = response.json()
+            result.should.have.property('status', 'okay')
+
+            response.statusCode.should.equal(200)
+        })
     })
 
     describe('Project Settings', function () {

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -1,7 +1,8 @@
-const should = require('should') // eslint-disable-line
-
 const crypto = require('crypto')
 const sleep = require('util').promisify(setTimeout)
+
+const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
 
 const setup = require('../setup')
 
@@ -134,14 +135,14 @@ describe('Project API', function () {
             cookies: { sid: TestObjects.tokens.alice }
         })
     }
-    async function createInstance () {
+    async function createInstance (start = false) {
         return app.factory.createInstance(
             { name: generateProjectName() },
             app.application,
             app.stack,
             app.template,
             app.projectType,
-            { start: false }
+            { start }
         )
     }
     async function duplicateProject (srcId, team, template, stack, duplicateOpts, accessToken, name) {
@@ -1832,6 +1833,52 @@ describe('Project API', function () {
             Object.keys(newCreds).should.have.length(0)
         })
     })
+
+    describe('Delete Instance', function () {
+        it('Non-member cannot delete instance', async function () {
+            const aTeamInstance = await createInstance()
+
+            // Chris (non-member) cannot delete in ATeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/projects/${aTeamInstance.id}`, // ATeam Project
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(404)
+        })
+
+        it('Non-owner member cannot delete instance', async function () {
+            const aTeamInstance = await createInstance()
+
+            // Bob (non-owner) can delete in ATeam
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/projects/${aTeamInstance.id}`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+
+            const result = response.json()
+            result.should.have.property('code', 'unauthorized')
+
+            response.statusCode.should.equal(403)
+        })
+
+        it('Owner can delete an instance', async function () {
+            const aTeamInstance = await createInstance({ start: true })
+
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/projects/${aTeamInstance.id}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+
+            const result = response.json()
+            result.should.have.property('status', 'okay')
+
+            response.statusCode.should.equal(200)
+        })
+    })
+
     describe('Project Settings', function () {
         // helper function to get settings
         const getSettings = async () => {
@@ -1903,6 +1950,7 @@ describe('Project API', function () {
             settingsAfter.should.have.property('theme', 'forge-dark') // should now be forge-dark
         })
     })
+
     describe('Project import flows & credentials', function () {
         const flows = [
             {


### PR DESCRIPTION
## Description

I ran against this issue locally where removal failed half way through (removed from docker but not FlowForge).
This then left my account in a state where I could not delete the instance as it had already been removed from docker.

It's _unlikely_ this would happen in production, but adding a guard just in case doesn't hurt!

## Related Issue(s)

None

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

