### PR TITLE
Improve error handling and UI for launcher "offline"

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -820,7 +820,9 @@ module.exports = async function (app) {
      *  - returns most recent 30 entries
      *  - ?cursor= can be used to set the 'most recent log entry' to query from
      *  - ?limit= can be used to modify how many entries to return
+     * @name /api/v1/projects/:id/logs // << Added an 's'
      * @name /api/v1/projects/:id/log
+     * @name /api/v1/projects/:id/logs // << Added an 's'
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId/logs', {
@@ -830,46 +832,70 @@ module.exports = async function (app) {
             reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
             return
         }
-        const paginationOptions = app.getPaginationOptions(request, { limit: 30 })
-
-        let logs = await app.containers.logs(request.project)
-        const firstLogCursor = logs.length > 0 ? logs[0].ts : null
-        const fullLogLength = logs.length
-        if (!paginationOptions.cursor) {
-            logs = logs.slice(-paginationOptions.limit)
-        } else {
-            let cursor = paginationOptions.cursor
-            let cursorDirection = true // 'next'
-            if (cursor[0] === '-') {
-                cursorDirection = false
-                cursor = cursor.substring(1)
-            }
-            let i = 0
-            for (;i < fullLogLength; i++) {
-                if (logs[i].ts === cursor) {
-                    break
+        try {
+            const paginationOptions = app.getPaginationOptions(request, { limit: 30 })
+            let logs = await app.containers?.logs(request.project)
+            const firstLogCursor = logs.length > 0 ? logs[0].ts : null
+            const fullLogLength = logs.length
+            if (!paginationOptions.cursor) {
+                logs = logs.slice(-paginationOptions.limit)
+            } else {
+                let cursor = paginationOptions.cursor
+                let cursorDirection = true // 'next'
+                if (cursor[0] === '-') {
+                    cursorDirection = false
+                    cursor = cursor.substring(1)
+                }
+                let i = 0
+                for (;i < fullLogLength; i++) {
+                    if (logs[i].ts === cursor) {
+                        break
+                    } else if (logs[i].ts > cursor) {
+                        if (i) { i-- }
+                        break
+                    }
+                }
+                if (i === fullLogLength) {
+                    // cursor not found
+                    logs = []
+                } else if (cursorDirection) {
+                    // logs *after* cursor
+                    logs = logs.slice(i + 1, i + 1 + paginationOptions.limit)
+                } else {
+                    // logs *before* cursor
+                    logs = logs.slice(Math.max(0, i - 1 - paginationOptions.limit), i)
                 }
             }
-            if (i === fullLogLength) {
-                // cursor not found
-                logs = []
-            } else if (cursorDirection) {
-                // logs *after* cursor
-                logs = logs.slice(i + 1, i + 1 + paginationOptions.limit)
-            } else {
-                // logs *before* cursor
-                logs = logs.slice(Math.max(0, i - 1 - paginationOptions.limit), i)
+            const result = {
+                meta: {
+                    // next_cursor - are there more recent logs to get?
+                    next_cursor: logs.length > 0 ? logs[logs.length - 1].ts : undefined,
+                    previous_cursor: logs.length > 0 && logs[0].ts !== firstLogCursor ? ('-' + logs[0].ts) : undefined
+                },
+                log: logs
             }
+            reply.send(result)
+        } catch (error) {
+            let responseCode = error.response?.status || 500 // default to 500
+            error.errorCode = 'unknown_error'
+            error.errorMessage = error.message || 'Unknown error'
+            if (error.code === 'ECONNREFUSED') {
+                responseCode = 503 // service unavailable
+                error.errorCode = 'connection_refused'
+                error.errorMessage = 'Connection refused'
+            } else if (error.code === 'ECONNRESET') {
+                responseCode = 503 // service unavailable
+                error.errorCode = 'connection_reset'
+                error.errorMessage = 'Connection reset'
+            } else if (error.code === 'ENOTFOUND') {
+                responseCode = 503 // service unavailable
+                error.errorCode = 'not_found'
+                error.errorMessage = 'Not found'
+            }
+            const info = `Instance: ${request.project.id} (${request.project.name}), Error: ${error.errorMessage} (${responseCode})`
+            app.log.warn(`Unable to get Node-RED instance logs from its Launcher. ${info}`)
+            reply.code(responseCode).send({ code: error.errorCode, error: error.errorMessage })
         }
-        const result = {
-            meta: {
-                // next_cursor - are there more recent logs to get?
-                next_cursor: logs.length > 0 ? logs[logs.length - 1].ts : undefined,
-                previous_cursor: logs.length > 0 && logs[0].ts !== firstLogCursor ? ('-' + logs[0].ts) : undefined
-            },
-            log: logs
-        }
-        reply.send(result)
     })
 
     /**

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -820,9 +820,7 @@ module.exports = async function (app) {
      *  - returns most recent 30 entries
      *  - ?cursor= can be used to set the 'most recent log entry' to query from
      *  - ?limit= can be used to modify how many entries to return
-     * @name /api/v1/projects/:id/logs // << Added an 's'
-     * @name /api/v1/projects/:id/log
-     * @name /api/v1/projects/:id/logs // << Added an 's'
+     * @name /api/v1/projects/:id/logs
      * @memberof forge.routes.api.project
      */
     app.get('/:projectId/logs', {

--- a/frontend/src/mixins/vue-timers.js
+++ b/frontend/src/mixins/vue-timers.js
@@ -1,0 +1,237 @@
+// Based on works in https://github.com/Kelin2025/vue-timers
+// The original MIT License is included below as per the original author's request
+
+// =================================================================================================
+// Copyright (c) 2017 Anton Kosykh
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// =================================================================================================
+
+// Rewritten for vue3, by @flowforge
+
+/**
+ * A timer mixin to simplify the use of timers in components.
+ * @module vue-timers
+ * @example
+ * // in your component
+ * import { VueTimersMixin } from './vue-timers.js'
+ * export default {
+ *   mixins: [VueTimersMixin],
+ *   timers: {
+ *     timer1: { time: 1000, repeat: true, immediate: true, autostart: true },
+ *     timer2: { time: 1000, repeat: true, immediate: false, autostart: false, callback: this.timerTick }
+ *   },
+ *   mounted () {
+ *     this.$timer.start('timer2')
+ *   }
+ *   methods: {
+ *     timer1 () { // do something },
+ *     timerTick () { // do something }
+ * },
+ */
+
+const VueTimers = {
+
+    data: function () {
+        if (!this.$options.timers) return {}
+        this.$options.timers = normalizeOptions(this.$options.timers, this)
+        return {
+            timers: generateData(this.$options.timers)
+        }
+    },
+
+    created: function () {
+        if (!this.$options.timers) return
+        const vm = this
+        const data = vm.timers
+        const options = vm.$options.timers
+        vm.$timer = {
+            start: function (name) {
+                if (process.env.NODE_ENV !== 'production' && !(name in options)) {
+                    throw new ReferenceError(
+                        '[vue-timers.start] Cannot find timer ' + name
+                    )
+                }
+                if (data[name].isRunning) return
+                data[name].isRunning = true
+                data[name].instance = generateTimer(
+                    set('time', data[name].time, options[name]),
+                    vm
+                )
+                if (options[name].immediate) {
+                    vm.$emit('timer-tick:' + name)
+                    options[name].callback()
+                }
+                vm.$emit('timer-start:' + name)
+            },
+
+            stop: function (name) {
+                if (process.env.NODE_ENV !== 'production' && !(name in options)) {
+                    throw new ReferenceError(
+                        '[vue-timers.stop] Cannot find timer ' + name
+                    )
+                }
+                if (!data[name].isRunning) return
+                clearTimer(options[name].repeat)(data[name].instance)
+                data[name].isRunning = false
+                vm.$emit('timer-stop:' + name)
+            },
+
+            restart: function (name) {
+                if (process.env.NODE_ENV !== 'production' && !(name in options)) {
+                    throw new ReferenceError(
+                        '[vue-timers.restart] Cannot find timer ' + name
+                    )
+                }
+                this.stop(name)
+                this.start(name)
+                vm.$emit('timer-restart:' + name)
+            }
+        }
+    },
+
+    mounted: function () {
+        if (!this.$options.timers) return
+        const vm = this
+        const options = vm.$options.timers
+        Object.keys(options).forEach(function (key) {
+            if (options[key].autostart) {
+                vm.$timer.start(key)
+            }
+        })
+    },
+
+    activated: function () {
+        if (!this.$options.timers) { return }
+        const vm = this
+        const data = vm.timers
+        const options = vm.$options.timers
+        Object.keys(options).forEach(function (key) {
+            if (options[key].isSwitchTab && data[key].instance) {
+                vm.$timer.start(key)
+            }
+        })
+    },
+
+    deactivated: function () {
+        if (!this.$options.timers) { return }
+        const vm = this
+        const data = vm.timers
+        const options = vm.$options.timers
+        Object.keys(options).forEach(function (key) {
+            if (options[key].isSwitchTab && data[key].instance) {
+                vm.$timer.stop(key)
+            }
+        })
+    },
+    beforeUnmount: function () {
+        if (!this.$options.timers) { return }
+        const vm = this
+        Object.keys(vm.$options.timers).forEach(function (key) {
+            vm.$timer.stop(key)
+        })
+    }
+}
+
+export default function install (Vue, _options) {
+    Vue.config.optionMergeStrategies.timers = Vue.config.optionMergeStrategies.methods
+    Vue.mixin(VueTimers)
+}
+
+if (typeof window !== 'undefined' && window.Vue) {
+    install(window.Vue)
+}
+
+export function timer (name, time, options) {
+    return Object.assign({ name, time }, options)
+}
+
+export const VueTimersMixin = VueTimers
+
+function set (key, value, obj) {
+    const clone = Object.assign({}, obj)
+    clone[key] = value
+    return clone
+}
+
+function generateData (timers) {
+    return Object.keys(timers).reduce(function (acc, cur) {
+        return set(
+            cur,
+            {
+                isRunning: false,
+                time: timers[cur].time || 0,
+                instance: null
+            },
+            acc
+        )
+    }, {})
+}
+
+function setTimer (repeat) {
+    return repeat ? setInterval : setTimeout
+}
+
+function clearTimer (repeat) {
+    return repeat ? clearInterval : clearTimeout
+}
+
+function generateTimer (options, vm) {
+    return setTimer(options.repeat)(function () {
+        vm.$emit('timer-tick:' + options.name)
+        options.callback()
+    }, options.time)
+}
+
+function normalizeConfig (config, vm) {
+    if (process.env.NODE_ENV !== 'production') {
+        if (!config.name) {
+            throw new Error('[vue-timers.create] name is required')
+        }
+        if (!config.callback && typeof vm[config.name] !== 'function') {
+            throw new ReferenceError(
+                '[vue-timers.create] Cannot find method ' + config.name
+            )
+        }
+        if (config.callback && typeof config.callback !== 'function') {
+            throw new TypeError(
+                '[vue-timers.create] Timer callback should be a function, ' +
+            typeof config.callback +
+            ' given'
+            )
+        }
+    }
+    return {
+        name: config.name,
+        time: config.time || 0,
+        repeat: 'repeat' in config ? config.repeat : false,
+        immediate: 'immediate' in config ? config.immediate : false,
+        autostart: 'autostart' in config ? config.autostart : false,
+        isSwitchTab: 'isSwitchTab' in config ? config.isSwitchTab : false,
+        callback: (config.callback && config.callback.bind(vm)) || vm[config.name]
+    }
+}
+
+function normalizeOptions (options, vm) {
+    if (Array.isArray(options)) {
+        return options.reduce(function (res, config) {
+            return set(config.name, normalizeConfig(config, vm), res)
+        }, {})
+    } else {
+        return Object.keys(options).reduce(function (res, key) {
+            return set(
+                key,
+                normalizeConfig(set('name', key, options[key]), vm),
+                res
+            )
+        }, {})
+    }
+}

--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -1,11 +1,8 @@
 <template>
     <ff-loading v-if="loading" message="Loading Logs..." />
-    <!-- <div v-if="showOfflineBanner" class="flex text-red-500 justify-center italic mb-2 p-0">
-        Launcher is offline
-    </div> -->
     <div v-if="showOfflineBanner" class="ff-banner ff-banner-info my-2 rounded p-2 font-mono">
         <span>
-            <span>The Node-RED Launcher for this instance is currently offline. Please wait.</span>
+            <span>The Node-RED instance cannot be reached at this time. Please wait...</span>
         </span>
     </div>
     <div v-if="!instance.meta || instance.meta.state === 'suspended'" class="flex text-gray-500 justify-center italic mb-4 p-8">
@@ -131,7 +128,7 @@ export default {
                         return // only show the alert once
                     }
                     this.showOfflineBanner = true // show the "offline" banner
-                    Alerts.emit('The Node-RED Launcher cannot be reached at this time', 'warning', (POLL_TIME - 500))
+                    Alerts.emit('The Node-RED instance cannot be reached at this time', 'warning', (POLL_TIME - 500))
                 } else if (error.response?.status !== 500 && error.response?.data?.code !== 'project_suspended') {
                     // display an alert. Ensure it is visible for less time than
                     // the polling interval to avoid multiple visible alerts
@@ -146,6 +143,12 @@ export default {
 
 <style scoped>
 .forge-log-offline-background {
-    background: repeating-linear-gradient( 45deg, #322e2e, #353131 10px, #804141 10px, #703f3f 20px );
+    background: repeating-linear-gradient(
+        -45deg,
+        #363848,
+        #363848 10px,
+        rgba(31, 41, 55, var(--tw-bg-opacity)) 10px,
+        rgba(31, 41, 55, var(--tw-bg-opacity)) 20px
+    );
 }
 </style>

--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -1,6 +1,17 @@
 <template>
     <ff-loading v-if="loading" message="Loading Logs..." />
-    <div v-else-if="instance.meta && instance.meta.state !== 'suspended'" class="mx-auto text-xs border bg-gray-800 text-gray-200 rounded p-2 font-mono">
+    <!-- <div v-if="showOfflineBanner" class="flex text-red-500 justify-center italic mb-2 p-0">
+        Launcher is offline
+    </div> -->
+    <div v-if="showOfflineBanner" class="ff-banner ff-banner-info my-2 rounded p-2 font-mono">
+        <span>
+            <span>The Node-RED Launcher for this instance is currently offline. Please wait.</span>
+        </span>
+    </div>
+    <div v-if="!instance.meta || instance.meta.state === 'suspended'" class="flex text-gray-500 justify-center italic mb-4 p-8">
+        Logs unavailable
+    </div>
+    <div v-else :class="showOfflineBanner ? 'forge-log-offline-background' : ''" class="mx-auto text-xs border bg-gray-800 text-gray-200 rounded p-2 font-mono">
         <div v-if="prevCursor" class="flex">
             <a class=" text-center w-full hover:text-blue-400 cursor-pointer pb-1" @click="loadPrevious">Load earlier...</a>
         </div>
@@ -10,16 +21,17 @@
             <div class="flex-grow break-all whitespace-pre-wrap">{{ item.msg }}</div>
         </div>
     </div>
-    <div v-else class="flex text-gray-500 justify-center italic mb-4 p-8">
-        Logs unavailable
-    </div>
 </template>
 
 <script>
 import InstanceApi from '../../../api/instances.js'
+import { VueTimersMixin } from '../../../mixins/vue-timers.js'
+import Alerts from '../../../services/alerts.js'
+const POLL_TIME = 5000
 
 export default {
     name: 'LogsShared',
+    mixins: [VueTimersMixin],
     inheritAttrs: false,
     props: {
         instance: {
@@ -34,27 +46,29 @@ export default {
             logEntries: [],
             prevCursor: null,
             nextCursor: null,
-            checkInterval: null
+            checkInterval: null,
+            showOfflineBanner: false
         }
+    },
+    timers: {
+        pollTimer: { time: POLL_TIME, repeat: true, autostart: false }
     },
     watch: {
         instance: 'fetchData'
     },
-    mounted () {
+    async mounted () {
         if (!this.instance.meta || this.instance.meta.state === 'suspended') {
             this.loading = false
         }
-        this.fetchData()
-        this.checkInterval = setInterval(() => {
+        await this.fetchData()
+        this.$timer.start('pollTimer')
+    },
+    methods: {
+        pollTimer: function () {
             if (this.instance.meta && this.instance.meta.state !== 'suspended') {
                 this.loadNext()
             }
-        }, 5000)
-    },
-    beforeUnmount () {
-        clearInterval(this.checkInterval)
-    },
-    methods: {
+        },
         fetchData: async function () {
             if (this.instance.id) {
                 if (this.instance.meta && this.instance.meta.state !== 'suspended') {
@@ -73,37 +87,65 @@ export default {
             this.loadItems(this.instance.id, this.nextCursor)
         },
         loadItems: async function (instanceId, cursor) {
-            const entries = await InstanceApi.getInstanceLogs(instanceId, cursor)
-            if (!cursor) {
-                this.prevCursor = null
-                this.logEntries = []
-            }
-            const toPrepend = []
-            if (entries.log.length > 0) {
-                entries.log.forEach(l => {
-                    const d = new Date(parseInt(l.ts.substring(0, l.ts.length - 4)))
-                    l.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
-                    if (typeof l.msg !== 'string') {
-                        l.msg = JSON.stringify(l.msg)
+            try {
+                const entries = await InstanceApi.getInstanceLogs(instanceId, cursor, null, { showAlert: false })
+                this.showOfflineBanner = false
+                if (!cursor) {
+                    this.prevCursor = null
+                    this.logEntries = []
+                }
+                const toPrepend = []
+                if (entries.log.length > 0) {
+                    entries.log.forEach(l => {
+                        const d = new Date(parseInt(l.ts.substring(0, l.ts.length - 4)))
+                        l.date = `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`
+                        if (typeof l.msg !== 'string') {
+                            l.msg = JSON.stringify(l.msg)
+                        }
+                        l.msg = l.msg.replace(/^[\n]*/, '')
+                        if (!cursor || cursor[0] !== '-') {
+                            this.logEntries.push(l)
+                        } else {
+                            toPrepend.push(l)
+                        }
+                    })
+                    if (toPrepend.length > 0) {
+                        this.logEntries = toPrepend.concat(this.logEntries)
                     }
-                    l.msg = l.msg.replace(/^[\n]*/, '')
+                    if (!cursor || cursor[0] === '-') {
+                        this.prevCursor = entries.meta.previous_cursor
+                    }
                     if (!cursor || cursor[0] !== '-') {
-                        this.logEntries.push(l)
-                    } else {
-                        toPrepend.push(l)
+                        this.nextCursor = entries.meta.next_cursor
                     }
-                })
-                if (toPrepend.length > 0) {
-                    this.logEntries = toPrepend.concat(this.logEntries)
                 }
-                if (!cursor || cursor[0] === '-') {
-                    this.prevCursor = entries.meta.previous_cursor
-                }
-                if (!cursor || cursor[0] !== '-') {
-                    this.nextCursor = entries.meta.next_cursor
+            } catch (error) {
+                // log the error as warn for troubleshooting purposes
+                console.warn('Unable to retrieve Node-RED instance logs:', error)
+
+                // Error 503 is returned by the API when the launcher is offline.
+                // Error 500 is handled (and surfaced) by the `client.interceptors` in `../../../api/client.js`
+                // Error with data.code === 'project_suspended' is ignored - it is expected when the project is suspended
+                if (error.response?.status === 503) {
+                    if (this.showOfflineBanner === true) {
+                        return // only show the alert once
+                    }
+                    this.showOfflineBanner = true // show the "offline" banner
+                    Alerts.emit('The Node-RED Launcher cannot be reached at this time', 'warning', (POLL_TIME - 500))
+                } else if (error.response?.status !== 500 && error.response?.data?.code !== 'project_suspended') {
+                    // display an alert. Ensure it is visible for less time than
+                    // the polling interval to avoid multiple visible alerts
+                    const message = error.response?.data?.error || error.message
+                    Alerts.emit('Could not get Node-RED logs: ' + message, 'warning', (POLL_TIME - 500))
                 }
             }
         }
     }
 }
 </script>
+
+<style scoped>
+.forge-log-offline-background {
+    background: repeating-linear-gradient( 45deg, #322e2e, #353131 10px, #804141 10px, #703f3f 20px );
+}
+</style>


### PR DESCRIPTION
closes #1083 

## Description

* Curates the error responses from the launcher to provide better info to the frontend (prevents the default technical "catch all" Error 500 toast notification)
* Makes the toast message more friendly and ONLY displays it once
* Adds a friendly / less alarming banner above the log panel to inform users that the logs are currently unavailable
* Stylises the log panel to indicate it may be stale
* Adds a timer `mixin` for controlling polling
  * This was something discussed in a meeting some time back. This component can be (should be) reused wherever polling is required as it can be easily controlled and automatically stops when component is unmounted etc.
 


https://github.com/flowforge/flowforge/assets/44235289/92d607e8-6bcc-4b9e-9d37-cc3dc427749a

## Related Issue(s)

#1083

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

