### PR TITLE
Update device agent docs around windows support

### DIFF
--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -9,6 +9,14 @@ A Device runs a software agent that connects back to the platform to receive upd
 
 This guide explains how to get starting with the Devices feature.
 
+## Prerequisites
+
+ - NodeJS v16 or later
+ 
+## Supported Operating Systems
+
+The Device Agent can be installed on most Linux distributions, Windows, and MacOS.
+
 ## Installing the Device Agent
 
 The Device Agent is published to the public npm repository as [@flowforge/flowforge-device-agent](https://www.npmjs.com/package/@flowforge/flowforge-device-agent).
@@ -16,9 +24,18 @@ The Device Agent is published to the public npm repository as [@flowforge/flowfo
 It can be installed as a global npm module. This will ensure the agent
 command is on the path:
 
+### Linux/MacOS
+
 ```bash
 sudo npm install -g @flowforge/flowforge-device-agent
 ```
+
+### Windows
+
+```bash
+npm install -g @flowforge/flowforge-device-agent
+```
+
 
 Or you can chose to run the Docker container. When you do, you'll need to mount
 the `device.yaml` obtained when [Registering the device](#register-the-device):
@@ -29,22 +46,25 @@ docker run --mount /path/to/device.yml:/opt/flowforge/device.yml -p 1880:1880 fl
 
 ## Configuration
 
+The agent configuration is provided by a `device.yml` file within its working
+directory.
+
 ### Working directory
 
-By default the agent uses `/opt/flowforge-device` or `c:\opt\flowforge-device` as its working directory. 
-This can be overridden with the `-d/--dir` option.
+By default the agent uses `/opt/flowforge-device` or `c:\opt\flowforge-device` as
+its working directory. This can be overridden with the `-d/--dir` option.
 
 The directory must exist and be accessible to the user that will be
 running the agent.
 
-#### Linux
+#### Linux/MacOS
 
 ```bash
 sudo mkdir /opt/flowforge-device
 sudo chown -R $USER /opt/flowforge-device
 ```
 
-#### Windows
+#### Windows (run elevated)
 
 ```bash
 mkdir c:\opt\flowforge-device

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -205,7 +205,7 @@ flowforge-device-agent -p 8080
 _Start the agent with a different working directory and the Web UI enabled_
 
 ```bash
-flowforge-device-agent -d /path/to/working/directory -w -ui-user admin -ui-pass password --ui-port 8081
+flowforge-device-agent -d /path/to/working/directory -w --ui-user admin --ui-pass password --ui-port 8081
 ```
 
 


### PR DESCRIPTION
## Description

Updates docs to specifically mention windows for Device Agent. 
Also, partially aligns with info in the Device Agent PR https://github.com/flowforge/flowforge-device-agent/pull/119 (though this doc is less technical)

## Related Issue(s)

https://github.com/flowforge/flowforge-device-agent/issues/78

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

