### PR TITLE
Limit invitiations to max 5 users at a time

### DIFF
--- a/forge/routes/api/teamInvitations.js
+++ b/forge/routes/api/teamInvitations.js
@@ -32,6 +32,10 @@ module.exports = async function (app) {
      */
     app.post('/', async (request, reply) => {
         const userDetails = request.body.user.split(',').map(u => u.trim()).filter(Boolean)
+        if (userDetails.length > 5) {
+            reply.code(429).send({ code: 'too_many_invites', error: 'maximum 5 invites at a time'})
+            return;
+        }
         const role = request.body.role || Roles.Member
         if (!TeamRoles.includes(role)) {
             reply.code(400).send({ code: 'invalid_team_role', error: 'invalid team role' })

--- a/test/unit/forge/routes/api/teamInvitations_spec.js
+++ b/test/unit/forge/routes/api/teamInvitations_spec.js
@@ -160,6 +160,21 @@ describe('Team Invitations API', function () {
             app.config.email.transport.getMessageQueue().should.have.lengthOf(1)
         })
 
+        it('no more than 5 invites at a time', async () => {
+            const response = await app.inject({
+                method: 'POST',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/invitations`,
+                cookies: { sid: TestObjects.tokens.alice },
+                payload: {
+                    user: 'alice, bob, chris, dave, eric, fred'
+                }
+            })
+            response.statusCode.should.equal(429)
+            const result = response.json()
+            result.should.have.property('code', 'too_many_invites')
+            result.should.have.property('error')
+        })
+
         describe('external users', async function () {
             it('team owner cannot invite external user if disabled', async () => {
                 // Alice cannot invite dave@example.com to ATeam


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Limit the maxium number of users that can be invited to a team in one go

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

