### PR TITLE
add Control view restrictions of the Environment Variable values

### DIFF
--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -18,6 +18,7 @@ module.exports = async function (app) {
                 'team:user:invite:external': app.settings.get('team:user:invite:external') && app.postoffice.enabled(),
                 'team:create': app.settings.get('team:create'),
                 'user:tcs-required': app.settings.get('user:tcs-required'),
+                'team:environment-variable-view': app.settings.get('team:environment-variable-view'),
                 'user:tcs-url': app.settings.get('user:tcs-url'),
                 'user:tcs-date': app.settings.get('user:tcs-date'),
                 'user:team:trial-mode:projectType': app.settings.get('user:team:trial-mode:projectType'),

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -38,6 +38,9 @@ module.exports = {
     // Should we auto-create a team for a user when they register
     'user:team:auto-create': false,
 
+    //  can user's see environment variable
+    'team:environment-variable-view': false,
+
     // Can external users be invited to join teams
     'team:user:invite:external': false,
 

--- a/frontend/src/pages/admin/Settings/General.vue
+++ b/frontend/src/pages/admin/Settings/General.vue
@@ -80,6 +80,12 @@
                 <p>Administrators can always create teams.</p>
             </template>
         </FormRow>
+        <FormRow v-model="input['team:environment-variable-view']" type="checkbox" >
+            Allow users to see environment variable
+            <template #description>
+                User can see environment variable of the team
+            </template>
+        </FormRow>
         <FormRow v-model="input['team:user:invite:external']" type="checkbox" :disabled="errors.requiresEmail" :error="errors.requiresEmail">
             Allow users to invite external users to teams
             <template #description>
@@ -173,6 +179,7 @@ const validSettings = [
     'user:tcs-url',
     'user:tcs-date',
     'team:create',
+    'team:environment-variable-view',
     'team:user:invite:external',
     'telemetry:enabled',
     'user:team:trial-mode',

--- a/frontend/src/pages/admin/Template/sections/Environment.vue
+++ b/frontend/src/pages/admin/Template/sections/Environment.vue
@@ -25,23 +25,22 @@
                             :error="item.error"
                             :disabled="item.encrypted"
                             value-empty-text=""
-                            :type="(!readOnly && (editTemplate || item.policy === undefined)) ? 'text' : 'uneditable'"
-                        ></FormRow>
+                            :type="(!readOnly && (editTemplate || item.policy === undefined))?'text':'uneditable'"></FormRow>
+                        <!-- <ff-text-input  v-model="item.name" :disabled="item.encrypted"  /> -->
                     </td>
-                    <td class="px-4 py-4 border w-auto align-top" :class="{'align-middle': item.encrypted}">
-                        <div class="w-full" v-if="settings['team:environment-variable-view'] || user.admin">
+                    <td class="px-4 py-4 border w-auto align-top" :class="{'align-middle':item.encrypted}">
+                        <div class="w-full" v-if="(settings['team:environment-variable-view'] || user.admin) && (!item.encrypted)">
                             <FormRow
                                 class="font-mono"
                                 :inputClass="item.deprecated ? 'text-yellow-700 italic' : ''"
                                 v-model="item.value"
                                 value-empty-text=""
-                                :type="(!readOnly && (editTemplate || item.policy === undefined || item.policy)) ? 'text' : 'uneditable'"
-                            ></FormRow>
+                                :type="(!readOnly && (editTemplate || item.policy === undefined || item.policy))?'text':'uneditable'"></FormRow>
                         </div>
-                        <div v-else class="pt-1 text-gray-400">Hidden</div>
+                        <div v-else class="pt-1 text-gray-400"><LockClosedIcon class="inline w-4" /> encrypted</div>
                     </td>
                     <td class="border w-16 align-middle">
-                        <div v-if="(!readOnly && (editTemplate || item.policy === undefined))" class="flex justify-center ">
+                        <div v-if="(!readOnly && (editTemplate|| item.policy === undefined))" class="flex justify-center ">
                             <ff-button kind="tertiary" @click="removeEnv(itemIdx)" size="small">
                                 <template v-slot:icon>
                                     <TrashIcon />
@@ -51,8 +50,7 @@
                         <div
                             v-else-if="(item.deprecated === true)"
                             class="flex justify-center "
-                            v-ff-tooltip:left="'This setting has been deprecated'"
-                        >
+                            v-ff-tooltip:left="'This setting has been deprecated'">
                             <ExclamationIcon class="inline text-yellow-700 w-4" />
                         </div>
                         <div v-else-if="(item.platform === true)" class="flex justify-center ">
@@ -68,8 +66,9 @@
                         No Environment Variables Defined
                     </td>
                 </tr>
+                <!-- Empty row to differentiate between the existing env vars, and the input form row-->
                 <tr v-if="!readOnly">
-                    <td :colspan="editTemplate ? 4 : 3" class="p-4 bg-gray-50"></td>
+                    <td :colspan="editTemplate?4:3" class="p-4 bg-gray-50"></td>
                 </tr>
                 <tr v-if="!readOnly" class="">
                     <td class="px-4 pt-4 border w-auto align-top">
@@ -93,9 +92,11 @@
             </tbody>
         </table>
     </form>
+
 </template>
 
 <script>
+
 import { ExclamationIcon, LockClosedIcon, PlusSmIcon, TrashIcon } from '@heroicons/vue/outline'
 import { mapState } from 'vuex'
 
@@ -116,8 +117,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['team', 'settings']),
-        ...mapState('account', ['user', 'team', 'teams']),
+        ...mapState('account', ['user', 'settings']),
         editable: {
             get () { return this.modelValue },
             set (localValue) { this.$emit('update:modelValue', localValue) }
@@ -140,7 +140,7 @@ export default {
         },
         'editable' () {
             if (this.editable) {
-                this.editable.settings.env.forEach((field) => {
+                this.editable.settings.env.forEach(field => {
                     this.envVarNames[field.name] = field
                 })
             }
@@ -157,7 +157,11 @@ export default {
                         field.policy = false
                     }
                     if (field.policy === undefined && this.envVarNames[field.name] !== i) {
-                        field.policy = true
+                        field.error = 'Field has duplicate name'
+                    } else if (/ /.test(field.name)) {
+                        field.error = 'Invalid name'
+                    } else {
+                        field.error = ''
                     }
                 })
             }
@@ -165,17 +169,29 @@ export default {
     },
     methods: {
         addEnv () {
-            const env = { name: this.input.name, value: this.input.value }
-            this.editable.settings.env.push(env)
+            const field = {
+                index: 'add-' + this.addedCount++,
+                name: this.input.name,
+                value: this.input.value,
+                encrypted: this.input.encrypt,
+                policy: this.editTemplate ? false : undefined
+            }
+            this.envVarNames[field.name] = this.editable.settings.env.length
+            this.editable.settings.env.push(field)
             this.input.name = ''
+            this.input.encrypt = false
             this.input.value = ''
-            this.addedCount += 1
-            this.$emit('change', `added environment variable "${env.name}"`)
         },
-        removeEnv (idx) {
-            const env = this.editable.settings.env.splice(idx, 1)[0]
-            this.$emit('change', `removed environment variable "${env.name}"`)
+        removeEnv (index) {
+            const field = this.editable.settings.env[index]
+            delete this.envVarNames[field.name]
+            this.editable.settings.env.splice(index, 1)
         }
+    },
+    mounted () {
+        this.editable.settings.env.forEach(field => {
+            this.envVarNames[field.name] = field
+        })
     },
     components: {
         FormRow,

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -98,6 +98,68 @@ describe('FlowForge - Applications', () => {
         })
     })
 
+    it('Verify visibility of environment variable values based on user permissions', () => {
+        // allow user to see environment variable values and before allowing check admin is able to see environment variable values when permission is disabled
+        cy.home()
+        cy.get(':nth-child(1) > .ff-applications-list-instances > :nth-child(2)').click()
+        cy.url().then(url => {
+            const urlSplitedArray = url.split('/')
+            cy.visit(`/instance/${urlSplitedArray[4]}/settings/general`)
+        })
+        cy.get('[data-nav="environment"]').click()
+        cy.get(':nth-child(1) > :nth-child(2) > :nth-child(1) > .max-w-sm > .flex > .w-full').should('not.contain', '  encrypted')
+        cy.home()
+        cy.visit('/admin/settings/general')
+        cy.get('#formRow-instance-6 > .checkbox').click()
+        cy.get('[data-action="save-settings"]').click()
+        cy.home()
+
+        cy.logout()
+
+        // login as user and check environment variable values are visible
+
+        cy.login('bob', 'bbPassword')
+        cy.home()
+        cy.get(':nth-child(1) > .ff-applications-list-instances > :nth-child(2)').click()
+        cy.url().then(url => {
+            const urlSplitedArray = url.split('/')
+            cy.visit(`/instance/${urlSplitedArray[4]}/settings/general`)
+        })
+        cy.get('[data-nav="environment"]').click()
+        cy.get(':nth-child(1) > :nth-child(2) > .pt-1').should('not.contain', '  encrypted')
+
+        cy.logout()
+
+        // check admin can see environment variable values or not and disable environment variable value visiblity for user
+
+        cy.login('alice', 'aaPassword')
+        cy.home()
+        cy.get(':nth-child(1) > .ff-applications-list-instances > :nth-child(2)').click()
+        cy.url().then(url => {
+            const urlSplitedArray = url.split('/')
+            cy.visit(`/instance/${urlSplitedArray[4]}/settings/general`)
+        })
+        cy.get('[data-nav="environment"]').click()
+        cy.get(':nth-child(1) > :nth-child(2) > :nth-child(1) > .max-w-sm > .flex > .w-full').should('not.contain', '  encrypted')
+        cy.home()
+        cy.visit('/admin/settings/general')
+        cy.get('#formRow-instance-6 > .checkbox').click()
+        cy.get('[data-action="save-settings"]').click()
+
+        cy.logout()
+
+        // check user cannot see environment variable values when permission is disabled
+        cy.login('bob', 'bbPassword')
+        cy.home()
+        cy.get(':nth-child(1) > .ff-applications-list-instances > :nth-child(2)').click()
+        cy.url().then(url => {
+            const urlSplitedArray = url.split('/')
+            cy.visit(`/instance/${urlSplitedArray[4]}/settings/general`)
+        })
+        cy.get('[data-nav="environment"]').click()
+        cy.get(':nth-child(1) > :nth-child(2) > .pt-1').contains(' encrypted')
+    })
+
     it('can be viewed', () => {
         cy.intercept('GET', '/api/*/applications/*').as('getApplication')
 


### PR DESCRIPTION
## Description

Added feature to control view restrictions of Environment Variable values

- Implemented a new feature that allows administrators to control the view restrictions of Environment Variable values.
- If the user is an admin, they now have the ability to see and control the view restrictions of the Environment Variable values.
- The feature enhances the existing functionality by providing fine-grained control over who can view the values of    Environment Variables.
- This feature helps improve security and privacy by limiting access to sensitive environment information.

https://github.com/flowforge/flowforge/assets/110285294/30613382-8aaa-46ce-b0c5-7bf656f14da2



closes #2289

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

