### PR TITLE
Improve logging and UX around switching Developer mode

### DIFF
--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -265,7 +265,7 @@ about working with snapshots.
 * The Web UI requires Device Agent v0.9.0 or later.
 * The device must first have a snapshot applied before editor access is possible.
 * The device will not receive any updates from the platform while in Developer Mode.
-* Disabling Developer Mode will cause the device to re-connected to the platform and any change to the target snapshot will cause the device to be updated. This will overwrite any changes made in Developer Mode. Therefore, it is recommended to create a snapshot of the changes before disabling Developer Mode.
+* Disabling Developer Mode will cause the device to check-in with the platform. If the device flows hve changed, it will be reloaded with the current target snapshot assigned to that device, causing any changes made in Developer Mode to be overwritten. Therefore, it is recommended to create a snapshot of the changes before disabling Developer Mode.
 * The device must be online and connected to the platform to enable "Editor Access".
 * To minimise server and device resources, it is recommended to disable "Editor Access" when not actively developing flows on a device.
 

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -386,7 +386,8 @@ module.exports = async function (app) {
         }
         request.device.mode = request.body.mode
         await request.device.save()
-
+        // send update to device for immediate effect
+        app.db.controllers.Device.sendDeviceUpdateCommand(request.device)
         // Audit log the change
         if (request.device.mode === 'developer') {
             await app.auditLog.Team.team.device.developerMode.enabled(request.session.User, null, request.device.Team, request.device)


### PR DESCRIPTION
## Description

Sends a command to device upon changing developer mode, to make the operation more instantanious - which has a positive UX improvement in that:
* device agent switches more immediately
* which in turn generates immediate log entries in the "device logs"
* which (when coupled with [#128](https://github.com/flowforge/flowforge-device-agent/pull/128) immediately feeds back to the platform
* which then updates the device status sooner - and permits operation of the "Enable Editor" button & actual device status. 
* update docs to reflect new behaviour when coupled with related PR [agent #128](https://github.com/flowforge/flowforge-device-agent/pull/128)

### TODO
- [x] check documentation algins with this  and change

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/2323

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

