### PR TITLE
Add trial user E2E Testing & ensure redirect correct after creating first application

### DIFF
--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div data-el="empty-state">
         <FeatureUnavailable v-if="featureUnavailable" />
         <div
             class="ff-empty-state" :class="{'ff-empty-state-feature-unavailable': featureUnavailable}"

--- a/frontend/src/pages/application/Overview.vue
+++ b/frontend/src/pages/application/Overview.vue
@@ -11,6 +11,7 @@
             </template>
             <template #tools>
                 <ff-button
+                    data-action="create-instance"
                     :to="{ name: 'ApplicationCreateInstance' }"
                 >
                     <template #icon-left><PlusSmIcon /></template>

--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -138,7 +138,6 @@ export default {
                 return
             }
 
-            this.loading = false
             this.$router.push({ name: 'Application', params: { id: this.application.id } })
         },
         createApplication (applicationDetails) {

--- a/test/e2e/frontend/cypress/tests-ee/trials.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/trials.spec.js
@@ -1,0 +1,49 @@
+describe('FlowForge - Trial Users', () => {
+    beforeEach(() => {
+        cy.login('terry', 'ttPassword')
+        cy.home()
+    })
+
+    it('are informed of their trial status', () => {
+        cy.get('[data-el="banner-team-trial"]').should('exist')
+    })
+
+    it('should be presented with an empty state on the Applications view', () => {
+        cy.get('[data-el="empty-state"] [data-action="create-application"]').click()
+    })
+
+    it('are redirected to their (first) newly created application', () => {
+        const APPLICATION_NAME = `new-application-${Math.random().toString(36).substring(2, 7)}`
+        const INSTANCE_NAME = `new-instance-${Math.random().toString(36).substring(2, 7)}`
+
+        cy.intercept('POST', '/api/*/applications').as('createApplication')
+        cy.intercept('POST', '/api/*/projects').as('createInstance')
+
+        cy.get('[data-el="empty-state"] [data-action="create-application"]').click()
+
+        cy.get('[data-action="create-project"]').should('be.disabled')
+
+        cy.get('[data-form="application-name"] input').clear()
+        cy.get('[data-form="application-name"] input').type(APPLICATION_NAME)
+
+        // Pre-fills instance name
+        cy.get('[data-form="project-name"] input').should(($input) => {
+            const projectName = $input.val()
+            expect(projectName.length).to.be.above(0)
+        })
+
+        cy.get('[data-form="project-name"] input').clear()
+        cy.get('[data-form="project-name"] input').type(INSTANCE_NAME)
+
+        cy.get('[data-action="create-project"]').should('not.be.disabled').click()
+
+        cy.url().should('include', '/instances')
+    })
+
+    it('cannot create a second instance', () => {
+        cy.get('[data-action="view-application"]').click()
+        cy.get('[data-action="create-instance"]').click()
+
+        cy.url().should('include', 'team/tteam/billing')
+    })
+})

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -91,7 +91,7 @@ module.exports = async function (settings = {}, config = {}) {
     // Application and Instances
     const application1 = await factory.createApplication({ name: 'application-1' }, team1)
     await factory.createInstance({ name: 'instance-1-1' }, application1, stack, template, projectType)
-    // await factory.createInstance({ name: 'instance-1-2' }, application1, stack, template, projectType)
+    await factory.createInstance({ name: 'instance-1-2' }, application1, stack, template, projectType)
 
     /// Team 2
     const team2 = await factory.createTeam({ name: 'BTeam' })

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -1,4 +1,5 @@
 const TestModelFactory = require('../../../lib/TestModelFactory')
+const StripeMock = require('../../../lib/stripeMock.js')
 
 const FF_UTIL = require('flowforge-test-utils')
 const Forge = FF_UTIL.require('forge/forge.js')
@@ -25,11 +26,31 @@ module.exports = async function (settings = {}, config = {}) {
         }
     }
 
+    // mock out stripe JS library
+    if (config.billing) {
+        StripeMock({
+            teams: {
+                starter: {
+                    product: 'starterteamprod',
+                    price: 'starterteampprice'
+                }
+            }
+        })
+    }
+
     const forge = await Forge({ config })
     await forge.settings.set('setup:initialised', true)
     const factory = new TestModelFactory(forge)
 
-    /// Create users
+    const projectType = await factory.createProjectType({ name: 'type1' })
+    // configure trial mode
+    if (settings.trialMode) {
+        forge.settings.set('user:team:trial-mode', true)
+        forge.settings.set('user:team:trial-mode:duration', 5)
+        forge.settings.set('user:team:trial-mode:projectType', projectType.hashid)
+    }
+
+    // Create users
     // full platform & team1 admin
     const userAlice = await factory.createUser({ admin: true, username: 'alice', name: 'Alice Skywalker', email: 'alice@example.com', email_verified: true, password: 'aaPassword' })
 
@@ -45,7 +66,6 @@ module.exports = async function (settings = {}, config = {}) {
 
     // Platform Setup
     const template = await factory.createProjectTemplate({ name: 'template1' }, userAlice)
-    const projectType = await factory.createProjectType({ name: 'type1' })
     const stack = await factory.createStack({ name: 'stack1' }, projectType)
     await factory.createStack({ name: 'stack2' }, projectType)
 
@@ -62,10 +82,16 @@ module.exports = async function (settings = {}, config = {}) {
     // Create a pending invite for Dave to join ATeam
     await factory.createInvitation(team1, userAlice, userDave)
 
+    // Add subscription to ATeam if Billing enabled
+    // Must do this before Instance creation
+    if (config.billing) {
+        await factory.createSubscription(team1)
+    }
+
     // Application and Instances
     const application1 = await factory.createApplication({ name: 'application-1' }, team1)
     await factory.createInstance({ name: 'instance-1-1' }, application1, stack, template, projectType)
-    await factory.createInstance({ name: 'instance-1-2' }, application1, stack, template, projectType)
+    // await factory.createInstance({ name: 'instance-1-2' }, application1, stack, template, projectType)
 
     /// Team 2
     const team2 = await factory.createTeam({ name: 'BTeam' })
@@ -73,6 +99,11 @@ module.exports = async function (settings = {}, config = {}) {
 
     // Create pending invite for Dave to join BTeam
     await factory.createInvitation(team2, userBob, userDave)
+
+    // Add subscription to ATeam if Billing enabled
+    if (config.billing) {
+        await factory.createSubscription(team2)
+    }
 
     // Unassigned devices
     await factory.createDevice({ name: 'team2-unassigned-device', type: 'type2' }, team2)
@@ -88,6 +119,9 @@ module.exports = async function (settings = {}, config = {}) {
     await factory.createSnapshot({ name: 'snapshot 1' }, instanceWithDevices, userBob)
     await factory.createSnapshot({ name: 'snapshot 2' }, instanceWithDevices, userBob)
     await factory.createSnapshot({ name: 'snapshot 3' }, instanceWithDevices, userBob)
+
+    forge.teams = [team1, team2]
+    forge.projectTypes = [projectType, spareProjectType]
 
     return forge
 }

--- a/test/e2e/frontend/test_environment_ee.js
+++ b/test/e2e/frontend/test_environment_ee.js
@@ -1,16 +1,50 @@
 /* eslint-disable n/no-process-exit */
 'use strict'
 
+const TestModelFactory = require('../../lib/TestModelFactory')
+
 const app = require('./environments/standard')
+
+const FF_UTIL = require('flowforge-test-utils')
+const { Roles } = FF_UTIL.require('forge/lib/roles')
 
 ;(async function () {
     const PORT = 3002
 
-    const flowforge = await app({}, {
+    const flowforge = await app({
+        trialMode: true
+    }, {
         license: 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwiZGV2Ijp0cnVlLCJpYXQiOjE2NjI0ODI5ODd9.e8Jeppq4aURwWYz-rEpnXs9RY2Y7HF7LJ6rMtMZWdw2Xls6-iyaiKV1TyzQw5sUBAhdUSZxgtiFH5e_cNJgrUg',
         host: 'localhost',
-        port: PORT
+        port: PORT,
+        billing: {
+            stripe: {
+                key: 1234,
+                team_product: 'defaultteamprod',
+                team_price: 'defaultteamprice',
+                new_customer_free_credit: 1000,
+                teams: {
+                    starter: {
+                        product: 'starterteamprod',
+                        price: 'starterteampprice'
+                    }
+                }
+            }
+        }
     })
+
+    const factory = new TestModelFactory(flowforge)
+
+    // setup team
+    const trialTeam = await factory.createTeam({ name: 'TTeam' })
+    // create trial subscription for the team
+    await factory.createTrialSubscription(trialTeam, 5)
+
+    // setup user
+    const userTerry = await factory.createUser({ username: 'terry', name: 'Terry Organa', email: 'terry@example.com', password: 'ttPassword', email_verified: true, password_expired: false })
+
+    await trialTeam.addUser(userTerry, { through: { role: Roles.Owner } })
+    // assign user to the trial team
 
     flowforge.listen(PORT, function (err, address) {
         console.info(`EE Environment running at http://localhost:${PORT}`)

--- a/test/lib/stripeMock.js
+++ b/test/lib/stripeMock.js
@@ -1,0 +1,92 @@
+const sinon = require('sinon')
+
+module.exports = (testSpecificMock = {}) => {
+    let stripeData = {}
+    let stripeItems = {}
+    let stripeItemCounter = 0
+    const sandbox = sinon.createSandbox()
+    const mock = {
+        _: {
+            data: stripeData,
+            items: stripeItems
+        },
+        checkout: {
+            sessions: {
+                create: sub => JSON.parse(JSON.stringify(sub))
+            }
+        },
+        customers: {
+            createBalanceTransaction: sandbox.stub().resolves({ status: 'ok' })
+        },
+        subscriptions: {
+            create: (subId) => {
+                if (!stripeData[subId]) {
+                    stripeData[subId] = { metadata: {}, items: { data: [] } }
+                }
+            },
+            retrieve: sandbox.stub().callsFake(async function (subId) {
+                if (!stripeData[subId]) {
+                    stripeData[subId] = { metadata: {}, items: { data: [] } }
+                }
+                return stripeData[subId]
+            }),
+            update: sandbox.stub().callsFake(async function (subId, update) {
+                if (!stripeData[subId]) {
+                    throw new Error('unknown subscription')
+                }
+                if (update.metadata) {
+                    stripeData[subId].metadata = update.metadata
+                }
+                // This is the initial add of an item
+                if (update.items) {
+                    update.items.forEach(item => {
+                        item.id = `item-${stripeItemCounter++}`
+                        item.plan = {
+                            product: (item.price || 'price').replace('price', 'product')
+                        }
+                        stripeItems[item.id] = item
+                    })
+                    stripeData[subId].items = {
+                        data: update.items
+                    }
+                }
+            })
+        },
+        subscriptionItems: {
+            update: sandbox.stub().callsFake(async function (itemId, update) {
+                if (!stripeItems[itemId]) {
+                    throw new Error('unknown item')
+                }
+                for (const [key, value] of Object.entries(update)) {
+                    stripeItems[itemId][key] = value
+                }
+            })
+        },
+        promotionCodes: {
+            list: async opts => {
+                if (opts.code === 'KNOWN_CODE') {
+                    return { data: [{ id: 'knownCodeId' }] }
+                }
+                return { data: [] }
+            }
+        },
+        ...testSpecificMock
+    }
+
+    require.cache[require.resolve('stripe')] = {
+        exports: function (apiKey) {
+            return mock
+        }
+    }
+
+    mock.clear = () => {
+        stripeData = {}
+        stripeItems = {}
+        stripeItemCounter = 0
+        mock._.data = stripeData
+        mock._.items = stripeItems
+        sandbox.resetHistory()
+    }
+
+    return mock
+}

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -1,5 +1,3 @@
-const sinon = require('sinon')
-
 const TestModelFactory = require('../../../lib/TestModelFactory')
 const StripeMock = require('../../../lib/stripeMock')
 

--- a/test/unit/forge/ee/setup.js
+++ b/test/unit/forge/ee/setup.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon')
 
 const TestModelFactory = require('../../../lib/TestModelFactory')
+const StripeMock = require('../../../lib/stripeMock')
 
 const FF_UTIL = require('flowforge-test-utils')
 
@@ -77,96 +78,7 @@ async function setup (config = {}) {
     return forge
 }
 
-setup.setupStripe = (testSpecificMock = {}) => {
-    let stripeData = {}
-    let stripeItems = {}
-    let stripeItemCounter = 0
-    const sandbox = sinon.createSandbox()
-
-    const mock = {
-        _: {
-            data: stripeData,
-            items: stripeItems
-        },
-        checkout: {
-            sessions: {
-                create: sub => JSON.parse(JSON.stringify(sub))
-            }
-        },
-        customers: {
-            createBalanceTransaction: sandbox.stub().resolves({ status: 'ok' })
-        },
-        subscriptions: {
-            create: (subId) => {
-                if (!stripeData[subId]) {
-                    stripeData[subId] = { metadata: {}, items: { data: [] } }
-                }
-            },
-            retrieve: sandbox.stub().callsFake(async function (subId) {
-                if (!stripeData[subId]) {
-                    stripeData[subId] = { metadata: {}, items: { data: [] } }
-                }
-                return stripeData[subId]
-            }),
-            update: sandbox.stub().callsFake(async function (subId, update) {
-                if (!stripeData[subId]) {
-                    throw new Error('unknown subscription')
-                }
-                if (update.metadata) {
-                    stripeData[subId].metadata = update.metadata
-                }
-                // This is the initial add of an item
-                if (update.items) {
-                    update.items.forEach(item => {
-                        item.id = `item-${stripeItemCounter++}`
-                        item.plan = {
-                            product: item.price.replace('price', 'product')
-                        }
-                        stripeItems[item.id] = item
-                    })
-                    stripeData[subId].items = {
-                        data: update.items
-                    }
-                }
-            })
-        },
-        subscriptionItems: {
-            update: sandbox.stub().callsFake(async function (itemId, update) {
-                if (!stripeItems[itemId]) {
-                    throw new Error('unknown item')
-                }
-                for (const [key, value] of Object.entries(update)) {
-                    stripeItems[itemId][key] = value
-                }
-            })
-        },
-        promotionCodes: {
-            list: async opts => {
-                if (opts.code === 'KNOWN_CODE') {
-                    return { data: [{ id: 'knownCodeId' }] }
-                }
-                return { data: [] }
-            }
-        },
-        ...testSpecificMock
-    }
-
-    require.cache[require.resolve('stripe')] = {
-        exports: function (apiKey) {
-            return mock
-        }
-    }
-
-    mock.clear = () => {
-        stripeData = {}
-        stripeItems = {}
-        stripeItemCounter = 0
-        mock._.data = stripeData
-        mock._.items = stripeItems
-        sandbox.resetHistory()
-    }
-    return mock
-}
+setup.setupStripe = StripeMock
 setup.resetStripe = () => {
     delete require.cache[require.resolve('stripe')]
 }


### PR DESCRIPTION
## Description

- Removes unnecessary `loading = false` just before the redirect, as that was triggering a re-mount of the `InstanceForm` and in turn redirecting to `/billing`
- Adds testing infrastructure for checking platform state with trial users.
    - Moves the stripe mocking into a central location for forge unit tests, and the new `ee` E2E tests.
    - Adds a new `terry` user who will be a user on trial for 5 days.
    - Adds tests to ensure message is shown when Terry logs in, that they can create an Application/Instance and that they're redirected to /billing when trying to create a second

## Related Issue(s)

Closes #2285

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->