### PR TITLE
Ensure instance-updated event is passed up from Instance Danger component

### DIFF
--- a/frontend/src/pages/instance/Settings/General.vue
+++ b/frontend/src/pages/instance/Settings/General.vue
@@ -29,6 +29,7 @@
         </FormRow>
         <DangerSettings
             :instance="instance"
+            @instance-updated="$emit('instance-updated')"
             @instance-confirm-delete="$emit('instance-confirm-delete')"
             @instance-confirm-suspend="$emit('instance-confirm-suspend')"
         />
@@ -57,7 +58,7 @@ export default {
             required: true
         }
     },
-    emits: ['instance-confirm-delete', 'instance-confirm-suspend'],
+    emits: ['instance-updated', 'instance-confirm-delete', 'instance-confirm-suspend'],
     data () {
         return {
             editing: {

--- a/frontend/src/pages/instance/Settings/dialogs/ChangeStackDialog.vue
+++ b/frontend/src/pages/instance/Settings/dialogs/ChangeStackDialog.vue
@@ -10,7 +10,7 @@
         <template #default>
             <form class="space-y-6" @submit.prevent>
                 <p>
-                    Select the new stack you want to use for this project:
+                    Select the new stack you want to use for this instance:
                 </p>
                 <FormRow
                     v-model="input.stack"


### PR DESCRIPTION
Fixes #2364 

## Description

When updating an instance stack, the 'instance-updated' event wasn't being passed up from the Danger component. This mean the overview page didn't know to refresh the review - so the stack 'update' didn't disappear and there's no feedback anything is happening.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

