### PR TITLE
add Control view restrictions of the Environment Variable values

### DIFF
--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -18,6 +18,7 @@ module.exports = async function (app) {
                 'team:user:invite:external': app.settings.get('team:user:invite:external') && app.postoffice.enabled(),
                 'team:create': app.settings.get('team:create'),
                 'user:tcs-required': app.settings.get('user:tcs-required'),
+                'team:environment-variable-view': app.settings.get('team:environment-variable-view'),
                 'user:tcs-url': app.settings.get('user:tcs-url'),
                 'user:tcs-date': app.settings.get('user:tcs-date'),
                 'user:team:trial-mode:projectType': app.settings.get('user:team:trial-mode:projectType'),

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -38,6 +38,9 @@ module.exports = {
     // Should we auto-create a team for a user when they register
     'user:team:auto-create': false,
 
+    //  can user's see environment variable
+    'team:environment-variable-view': false,
+
     // Can external users be invited to join teams
     'team:user:invite:external': false,
 

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -80,6 +80,12 @@
                 <p>Administrators can always create teams.</p>
             </template>
         </FormRow>
+        <FormRow v-model="input['team:environment-variable-view']" type="checkbox" >
+            Allow users to see environment variable
+            <template #description>
+                User can see environment variable of the team
+            </template>
+        </FormRow>
         <FormRow v-model="input['team:user:invite:external']" type="checkbox" :disabled="errors.requiresEmail" :error="errors.requiresEmail">
             Allow users to invite external users to teams
             <template #description>
@@ -173,6 +179,7 @@ const validSettings = [
     'user:tcs-url',
     'user:tcs-date',
     'team:create',
+    'team:environment-variable-view',
     'team:user:invite:external',
     'telemetry:enabled',
     'user:team:trial-mode',

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -165,16 +165,23 @@ export default {
     },
     methods: {
         addEnv () {
-            const env = { name: this.input.name, value: this.input.value }
-            this.editable.settings.env.push(env)
+            const field = {
+                index: 'add-' + this.addedCount++,
+                name: this.input.name,
+                value: this.input.value,
+                encrypted: this.input.encrypt,
+                policy: this.editTemplate ? false : undefined
+            }
+            this.envVarNames[field.name] = this.editable.settings.env.length
+            this.editable.settings.env.push(field)
             this.input.name = ''
+            this.input.encrypt = false
             this.input.value = ''
-            this.addedCount += 1
-            this.$emit('change', `added environment variable "${env.name}"`)
         },
-        removeEnv (idx) {
-            const env = this.editable.settings.env.splice(idx, 1)[0]
-            this.$emit('change', `removed environment variable "${env.name}"`)
+        removeEnv (index) {
+            const field = this.editable.settings.env[index]
+            delete this.envVarNames[field.name]
+            this.editable.settings.env.splice(index, 1)
         }
     },
     components: {


### PR DESCRIPTION
## Description

Added feature to control view restrictions of Environment Variable values

- Implemented a new feature that allows administrators to control the view restrictions of Environment Variable values.
- If the user is an admin, they now have the ability to see and control the view restrictions of the Environment Variable values.
- The feature enhances the existing functionality by providing fine-grained control over who can view the values of    Environment Variables.
- This feature helps improve security and privacy by limiting access to sensitive environment information.

https://github.com/flowforge/flowforge/assets/110285294/30613382-8aaa-46ce-b0c5-7bf656f14da2



closes #2289

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

