### PR TITLE
Increase default helm install timeout

### DIFF
--- a/docs/install/kubernetes/README.md
+++ b/docs/install/kubernetes/README.md
@@ -135,7 +135,7 @@ A full list of all the configurable values can be found in the [Helm Chart READM
 The install can then be started with the following command:
 
 ```bash
-helm upgrade --atomic --install flowforge flowforge/flowforge -f customization.yml
+helm upgrade --atomic --install --timeout 10m flowforge flowforge/flowforge -f customization.yml
 ```
 
 ### Enabling the MQTT broker


### PR DESCRIPTION
fixes flowforge/helm#142

Default 5m timeout can be too slow to install posgresql chart as well as FlowForge.

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

