### PR TITLE
Refector application collection endpoints to not return full Instance objects

### DIFF
--- a/forge/db/views/Application.js
+++ b/forge/db/views/Application.js
@@ -33,14 +33,14 @@ module.exports = {
         }
     },
     async teamApplicationList (app, applications, { includeInstances = false } = {}) {
-        return await Promise.all(applications.map(async (application) => {
+        return applications.map((application) => {
             const summary = app.db.views.Application.applicationSummary(application)
             if (includeInstances) {
-                summary.instances = await app.db.views.Project.instancesList(application.Instances)
+                summary.instances = app.db.views.Project.instancesSummaryList(application.Instances)
             }
 
             return summary
-        }))
+        })
     },
     async instanceStatuses (app, instancesArray) {
         return await Promise.all(instancesArray.map(async (instance) => {

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -93,7 +93,6 @@ module.exports = {
     },
     instancesSummaryList: function (app, instancesArray) {
         return instancesArray.map((instance) => {
-            // Full settings are not
             const result = app.db.views.Project.projectSummary(instance)
             if (!result.url) {
                 delete result.url

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -80,7 +80,7 @@ module.exports = {
         return result
     },
     instancesList: async function (app, instancesArray) {
-        return await Promise.all(instancesArray.map(async (instance) => {
+        return Promise.all(instancesArray.map(async (instance) => {
             // Full settings are not
             const result = await app.db.views.Project.project(instance, { includeSettings: true })
 
@@ -91,14 +91,38 @@ module.exports = {
             return result
         }))
     },
+    instancesSummaryList: function (app, instancesArray) {
+        return instancesArray.map((instance) => {
+            // Full settings are not
+            const result = app.db.views.Project.projectSummary(instance)
+            if (!result.url) {
+                delete result.url
+            }
+            return result
+        })
+    },
     projectSummary: function (app, project) {
-        return {
+        const result = {
             id: project.id,
             name: project.name,
+            url: project.url,
             createdAt: project.createdAt,
             updatedAt: project.updatedAt,
             links: project.links
         }
+        const settingsSettingsRow = project.ProjectSettings?.find((projectSettingsRow) => projectSettingsRow.key === KEY_SETTINGS)
+        if (settingsSettingsRow) {
+            if (Object.hasOwn(settingsSettingsRow?.value, 'disableEditor')) {
+                result.settings = {
+                    disableEditor: settingsSettingsRow.value.disableEditor
+                }
+            }
+        }
+        if (app.config.features.enabled('ha')) {
+            const settingsHARow = project.ProjectSettings?.find(row => row.key === KEY_HA)
+            result.ha = settingsHARow?.value || { disabled: true }
+        }
+        return result
     },
     userProjectList: function (app, projectList) {
         return projectList.map((t) => {

--- a/forge/routes/api/application.js
+++ b/forge/routes/api/application.js
@@ -155,7 +155,7 @@ module.exports = async function (app) {
         // Settings needed to be able to include the project URL in the response
         const instances = await app.db.models.Project.byApplication(request.application.hashid, { includeSettings: true })
         if (instances) {
-            let result = await app.db.views.Project.instancesList(instances)
+            let result = await app.db.views.Project.instancesSummaryList(instances)
             if (request.session.ownerType === 'project') {
                 // This request is from a project token. Filter the list to return
                 // the minimal information needed

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -57,7 +57,7 @@
                             <InstanceEditorLinkCell
                                 :id="instance.id"
                                 :url="instance.url"
-                                :editorDisabled="instance.settings.disableEditor"
+                                :editorDisabled="!!(instance.settings?.disableEditor)"
                                 :disabled="instance.meta?.state !== 'running'"
                                 :isHA="instance.ha?.replicas !== undefined"
                             />


### PR DESCRIPTION
## Description

A pair of end points that return lists of Applications and their instances was including the *full* instance object. This is was far more information than was needed.

This PR changes those endpoints to run an `InstanceSummary` view which is the minimum information needed for list views.

Affected endpoints:
 - `/api/v1/application/:id/instances`
 - `/api/v1/teams/:teamId/applications`

I have verified all of the users of these endpoints in the UI work with these summaries.

Work to document these changes will happen as part of the api doc work in #1556 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

