### PR TITLE
Remove overloading of /api/v1/teams endpoint

### DIFF
--- a/forge/lib/permissions.js
+++ b/forge/lib/permissions.js
@@ -9,6 +9,7 @@ const Permissions = {
     'user:team:list': { description: 'List a Users teams', role: Roles.Admin, self: true },
     // Team Scoped Actions
     'team:create': { description: 'Create Team' },
+    'team:list': { description: 'List Teams', role: Roles.Admin },
     'team:read': { description: 'View a Team', role: Roles.Dashboard },
     'team:edit': { description: 'Edit Team', role: Roles.Owner },
     'team:delete': { description: 'Delete Team', role: Roles.Owner },

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -21,7 +21,7 @@ const getTeams = () => {
 const getTeam = (team) => {
     let url
     if (typeof team === 'object') {
-        url = `/api/v1/teams/?slug=${team.slug}`
+        url = `/api/v1/teams/slug/${team.slug}`
     } else {
         url = `/api/v1/teams/${team}`
     }

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -69,13 +69,65 @@ describe('Team API', function () {
 
     describe('Team API', function async () {
         describe('Get team details', async function () {
-            // GET /api/v1/teams/:teamId
-            // - Must be admin or team owner/member
+            it('admin can access any team', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('id', TestObjects.BTeam.hashid)
+            })
+            it('member can access team', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('id', TestObjects.BTeam.hashid)
+            })
+            it('non-member cannot access team', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                    cookies: { sid: TestObjects.tokens.chris }
+                })
+                response.statusCode.should.equal(404)
+            })
         })
 
         describe('Get team details by slug', async function () {
-            // GET /api/v1/teams/:teamId?slug=<teamSlug>
-            // - Must be admin or team owner/member
+            it('admin can access any team', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('id', TestObjects.BTeam.hashid)
+            })
+            it('member can access team', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
+                    cookies: { sid: TestObjects.tokens.bob }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('id', TestObjects.BTeam.hashid)
+            })
+            it('non-member cannot access team', async function () {
+                const response = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
+                    cookies: { sid: TestObjects.tokens.chris }
+                })
+                response.statusCode.should.equal(404)
+            })
         })
 
         describe('Get list of teams', async function () {

--- a/test/unit/frontend/api/team.spec.js
+++ b/test/unit/frontend/api/team.spec.js
@@ -71,7 +71,7 @@ describe('Team API', async () => {
         const teamslug = 'teamslug'
         TeamAPI.default.getTeam({ slug: teamslug })
         expect(mockGet).toHaveBeenCalledOnce()
-        expect(mockGet).toHaveBeenCalledWith('/api/v1/teams/?slug=' + teamslug)
+        expect(mockGet).toHaveBeenCalledWith('/api/v1/teams/slug/' + teamslug)
     })
 
     test('getTeam calls the correct API endpoint when provided a string', () => {


### PR DESCRIPTION
## Description

The `/api/v1/teams` endpoint served two purposes:

 - If `admin`, return a paginated list of teams on the platform
 - If `?slug=<slug>` is provided, provide details of the corresponding team - with the appropriate ACL checks

This overloading is not nice when it comes to documenting the API. This PR cleans things up by introducing a separate endpoint to get a team by its slug: `/api/v1/teams/slug/:teamSlug`.

Added unit test coverage of the new endpoint; the previous version was not explicitly covered.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

