### PR TITLE
Explicitly upgrade to latest lottie and use new import style

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,4 @@
-import LottieAnimation from 'lottie-web-vue'
+import { LottieAnimation } from 'lottie-web-vue'
 
 import ForgeUIComponents from '@flowforge/forge-ui-components'
 import { AxiosError } from 'axios'

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "handlebars": "^4.7.7",
         "hashids": "^2.3.0",
         "jsonwebtoken": "^9.0.0",
-        "lottie-web-vue": "^2.0.6",
+        "lottie-web-vue": "^2.0.7",
         "lru-cache": "^9.1.2",
         "marked": "^4.3.0",
         "mqtt": "^4.3.7",


### PR DESCRIPTION
## Description

I have been experiencing a very time consuming issue in my local where FlowForge never stops loading, but shows no errors:
<img width="1115" alt="Screenshot 2023-06-20 at 15 44 58" src="https://github.com/flowforge/flowforge/assets/507155/88316d9a-bb97-4144-a85f-b69f28697d59">

The cause was that my local had updated to the latest patch version of lottie-web-vue (see https://github.com/garbit/lottie-web-vue/pull/19), which appears to expect a different import style. 

Tracking down the root cause was complicated by our lack of lock files in FlowForge repos. I propose we start using them with immediate effect, see:  https://github.com/flowforge/flowforge-dev-env/issues/20 

## Related Issue(s)

None

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

