### PR TITLE
Add schemas to device api routes

### DIFF
--- a/forge/db/views/AccessToken.js
+++ b/forge/db/views/AccessToken.js
@@ -1,5 +1,25 @@
-module.exports = {
-    provisioningTokenSummary: async function (app, token) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'ProvisioningTokenSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            team: { type: 'string', nullable: true },
+            project: { type: 'string' },
+            expiresAt: { type: 'string', nullable: true },
+            targetSnapshot: { type: 'string' }
+        }
+    })
+    app.addSchema({
+        $id: 'ProvisioningToken',
+        type: 'object',
+        allOf: [{ $ref: 'ProvisioningTokenSummary' }],
+        properties: {
+            token: { type: 'string' }
+        }
+    })
+    async function provisioningTokenSummary (token) {
         // build a tokenSummary object from the token
         const tokenSummary = {
             id: token.hashid,
@@ -27,5 +47,8 @@ module.exports = {
             }
         }
         return tokenSummary
+    }
+    return {
+        provisioningTokenSummary
     }
 }

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -8,8 +8,8 @@ module.exports = function (app) {
             type: { type: 'string' },
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' },
-            lastSeenAt: { type: 'string' },
-            lastSeenMs: { type: 'number' },
+            lastSeenAt: { nullable: true, type: 'string' },
+            lastSeenMs: { nullable: true, type: 'number' },
             activeSnapshot: {
                 nullable: true,
                 allOf: [{ $ref: 'SnapshotSummary' }]

--- a/forge/db/views/Project.js
+++ b/forge/db/views/Project.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
             hostname: { type: 'string' },
             application: { $ref: 'ApplicationSummary' },
             team: { $ref: 'TeamSummary' },
-            projectType: { $ref: 'ProjectTypeSummary' },
+            projectType: { $ref: 'InstanceTypeSummary' },
             settings: {
                 type: 'object',
                 additionalProperties: true

--- a/forge/db/views/ProjectTemplate.js
+++ b/forge/db/views/ProjectTemplate.js
@@ -1,14 +1,22 @@
-module.exports = {
-    template: function (app, template) {
+module.exports = function (app) {
+    app.addSchema({
+        $id: 'Template',
+        type: 'object',
+        allOf: [{ $ref: 'TemplateSummary' }],
+        properties: {
+            settings: { type: 'object', additionalProperties: true },
+            policy: { type: 'object', additionalProperties: true }
+        }
+    })
+    function template (template) {
         if (template) {
             const result = template.toJSON()
             const filtered = {
                 id: result.hashid,
-                // template: result.templateId,
-                // revision: result.revision,
                 name: result.name,
                 description: result.description,
                 active: result.active,
+                projectCount: result.projectCount,
                 settings: result.settings || {},
                 policy: result.policy || {},
                 createdAt: result.createdAt,
@@ -25,14 +33,26 @@ module.exports = {
         } else {
             return null
         }
-    },
-    templateSummary: function (app, template) {
+    }
+    app.addSchema({
+        $id: 'TemplateSummary',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            description: { type: 'string' },
+            active: { type: 'boolean' },
+            projectCount: { type: 'number' },
+            createdAt: { type: 'string' },
+            links: { $ref: 'LinksMeta' },
+            owner: { $ref: 'UserSummary' }
+        }
+    })
+    function templateSummary (template) {
         if (template) {
             const result = template.toJSON()
             const filtered = {
                 id: result.hashid,
-                // template: result.templateId,
-                // revision: result.revision,
                 name: result.name,
                 description: result.description,
                 active: result.active,
@@ -47,5 +67,9 @@ module.exports = {
         } else {
             return null
         }
+    }
+    return {
+        template,
+        templateSummary
     }
 }

--- a/forge/db/views/ProjectType.js
+++ b/forge/db/views/ProjectType.js
@@ -1,6 +1,6 @@
 module.exports = function (app) {
     app.addSchema({
-        $id: 'ProjectTypeSummary',
+        $id: 'InstanceTypeSummary',
         type: 'object',
         properties: {
             id: { type: 'string' },
@@ -16,6 +16,23 @@ module.exports = function (app) {
             name: projectType.name
         }
     }
+    app.addSchema({
+        $id: 'InstanceType',
+        type: 'object',
+        properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            active: { type: 'boolean' },
+            description: { type: 'string' },
+            order: { type: 'number' },
+            properties: { type: 'object', additionalProperties: true },
+            createdAt: { type: 'string' },
+            defaultStack: { type: 'string', nullable: true },
+            projectCount: { type: 'number' },
+            stackCount: { type: 'number' }
+
+        }
+    })
     function projectType (projectType, includeCount) {
         if (projectType) {
             const result = projectType.toJSON()

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -39,6 +39,7 @@ module.exports = async (options = {}) => {
         loggerLevel = options.config.logging.level || 'info'
     }
     const server = fastify({
+        forceCloseConnections: true,
         bodyLimit: 5242880,
         maxParamLength: 500,
         trustProxy: true,

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -1,5 +1,20 @@
 module.exports = async function (app) {
-    app.get('/', { config: { allowAnonymous: true, allowUnverifiedEmail: true } }, async (request, reply) => {
+    app.get('/', {
+        config: { allowAnonymous: true, allowUnverifiedEmail: true },
+        schema: {
+            summary: 'Get platform settings',
+            tags: ['Platform'],
+            response: {
+                200: {
+                    type: 'object',
+                    additionalProperties: true
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         // This isn't as clean as I'd like, but it works for now.
         //
         // We return different things depending on the user session.
@@ -93,7 +108,22 @@ module.exports = async function (app) {
         }
     })
 
-    app.put('/', { preHandler: app.needsPermission('settings:edit') }, async (request, reply) => {
+    app.put('/', {
+        preHandler: app.needsPermission('settings:edit'),
+        schema: {
+            summary: 'Get platform settings',
+            tags: ['Platform'],
+            body: { type: 'object' },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         if (request.body) {
             const updates = new app.auditLog.formatters.UpdatesCollection()
             for (let [key, value] of Object.entries(request.body)) {

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -14,7 +14,25 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.get('/', {
-        preHandler: app.needsPermission('template:list')
+        preHandler: app.needsPermission('template:list'),
+        schema: {
+            summary: 'Get a list of all templates',
+            tags: ['Templates'],
+            query: { $ref: 'PaginationParams' },
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        meta: { $ref: 'PaginationMeta' },
+                        count: { type: 'number' },
+                        templates: { type: 'array', items: { $ref: 'TemplateSummary' } }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const paginationOptions = app.getPaginationOptions(request)
         const templates = await app.db.models.ProjectTemplate.getAll(paginationOptions)
@@ -29,7 +47,25 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.get('/:templateId', {
-        preHandler: app.needsPermission('template:read')
+        preHandler: app.needsPermission('template:read'),
+        schema: {
+            summary: 'Get a template',
+            tags: ['Templates'],
+            params: {
+                type: 'object',
+                properties: {
+                    templateId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'Template'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
         if (template) {
@@ -48,6 +84,8 @@ module.exports = async function (app) {
     app.post('/', {
         preHandler: app.needsPermission('template:create'),
         schema: {
+            summary: 'Create a template - admin-only',
+            tags: ['Templates'],
             body: {
                 type: 'object',
                 required: ['name', 'settings', 'policy'],
@@ -57,6 +95,14 @@ module.exports = async function (app) {
                     description: { type: 'string' },
                     settings: { type: 'object' },
                     policy: { type: 'object' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'TemplateSummary'
+                },
+                '4xx': {
+                    $ref: 'APIError'
                 }
             }
         }
@@ -95,7 +141,25 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.delete('/:templateId', {
-        preHandler: app.needsPermission('template:delete')
+        preHandler: app.needsPermission('template:delete'),
+        schema: {
+            summary: 'Delete a template - admin-only',
+            tags: ['Templates'],
+            params: {
+                type: 'object',
+                properties: {
+                    templateId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)
         // The `beforeDestroy` hook of the ProjectTemplate model ensures
@@ -115,7 +179,30 @@ module.exports = async function (app) {
      * @memberof forge.routes.api.templates
      */
     app.put('/:templateId', {
-        preHandler: app.needsPermission('template:edit')
+        preHandler: app.needsPermission('template:edit'),
+        schema: {
+            summary: 'Update a template - admin-only',
+            tags: ['Templates'],
+            body: {
+                type: 'object',
+                required: ['name', 'settings', 'policy'],
+                properties: {
+                    name: { type: 'string' },
+                    active: { type: 'boolean' },
+                    description: { type: 'string' },
+                    settings: { type: 'object' },
+                    policy: { type: 'object' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'TemplateSummary'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
     }, async (request, reply) => {
         const templateSettings = app.db.controllers.ProjectTemplate.validateSettings(request.body.settings)
         const template = await app.db.models.ProjectTemplate.byId(request.params.templateId)

--- a/forge/routes/api/userInvitations.js
+++ b/forge/routes/api/userInvitations.js
@@ -11,7 +11,25 @@
 module.exports = async function (app) {
     app.addHook('preHandler', app.needsPermission('user:edit'))
 
-    app.get('/', async (request, reply) => {
+    app.get('/', {
+        schema: {
+            summary: 'Get a list of the current users invitations',
+            tags: ['User'],
+            response: {
+                200: {
+                    type: 'object',
+                    properties: {
+                        meta: { $ref: 'PaginationMeta' },
+                        count: { type: 'number' },
+                        invitations: { $ref: 'InvitationList' }
+                    }
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const invitations = await app.db.models.Invitation.forUser(request.session.User)
         const result = app.db.views.Invitation.invitationList(invitations)
         reply.send({
@@ -25,7 +43,26 @@ module.exports = async function (app) {
      * Accept an invitation
      * PATCH [/api/v1/user/invitations]/:invitationId
      */
-    app.patch('/:invitationId', async (request, reply) => {
+    app.patch('/:invitationId', {
+        schema: {
+            summary: 'Accept an invitation',
+            tags: ['User'],
+            params: {
+                type: 'object',
+                properties: {
+                    invitationId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId, request.session.User)
         if (invitation) {
             await app.db.controllers.Invitation.acceptInvitation(invitation, request.session.User)
@@ -42,7 +79,26 @@ module.exports = async function (app) {
      * Reject an invitation
      * DELETE [/api/v1/user/invitations]/:invitationId
      */
-    app.delete('/:invitationId', async (request, reply) => {
+    app.delete('/:invitationId', {
+        schema: {
+            summary: 'Reject an invitation',
+            tags: ['User'],
+            params: {
+                type: 'object',
+                properties: {
+                    invitationId: { type: 'string' }
+                }
+            },
+            response: {
+                200: {
+                    $ref: 'APIStatus'
+                },
+                '4xx': {
+                    $ref: 'APIError'
+                }
+            }
+        }
+    }, async (request, reply) => {
         const invitation = await app.db.models.Invitation.byId(request.params.invitationId, request.session.User)
         if (invitation) {
             await app.db.controllers.Invitation.rejectInvitation(invitation, request.session.User)


### PR DESCRIPTION
Part of https://github.com/flowforge/flowforge/issues/1556

This targets the branch of https://github.com/flowforge/flowforge/pull/2356

This PR adds schemas  to `routes/api/device.js`

Along the way I found one route that had a test looking for the built-in required params validation error message. However, for reasons, having applied the schema the response format is different and doesn't provide the useful error message about what has failed.

As it stands, I haven't been setting the `required` flag on any schema consistently - some already had it. We'll want to do a second pass through and tidy that up - including getting the error response object to contain useful information in a useful structure.

https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/#error-handling covers a lot of it.