### PR TITLE
Add schemas to all /project/ routes

### DIFF
--- a/forge/db/views/AccessToken.js
+++ b/forge/db/views/AccessToken.js
@@ -1,5 +1,25 @@
-module.exports = {
-    provisioningTokenSummary: async function (app, token) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'ProvisioningTokenSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            team: { type: 'string', nullable: true },
+            project: { type: 'string' },
+            expiresAt: { type: 'string', nullable: true },
+            targetSnapshot: { type: 'string' }
+        }
+    })
+    app.addSchema({
+        $id: 'ProvisioningToken',
+        type: 'object',
+        allOf: [{ $ref: 'ProvisioningTokenSummary' }],
+        properties: {
+            token: { type: 'string' }
+        }
+    })
+    async function provisioningTokenSummary (token) {
         // build a tokenSummary object from the token
         const tokenSummary = {
             id: token.hashid,
@@ -27,5 +47,8 @@ module.exports = {
             }
         }
         return tokenSummary
+    }
+    return {
+        provisioningTokenSummary
     }
 }

--- a/forge/db/views/Application.js
+++ b/forge/db/views/Application.js
@@ -79,25 +79,6 @@ module.exports = function (app) {
     }
 
     app.addSchema({
-        $id: 'InstanceStatusList',
-        type: 'array',
-        items: {
-            type: 'object',
-            properties: {
-                id: { type: 'string' },
-                state: { type: 'object', additionalProperties: true }
-            },
-            additionalProperties: true
-        }
-    })
-    async function instanceStatusList (instancesArray) {
-        return await Promise.all(instancesArray.map(async (instance) => {
-            const state = await instance.liveState()
-            return { id: instance.id, ...state }
-        }))
-    }
-
-    app.addSchema({
         $id: 'ApplicationInstanceStatusList',
         type: 'array',
         items: {
@@ -114,7 +95,7 @@ module.exports = function (app) {
         return Promise.all(applicationsArray.map(async (application) => {
             return {
                 id: application.hashid,
-                instances: await instanceStatusList(application.Instances)
+                instances: await app.db.views.Project.instanceStatusList(application.Instances)
             }
         }))
     }
@@ -122,7 +103,6 @@ module.exports = function (app) {
     return {
         application,
         applicationInstanceStatusList,
-        instanceStatusList,
         teamApplicationList,
         applicationSummary
     }

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -8,8 +8,8 @@ module.exports = function (app) {
             type: { type: 'string' },
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' },
-            lastSeenAt: { type: 'string' },
-            lastSeenMs: { type: 'number' },
+            lastSeenAt: { nullable: true, type: 'string' },
+            lastSeenMs: { nullable: true, type: 'number' },
             activeSnapshot: {
                 nullable: true,
                 allOf: [{ $ref: 'SnapshotSummary' }]

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -1,5 +1,35 @@
-module.exports = {
-    device: function (app, device, options) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'Device',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            type: { type: 'string' },
+            createdAt: { type: 'string' },
+            updatedAt: { type: 'string' },
+            lastSeenAt: { type: 'string' },
+            lastSeenMs: { type: 'number' },
+            activeSnapshot: {
+                nullable: true,
+                allOf: [{ $ref: 'SnapshotSummary' }]
+            },
+            targetSnapshot: {
+                nullable: true,
+                allOf: [{ $ref: 'SnapshotSummary' }]
+            },
+            status: { type: 'string' },
+            agentVersion: { type: 'string' },
+            mode: { type: 'string' },
+            links: { $ref: 'LinksMeta' },
+            team: { $ref: 'TeamSummary' },
+            project: { $ref: 'InstanceSummary' },
+            application: { $ref: 'ApplicationSummary' },
+            editor: { type: 'object', additionalProperties: true }
+        }
+    })
+
+    function device (device, options) {
         if (!device) {
             return null
         }
@@ -15,8 +45,8 @@ module.exports = {
             updatedAt: result.updatedAt,
             lastSeenAt: result.lastSeenAt,
             lastSeenMs: result.lastSeenAt ? (Date.now() - new Date(result.lastSeenAt).valueOf()) : null,
-            activeSnapshot: app.db.views.ProjectSnapshot.snapshot(device.activeSnapshot),
-            targetSnapshot: app.db.views.ProjectSnapshot.snapshot(device.targetSnapshot),
+            activeSnapshot: app.db.views.ProjectSnapshot.snapshotSummary(device.activeSnapshot),
+            targetSnapshot: app.db.views.ProjectSnapshot.snapshotSummary(device.targetSnapshot),
             links: result.links,
             status: result.state || 'offline',
             agentVersion: result.agentVersion,
@@ -37,9 +67,18 @@ module.exports = {
             filtered.editor = tunnelManager.getTunnelStatus(result.hashid) || {}
         }
         return filtered
-    },
-
-    deviceSummary: function (app, device) {
+    }
+    app.addSchema({
+        $id: 'DeviceSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            type: { type: 'string' },
+            links: { $ref: 'LinksMeta' }
+        }
+    })
+    function deviceSummary (device) {
         if (device) {
             const result = device.toJSON()
             const filtered = {
@@ -52,5 +91,10 @@ module.exports = {
         } else {
             return null
         }
+    }
+
+    return {
+        device,
+        deviceSummary
     }
 }

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
             hostname: { type: 'string' },
             application: { $ref: 'ApplicationSummary' },
             team: { $ref: 'TeamSummary' },
-            projectType: { $ref: 'ProjectTypeSummary' },
+            projectType: { $ref: 'InstanceTypeSummary' },
             settings: {
                 type: 'object',
                 additionalProperties: true

--- a/forge/db/views/ProjectSnapshot.js
+++ b/forge/db/views/ProjectSnapshot.js
@@ -1,5 +1,18 @@
-module.exports = {
-    snapshot: function (app, snapshot) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'Snapshot',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            description: { type: 'string' },
+            createdAt: { type: 'string' },
+            updatedAt: { type: 'string' },
+            user: { $ref: 'UserSummary' },
+            modules: { type: 'object', additionalProperties: true }
+        }
+    })
+    function snapshot (snapshot) {
         if (snapshot) {
             const result = snapshot.toJSON()
             const filtered = {
@@ -19,5 +32,32 @@ module.exports = {
         } else {
             return null
         }
+    }
+    app.addSchema({
+        $id: 'SnapshotSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            description: { type: 'string' }
+        }
+    })
+    function snapshotSummary (snapshot) {
+        if (snapshot) {
+            const result = snapshot.toJSON()
+            const filtered = {
+                id: result.hashid,
+                name: result.name,
+                description: result.description || ''
+            }
+            return filtered
+        } else {
+            return null
+        }
+    }
+
+    return {
+        snapshot,
+        snapshotSummary
     }
 }

--- a/forge/db/views/ProjectStack.js
+++ b/forge/db/views/ProjectStack.js
@@ -1,5 +1,22 @@
-module.exports = {
-    stack: function (app, stack, includeCount) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'Stack',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            label: { type: 'string' },
+            active: { type: 'boolean' },
+            projectType: { type: 'string' },
+            properties: { type: 'object', additionalProperties: true },
+            replacedBy: { type: 'string' },
+            createdAt: { type: 'string' },
+            projectCount: { type: 'number' },
+            links: { $ref: 'LinksMeta' }
+        }
+    })
+
+    function stack (stack, includeCount) {
         if (stack) {
             const result = stack.toJSON()
             const filtered = {
@@ -10,7 +27,8 @@ module.exports = {
                 projectType: app.db.models.ProjectType.encodeHashid(result.ProjectTypeId) || undefined,
                 properties: result.properties || {},
                 replacedBy: app.db.models.ProjectStack.encodeHashid(result.replacedBy) || undefined,
-                createdAt: result.createdAt
+                createdAt: result.createdAt,
+                links: stack.links
             }
             if (includeCount) {
                 filtered.projectCount = parseInt(result.projectCount) || 0
@@ -19,5 +37,35 @@ module.exports = {
         } else {
             return null
         }
+    }
+
+    app.addSchema({
+        $id: 'StackSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            label: { type: 'string' },
+            properties: { type: 'object', additionalProperties: true },
+            replacedBy: { type: 'string' },
+            links: { $ref: 'LinksMeta' }
+        }
+    })
+    function stackSummary (stack) {
+        if (stack.toJSON) {
+            stack = stack.toJSON()
+        }
+        return {
+            id: stack.hashid,
+            name: stack.name,
+            label: stack.label,
+            properties: stack.properties || {},
+            replacedBy: app.db.models.ProjectStack.encodeHashid(stack.replacedBy) || undefined,
+            links: stack.links
+        }
+    }
+    return {
+        stack,
+        stackSummary
     }
 }

--- a/forge/db/views/ProjectTemplate.js
+++ b/forge/db/views/ProjectTemplate.js
@@ -1,14 +1,22 @@
-module.exports = {
-    template: function (app, template) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'Template',
+        type: 'object',
+        allOf: [{ $ref: 'TemplateSummary' }],
+        properties: {
+            settings: { type: 'object', additionalProperties: true },
+            policy: { type: 'object', additionalProperties: true }
+        }
+    })
+    function template (template) {
         if (template) {
             const result = template.toJSON()
             const filtered = {
                 id: result.hashid,
-                // template: result.templateId,
-                // revision: result.revision,
                 name: result.name,
                 description: result.description,
                 active: result.active,
+                projectCount: result.projectCount,
                 settings: result.settings || {},
                 policy: result.policy || {},
                 createdAt: result.createdAt,
@@ -25,14 +33,26 @@ module.exports = {
         } else {
             return null
         }
-    },
-    templateSummary: function (app, template) {
+    }
+    app.addSchema({
+        $id: 'TemplateSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            description: { type: 'string' },
+            active: { type: 'boolean' },
+            projectCount: { type: 'number' },
+            createdAt: { type: 'string' },
+            links: { $ref: 'LinksMeta' },
+            owner: { $ref: 'UserSummary' }
+        }
+    })
+    function templateSummary (template) {
         if (template) {
             const result = template.toJSON()
             const filtered = {
                 id: result.hashid,
-                // template: result.templateId,
-                // revision: result.revision,
                 name: result.name,
                 description: result.description,
                 active: result.active,
@@ -47,5 +67,9 @@ module.exports = {
         } else {
             return null
         }
+    }
+    return {
+        template,
+        templateSummary
     }
 }

--- a/forge/db/views/ProjectType.js
+++ b/forge/db/views/ProjectType.js
@@ -1,6 +1,6 @@
 module.exports = function (app) {
     app.addSchema({
-        $id: 'ProjectTypeSummary',
+        $id: 'InstanceTypeSummary',
         type: 'object',
         properties: {
             id: { type: 'string' },
@@ -16,6 +16,23 @@ module.exports = function (app) {
             name: projectType.name
         }
     }
+    app.addSchema({
+        $id: 'InstanceType',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            active: { type: 'boolean' },
+            description: { type: 'string' },
+            order: { type: 'number' },
+            properties: { type: 'object', additionalProperties: true },
+            createdAt: { type: 'string' },
+            defaultStack: { type: 'string', nullable: true },
+            projectCount: { type: 'number' },
+            stackCount: { type: 'number' }
+
+        }
+    })
     function projectType (projectType, includeCount) {
         if (projectType) {
             const result = projectType.toJSON()

--- a/forge/db/views/ProjectType.js
+++ b/forge/db/views/ProjectType.js
@@ -1,5 +1,22 @@
-module.exports = {
-    projectType: function (app, projectType, includeCount) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'ProjectTypeSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' }
+        }
+    })
+    function projectTypeSummary (projectType) {
+        if (projectType.toJSON) {
+            projectType = projectType.toJSON()
+        }
+        return {
+            id: projectType.hashid,
+            name: projectType.name
+        }
+    }
+    function projectType (projectType, includeCount) {
         if (projectType) {
             const result = projectType.toJSON()
             const filtered = {
@@ -20,5 +37,9 @@ module.exports = {
         } else {
             return null
         }
+    }
+    return {
+        projectType,
+        projectTypeSummary
     }
 }

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -39,6 +39,7 @@ module.exports = async (options = {}) => {
         loggerLevel = options.config.logging.level || 'info'
     }
     const server = fastify({
+        forceCloseConnections: true,
         bodyLimit: 5242880,
         maxParamLength: 500,
         trustProxy: true,

--- a/forge/routes/api-docs.js
+++ b/forge/routes/api-docs.js
@@ -4,7 +4,7 @@ const path = require('path')
 const fp = require('fastify-plugin')
 module.exports = fp(async function (app, opts, done) {
     await app.register(require('@fastify/swagger'), {
-        swagger: {
+        openapi: {
             info: {
                 title: 'FlowForge Platform API',
                 description: 'API documentation for interacting with the FlowForge platform',

--- a/forge/routes/api/application.js
+++ b/forge/routes/api/application.js
@@ -310,7 +310,7 @@ module.exports = async function (app) {
     }, async (request, reply) => {
         const instances = await app.db.models.Project.byApplication(request.application.hashid)
         if (instances) {
-            const instanceStatuses = await app.db.views.Application.instanceStatusList(instances)
+            const instanceStatuses = await app.db.views.Project.instanceStatusList(instances)
             reply.send({
                 count: instanceStatuses.length,
                 instances: instanceStatuses

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -9,9 +9,30 @@
  * @memberof forge.routes.api
  */
 module.exports = async function (app) {
-    const changeStatusPreHandler = { preHandler: app.needsPermission('project:change-status') }
-
-    app.post('/start', changeStatusPreHandler, async (request, reply) => {
+    app.post('/start', {
+        preHandler: app.needsPermission('project:change-status'),
+        schema: {
+            summary: 'Start an instance',
+            tags: ['Instance Actions'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                },
+                500: {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
                 if (app.license.active() && app.billing) {
@@ -42,7 +63,7 @@ module.exports = async function (app) {
                 await app.auditLog.Project.project.started(request.session.User, null, request.project)
                 app.db.controllers.Project.clearInflightState(request.project)
             }
-            reply.send()
+            reply.send({ status: 'okay' })
         } catch (err) {
             app.db.controllers.Project.clearInflightState(request.project)
 
@@ -52,7 +73,30 @@ module.exports = async function (app) {
         }
     })
 
-    app.post('/stop', changeStatusPreHandler, async (request, reply) => {
+    app.post('/stop', {
+        preHandler: app.needsPermission('project:change-status'),
+        schema: {
+            summary: 'Stop an instance',
+            tags: ['Instance Actions'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                },
+                500: {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
                 reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
@@ -61,10 +105,10 @@ module.exports = async function (app) {
             app.db.controllers.Project.setInflightState(request.project, 'stopping')
             request.project.state = 'stopped'
             await request.project.save()
-            const result = await app.containers.stopFlows(request.project)
+            await app.containers.stopFlows(request.project)
             await app.auditLog.Project.project.stopped(request.session.User, null, request.project)
             app.db.controllers.Project.clearInflightState(request.project)
-            reply.send(result)
+            reply.send({ status: 'okay' })
         } catch (err) {
             app.db.controllers.Project.clearInflightState(request.project)
 
@@ -74,7 +118,30 @@ module.exports = async function (app) {
         }
     })
 
-    app.post('/restart', changeStatusPreHandler, async (request, reply) => {
+    app.post('/restart', {
+        preHandler: app.needsPermission('project:change-status'),
+        schema: {
+            summary: 'Restart an instance',
+            tags: ['Instance Actions'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                },
+                500: {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
                 reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
@@ -83,10 +150,10 @@ module.exports = async function (app) {
             app.db.controllers.Project.setInflightState(request.project, 'restarting')
             request.project.state = 'running'
             await request.project.save()
-            const result = await app.containers.restartFlows(request.project)
+            await app.containers.restartFlows(request.project)
             await app.auditLog.Project.project.restarted(request.session.User, null, request.project)
             app.db.controllers.Project.clearInflightState(request.project)
-            reply.send(result)
+            reply.send({ status: 'okay' })
         } catch (err) {
             app.db.controllers.Project.clearInflightState(request.project)
 
@@ -96,7 +163,30 @@ module.exports = async function (app) {
         }
     })
 
-    app.post('/suspend', changeStatusPreHandler, async (request, reply) => {
+    app.post('/suspend', {
+        preHandler: app.needsPermission('project:change-status'),
+        schema: {
+            summary: 'Suspend an instance',
+            tags: ['Instance Actions'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                },
+                500: {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         try {
             if (request.project.state === 'suspended') {
                 reply.code(400).send({ code: 'project_suspended', error: 'Project suspended' })
@@ -106,7 +196,7 @@ module.exports = async function (app) {
             await app.containers.stop(request.project)
             app.db.controllers.Project.clearInflightState(request.project)
             await app.auditLog.Project.project.suspended(request.session.User, null, request.project)
-            reply.send()
+            reply.send({ status: 'okay' })
         } catch (err) {
             app.db.controllers.Project.clearInflightState(request.project)
 
@@ -116,17 +206,46 @@ module.exports = async function (app) {
         }
     })
 
-    app.post('/rollback', { preHandler: app.needsPermission('project:snapshot:rollback') }, async (request, reply) => {
+    app.post('/rollback', {
+        preHandler: app.needsPermission('project:snapshot:rollback'),
+        schema: {
+            summary: 'Rollback an instance to a snapshot',
+            tags: ['Instance Actions'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    snapshot: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                },
+                500: {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         let restartProject = false
         try {
             // get (and check) snapshot is valid / owned by project before any actions
             const snapshot = await app.db.models.ProjectSnapshot.byId(request.body.snapshot)
             if (!snapshot) {
-                reply.code(400).send({ code: 'invalid_snapshot', error: `snapshot '${request.body.snapshotId}' not found for project '${request.project.id}'` })
+                reply.code(400).send({ code: 'invalid_snapshot', error: `snapshot '${request.body.snapshot}' not found for project '${request.project.id}'` })
                 return
             }
             if (snapshot.ProjectId !== request.project.id) {
-                reply.code(400).send({ code: 'invalid_snapshot', error: `snapshot '${request.body.snapshotId}' not found for project '${request.project.id}'` })
+                reply.code(400).send({ code: 'invalid_snapshot', error: `snapshot '${request.body.snapshot}' not found for project '${request.project.id}'` })
                 return
             }
             if (request.project.state === 'running') {
@@ -148,7 +267,30 @@ module.exports = async function (app) {
         }
     })
 
-    app.post('/restartStack', changeStatusPreHandler, async (request, reply) => {
+    app.post('/restartStack', {
+        preHandler: app.needsPermission('project:change-status'),
+        schema: {
+            summary: 'Restart an instance stack',
+            tags: ['Instance Actions'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                },
+                500: {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         try {
             await app.auditLog.Project.project.stack.restart(request.session.User, null, request.project)
             if (request.project.state !== 'suspended') {

--- a/forge/routes/api/projectActions.js
+++ b/forge/routes/api/projectActions.js
@@ -3,7 +3,7 @@
  *
  * request.project will be defined for any route defined in here
  *
- * - /api/v1/projects/:projectId/actions/
+ * - /api/v1/projects/:instanceId/actions/
  *
  * @namespace project
  * @memberof forge.routes.api

--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -1,9 +1,9 @@
 /**
  * Project Devices api routes
  *
- * - /api/v1/projects/:projectId/devices
+ * - /api/v1/projects/:instanceId/devices
  *
- * By the time these handlers are invoked, :projectId will have been validated
+ * By the time these handlers are invoked, :instanceId will have been validated
  * and 404'd if it doesn't exist. `request.project` will contain the project object
  *
  * @namespace projectDevices
@@ -12,7 +12,7 @@
 module.exports = async function (app) {
     /**
      * Get a list of projects assigned to this team
-     * @name /api/v1/projects/:projectId/devices
+     * @name /api/v1/projects/:instanceId/devices
      * @static
      * @memberof forge.routes.api.project
      */

--- a/forge/routes/api/projectDevices.js
+++ b/forge/routes/api/projectDevices.js
@@ -11,12 +11,37 @@
  */
 module.exports = async function (app) {
     /**
-     * Get a list of projects assigned to this team
+     * Get a list of devices assigned to this team
      * @name /api/v1/projects/:instanceId/devices
      * @static
      * @memberof forge.routes.api.project
      */
-    app.get('/', { preHandler: app.needsPermission('project:read') }, async (request, reply) => {
+    app.get('/', {
+        preHandler: app.needsPermission('project:read'),
+        schema: {
+            summary: 'Get a list of devices assigned to an instance',
+            tags: ['Instances'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        meta: { $ref: 'PaginationMeta' },
+                        count: { type: 'number' },
+                        devices: { type: 'array', items: { $ref: 'Device' } }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const where = {
             ProjectId: request.project.id
@@ -26,7 +51,30 @@ module.exports = async function (app) {
         reply.send(devices)
     })
 
-    app.get('/settings', { preHandler: app.needsPermission('project:read') }, async (request, reply) => {
+    app.get('/settings', {
+        preHandler: app.needsPermission('project:read'),
+        schema: {
+            summary: 'Get instance device settings',
+            tags: ['Instances'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        targetSnapshot: { type: 'string' }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const deviceSettings = await request.project.getSetting('deviceSettings') || {
             targetSnapshot: null
         }
@@ -36,7 +84,33 @@ module.exports = async function (app) {
         reply.send(deviceSettings)
     })
 
-    app.post('/settings', { preHandler: app.needsPermission('project:snapshot:set-target') }, async (request, reply) => {
+    app.post('/settings', {
+        preHandler: app.needsPermission('project:snapshot:set-target'),
+        schema: {
+            summary: 'Update instance device settings',
+            tags: ['Instances'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    targetSnapshot: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         if (request.body.targetSnapshot) {
             // We currently only have `targetSnapshot` under deviceSettings.
             // For now, only care about that - when we add other device settings, this

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -32,7 +32,30 @@ module.exports = async function (app) {
      * Get list of all project snapshots
      */
     app.get('/', {
-        preHandler: app.needsPermission('project:snapshot:list')
+        preHandler: app.needsPermission('project:snapshot:list'),
+        schema: {
+            summary: 'Get a list of instance snapshots',
+            tags: ['Snapshots'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        meta: { $ref: 'PaginationMeta' },
+                        count: { type: 'number' },
+                        snapshots: { type: 'array', items: { $ref: 'Snapshot' } }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const snapshots = await app.db.models.ProjectSnapshot.forProject(request.project.id, paginationOptions)
@@ -44,7 +67,26 @@ module.exports = async function (app) {
      * Get details of a snapshot - metadata only
      */
     app.get('/:snapshotId', {
-        preHandler: app.needsPermission('project:snapshot:read')
+        preHandler: app.needsPermission('project:snapshot:read'),
+        schema: {
+            summary: 'Get details of a snapshot',
+            tags: ['Snapshots'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' },
+                    snapshotId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'Snapshot'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         reply.send(app.db.views.ProjectSnapshot.snapshot(request.snapshot))
     })
@@ -53,7 +95,26 @@ module.exports = async function (app) {
      * Delete a snapshot
      */
     app.delete('/:snapshotId', {
-        preHandler: app.needsPermission('project:snapshot:delete')
+        preHandler: app.needsPermission('project:snapshot:delete'),
+        schema: {
+            summary: 'Delete a snapshot',
+            tags: ['Teams'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' },
+                    snapshotId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const project = await request.snapshot.getProject()
         const deviceSettings = await project.getSetting('deviceSettings') || {
@@ -82,7 +143,42 @@ module.exports = async function (app) {
      * @name /api/v1/projects/:instanceId/snapshots
      */
     app.post('/', {
-        preHandler: app.needsPermission('project:snapshot:create')
+        preHandler: app.needsPermission('project:snapshot:create'),
+        schema: {
+            summary: 'Create a snapshot from an instance',
+            tags: ['Snapshots'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceId: { type: 'string' }
+                }
+            },
+            body: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    description: { type: 'string' },
+                    flows: { type: 'array' },
+                    credentials: { type: 'object' },
+                    credentialSecret: { type: 'string' },
+                    settings: {
+                        type: 'object',
+                        properties: {
+                            modules: { type: 'object', additionalProperties: true }
+                        }
+                    },
+                    setAsTarget: { type: 'boolean' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'Snapshot'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const snapShot = await app.db.controllers.ProjectSnapshot.createSnapshot(
             request.project,

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -3,7 +3,7 @@
  *
  * request.project will be defined for any route defined in here
  *
- * - /api/v1/projects/:projectId/snapshots/
+ * - /api/v1/projects/:instanceId/snapshots/
  *
  * @namespace project
  * @memberof forge.routes.api
@@ -79,7 +79,7 @@ module.exports = async function (app) {
 
     /**
      * Create a snapshot
-     * @name /api/v1/projects/:projectId/snapshots
+     * @name /api/v1/projects/:instanceId/snapshots
      */
     app.post('/', {
         preHandler: app.needsPermission('project:snapshot:create')

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -1,5 +1,20 @@
 module.exports = async function (app) {
-    app.get('/', { config: { allowAnonymous: true, allowUnverifiedEmail: true } }, async (request, reply) => {
+    app.get('/', {
+        config: { allowAnonymous: true, allowUnverifiedEmail: true },
+        schema: {
+            summary: 'Get platform settings',
+            tags: ['Platform'],
+            response: {
+                200: {
+                    type: 'object',
+                    additionalProperties: true
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         // This isn't as clean as I'd like, but it works for now.
         //
         // We return different things depending on the user session.
@@ -93,7 +108,22 @@ module.exports = async function (app) {
         }
     })
 
-    app.put('/', { preHandler: app.needsPermission('settings:edit') }, async (request, reply) => {
+    app.put('/', {
+        preHandler: app.needsPermission('settings:edit'),
+        schema: {
+            summary: 'Get platform settings',
+            tags: ['Platform'],
+            body: { type: 'object' },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         if (request.body) {
             const updates = new app.auditLog.formatters.UpdatesCollection()
             for (let [key, value] of Object.entries(request.body)) {

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -14,7 +14,25 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.get('/', {
-        preHandler: app.needsPermission('template:list')
+        preHandler: app.needsPermission('template:list'),
+        schema: {
+            summary: 'Get a list of all templates',
+            tags: ['Templates'],
+            query: { $ref: 'PaginationParams' },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        meta: { $ref: 'PaginationMeta' },
+                        count: { type: 'number' },
+                        templates: { type: 'array', items: { $ref: 'TemplateSummary' } }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const templates = await app.db.models.ProjectTemplate.getAll(paginationOptions)
@@ -29,7 +47,25 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.get('/:templateId', {
-        preHandler: app.needsPermission('template:read')
+        preHandler: app.needsPermission('template:read'),
+        schema: {
+            summary: 'Get a template',
+            tags: ['Templates'],
+            params: {
+                type: 'object',
+                properties: {
+                    templateId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'Template'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
         if (template) {
@@ -48,6 +84,8 @@ module.exports = async function (app) {
     app.post('/', {
         preHandler: app.needsPermission('template:create'),
         schema: {
+            summary: 'Create a template - admin-only',
+            tags: ['Templates'],
             body: {
                 type: 'object',
                 required: ['name', 'settings', 'policy'],
@@ -57,6 +95,14 @@ module.exports = async function (app) {
                     description: { type: 'string' },
                     settings: { type: 'object' },
                     policy: { type: 'object' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'TemplateSummary'
+                },
+                '4xx': {
+                    $ref: 'APIError'
                 }
             }
         }
@@ -95,7 +141,25 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.delete('/:templateId', {
-        preHandler: app.needsPermission('template:delete')
+        preHandler: app.needsPermission('template:delete'),
+        schema: {
+            summary: 'Delete a template - admin-only',
+            tags: ['Templates'],
+            params: {
+                type: 'object',
+                properties: {
+                    templateId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
         // The `beforeDestroy` hook of the ProjectTemplate model ensures
@@ -115,7 +179,30 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.put('/:templateId', {
-        preHandler: app.needsPermission('template:edit')
+        preHandler: app.needsPermission('template:edit'),
+        schema: {
+            summary: 'Update a template - admin-only',
+            tags: ['Templates'],
+            body: {
+                type: 'object',
+                required: ['name', 'settings', 'policy'],
+                properties: {
+                    name: { type: 'string' },
+                    active: { type: 'boolean' },
+                    description: { type: 'string' },
+                    settings: { type: 'object' },
+                    policy: { type: 'object' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'TemplateSummary'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const templateSettings = app.db.controllers.ProjectTemplate.validateSettings(request.body.settings)
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -11,7 +11,25 @@
 module.exports = async function (app) {
     app.addHook('preHandler', app.needsPermission('user:edit'))
 
-    app.get('/', async (request, reply) => {
+    app.get('/', {
+        schema: {
+            summary: 'Get a list of the current users invitations',
+            tags: ['User'],
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        meta: { $ref: 'PaginationMeta' },
+                        count: { type: 'number' },
+                        invitations: { $ref: 'InvitationList' }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const invitations = await app.db.models.Invitation.forUser(request.session.User)
         const result = app.db.views.Invitation.invitationList(invitations)
         reply.send({
@@ -25,7 +43,26 @@ module.exports = async function (app) {
      * Accept an invitation
      * PATCH [/api/v1/user/invitations]/:invitationId
      */
-    app.patch('/:invitationId', async (request, reply) => {
+    app.patch('/:invitationId', {
+        schema: {
+            summary: 'Accept an invitation',
+            tags: ['User'],
+            params: {
+                type: 'object',
+                properties: {
+                    invitationId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId, request.session.User)
         if (invitation) {
             await app.db.controllers.Invitation.acceptInvitation(invitation, request.session.User)
@@ -42,7 +79,26 @@ module.exports = async function (app) {
      * Reject an invitation
      * DELETE [/api/v1/user/invitations]/:invitationId
      */
-    app.delete('/:invitationId', async (request, reply) => {
+    app.delete('/:invitationId', {
+        schema: {
+            summary: 'Reject an invitation',
+            tags: ['User'],
+            params: {
+                type: 'object',
+                properties: {
+                    invitationId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId, request.session.User)
         if (invitation) {
             await app.db.controllers.Invitation.rejectInvitation(invitation, request.session.User)

--- a/test/unit/forge/ee/routes/api/project_spec.js
+++ b/test/unit/forge/ee/routes/api/project_spec.js
@@ -71,20 +71,18 @@ describe('Projects API - with billing enabled', function () {
                 // Put project in running state
                 await app.containers.start(project)
                 app.billing.addProject.resetHistory()
-
                 const response = await app.inject({
                     method: 'PUT',
                     url: `/api/v1/projects/${app.project.id}`,
                     payload: {
-                        projectType: projectType.id,
-                        stack: stack.id
+                        projectType: projectType.hashid,
+                        stack: stack.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
-
                 response.statusCode.should.equal(200)
 
-                await sleep(START_DELAY + STOP_DELAY + 50)
+                await sleep(START_DELAY + STOP_DELAY + 100)
 
                 should.equal(app.billing.removeProject.calledOnce, true)
                 should.equal(app.billing.addProject.calledOnce, true)
@@ -116,7 +114,7 @@ describe('Projects API - with billing enabled', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${app.project.id}`,
                     payload: {
-                        stack: stack.id
+                        stack: stack.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -974,8 +974,8 @@ describe('Project API', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${project.id}`,
                     payload: {
-                        projectType: projectType.id,
-                        stack: stack.id
+                        projectType: projectType.hashid,
+                        stack: stack.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -1041,8 +1041,8 @@ describe('Project API', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${project.id}`,
                     payload: {
-                        projectType: projectType.id,
-                        stack: stack.id
+                        projectType: projectType.hashid,
+                        stack: stack.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -1093,7 +1093,7 @@ describe('Project API', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${TestObjects.project1.id}`,
                     payload: {
-                        projectType: TestObjects.projectType1.id
+                        projectType: TestObjects.projectType1.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -1107,8 +1107,8 @@ describe('Project API', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${TestObjects.project1.id}`,
                     payload: {
-                        projectType: 123,
-                        stack: 123
+                        projectType: '123',
+                        stack: '123'
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -1120,8 +1120,8 @@ describe('Project API', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${TestObjects.project1.id}`,
                     payload: {
-                        projectType: TestObjects.projectType1.id,
-                        stack: 123
+                        projectType: TestObjects.projectType1.hashid,
+                        stack: '123'
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -1237,7 +1237,7 @@ describe('Project API', function () {
                     method: 'PUT',
                     url: `/api/v1/projects/${newProject.id}`,
                     payload: {
-                        stack: stack2.id
+                        stack: stack2.hashid
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -1304,7 +1304,7 @@ describe('Project API', function () {
                         method: 'PUT',
                         url: `/api/v1/projects/${newProject.id}`,
                         payload: {
-                            stack: stack2.id
+                            stack: stack2.hashid
                         },
                         cookies: { sid: TestObjects.tokens.alice }
                     })


### PR DESCRIPTION
Part of #1556 

This targets the branch of #2351 - I've split this out to try to keep things reviewable.

This PR adds schemas to all of the `routes/api/project*` files.

Along the way it also:

 - modifies the swagger config to generate OpenAPI 3.x (rather than Swagger/OpenAPI 2.x)
 - Fixes a few tests that were passing in raw database indexes to the public API, rather than the expected hashids. Found them thanks to the tightened up schema validation - hurrah!
 - renames `:projectId` to `:instanceId` in all route definitions - as this gets included in generated api docs.
