### PR TITLE
Fix broken link

### DIFF
--- a/docs/cloud/README.md
+++ b/docs/cloud/README.md
@@ -36,7 +36,7 @@ See the [Billing](./billing.md) page for more detailed answers about billing.
 
 ## Support
 
-Premium customers can get support by [filing a ticket](./support). We offer
+Premium customers can get support by [filing a ticket](/support). We offer
 support for the FlowForge application and your account, any issues relating to
 Node-RED such as your flows or a 3rd party node should be raised in the
 [community forum](https://community.flowforge.com).


### PR DESCRIPTION
## Description

The support page is hosted at the root of our website, at: https://flowforge.com/support/

This link was broken as it was relative to the current path, not anchored to the root.

## Related Issue(s)

CI for website PRs are currently broken because of this broken link.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [X] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [X] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

