### PR TITLE
Use findOrCreate to handle retrying failed setup

### DIFF
--- a/forge/db/controllers/ProjectStack.js
+++ b/forge/db/controllers/ProjectStack.js
@@ -7,13 +7,17 @@ module.exports = {
             label = `Node-RED ${properties.nodered}`
             name = label.toLowerCase().replace(/[ .]/g, '-')
         }
-        const stack = await app.db.models.ProjectStack.create({
-            name,
-            label,
-            active: true,
-            order: 1,
-            description: '',
-            properties
+        const [stack] = await app.db.models.ProjectStack.findOrCreate({
+            where: {
+                name,
+                active: true
+            },
+            defaults: {
+                label,
+                order: 1,
+                description: '',
+                properties
+            }
         })
         await stack.setProjectType(projectType)
         return stack

--- a/forge/db/controllers/ProjectTemplate.js
+++ b/forge/db/controllers/ProjectTemplate.js
@@ -226,11 +226,16 @@ module.exports = {
             setTemplateValue(settings, name, defaultTemplateValues[name])
             setTemplateValue(policy, name, defaultTemplatePolicy[name])
         })
-        const template = await app.db.models.ProjectTemplate.create({
-            name: 'Default',
-            active: true,
-            settings,
-            policy
+        const [template] = await app.db.models.ProjectTemplate.findOrCreate({
+            where: {
+                name: 'Default',
+                active: true,
+                ownerId: user.id
+            },
+            defaults: {
+                settings,
+                policy
+            }
         })
         await template.setOwner(user)
         return template

--- a/forge/db/controllers/ProjectType.js
+++ b/forge/db/controllers/ProjectType.js
@@ -1,11 +1,18 @@
 module.exports = {
     createDefaultProjectType: async function (app) {
-        return await app.db.models.ProjectType.create({
-            name: 'Default',
-            active: true,
-            order: 1,
-            description: '',
-            properties: {}
+        const [projectType] = await app.db.models.ProjectType.findOrCreate({
+            where: {
+                name: 'Default',
+                active: true
+            },
+            defaults: {
+                active: true,
+                order: 1,
+                description: '',
+                properties: {}
+            }
         })
+
+        return projectType
     }
 }


### PR DESCRIPTION
## Description

If setup fails at any step, the database can be left in a half setup state.

When the user tries setup a second time, it fails with a database constraint about duplicate entries.
Using findOrCreate means if the record already exists, it won't try to be recreated.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass - Not sure how to test setup reliably...
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

