### PR TITLE
Add FF_SNAPSHOT_ID to devices

### DIFF
--- a/docs/user/envvar.md
+++ b/docs/user/envvar.md
@@ -53,6 +53,7 @@ In addition, the following variables are set when running on a device:
 - `FF_DEVICE_NAME`
 - `FF_DEVICE_TYPE`
 - `FF_SNAPSHOT_ID`
+- `FF_SNAPSHOT_NAME`
 
 When deploying the same set of flows out to multiple devices, these variables can
 be used by the flows to identify the specific device being run on.

--- a/docs/user/envvar.md
+++ b/docs/user/envvar.md
@@ -41,18 +41,18 @@ The third one `user` is set for the instance, the value can be edited or the var
 
 ## Standard environment variables
 
-Instances running on FlowForge are assigned a standard set environment variables as follows.
+Standard environment variables are set for all Node-RED instances running
+within the platform:
 
 - `FF_INSTANCE_ID`
 - `FF_INSTANCE_NAME`
-- `FF_PROJECT_ID` (depreciated as of V1.6.0, use `FF_INSTANCE_ID` instead)
-- `FF_PROJECT_NAME` (depreciated as of V1.6.0, use `FF_INSTANCE_NAME` instead)
-- `FF_DEVICE_ID` (devices only)
-- `FF_DEVICE_NAME` (devices only)
-- `FF_DEVICE_TYPE` (devices only)
 
-`FF_INSTANCE_ID` and `FF_INSTANCE_NAME` are assigned to the Node-RED instance running on the FlowForge server as well as all associated Devices.
+In addition, the following variables are set when running on a device:
 
-Devices also have `FF_DEVICE_ID`, `FF_DEVICE_NAME` and `FF_DEVICE_TYPE` set so that flows can know where they are running.
+- `FF_DEVICE_ID`
+- `FF_DEVICE_NAME`
+- `FF_DEVICE_TYPE`
+- `FF_SNAPSHOT_ID`
 
-
+When deploying the same set of flows out to multiple devices, these variables can
+be used by the flows to identify the specific device being run on.

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -68,6 +68,7 @@ module.exports = {
         result.push(makeVar('FF_DEVICE_ID', device.hashid || ''))
         result.push(makeVar('FF_DEVICE_NAME', device.name || ''))
         result.push(makeVar('FF_DEVICE_TYPE', device.type || ''))
+        result.push(makeVar('FF_SNAPSHOT_ID', device.targetSnapshot?.hashid || ''))
         result.push(...app.db.controllers.Device.removePlatformSpecificEnvVars(envVars))
         return result
     },

--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -69,6 +69,7 @@ module.exports = {
         result.push(makeVar('FF_DEVICE_NAME', device.name || ''))
         result.push(makeVar('FF_DEVICE_TYPE', device.type || ''))
         result.push(makeVar('FF_SNAPSHOT_ID', device.targetSnapshot?.hashid || ''))
+        result.push(makeVar('FF_SNAPSHOT_NAME', device.targetSnapshot?.name || ''))
         result.push(...app.db.controllers.Device.removePlatformSpecificEnvVars(envVars))
         return result
     },

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -18,13 +18,17 @@ describe('Device controller', function () {
                 id: '1',
                 hashid: 'a-b-c-device-1',
                 name: 'device1',
-                type: 'PI4'
+                type: 'PI4',
+                targetSnapshot: {
+                    hashid: 'snapshot-id'
+                }
             }
             const env = app.db.controllers.Device.insertPlatformSpecificEnvVars(device, null)
-            should(env).be.an.Array().with.lengthOf(3)
+            should(env).be.an.Array().with.lengthOf(4)
             env.should.containEql({ name: 'FF_DEVICE_ID', value: device.hashid, platform: true })
             env.should.containEql({ name: 'FF_DEVICE_NAME', value: 'device1', platform: true })
             env.should.containEql({ name: 'FF_DEVICE_TYPE', value: 'PI4', platform: true })
+            env.should.containEql({ name: 'FF_SNAPSHOT_ID', value: 'snapshot-id', platform: true })
         })
         it('merges env vars', async function () {
             const device = {
@@ -38,7 +42,7 @@ describe('Device controller', function () {
                 { name: 'two', value: '2' }
             ]
             const env = app.db.controllers.Device.insertPlatformSpecificEnvVars(device, dummyEnvVars)
-            should(env).be.an.Array().with.lengthOf(5)
+            should(env).be.an.Array().with.lengthOf(6)
             env.should.containEql({ name: 'FF_DEVICE_ID', value: device.hashid, platform: true })
             env.should.containEql({ name: 'FF_DEVICE_NAME', value: 'device2', platform: true })
             env.should.containEql({ name: 'FF_DEVICE_TYPE', value: 'PI3b', platform: true })

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -20,15 +20,17 @@ describe('Device controller', function () {
                 name: 'device1',
                 type: 'PI4',
                 targetSnapshot: {
+                    name: 'snapshot-name',
                     hashid: 'snapshot-id'
                 }
             }
             const env = app.db.controllers.Device.insertPlatformSpecificEnvVars(device, null)
-            should(env).be.an.Array().with.lengthOf(4)
+            should(env).be.an.Array().with.lengthOf(5)
             env.should.containEql({ name: 'FF_DEVICE_ID', value: device.hashid, platform: true })
             env.should.containEql({ name: 'FF_DEVICE_NAME', value: 'device1', platform: true })
             env.should.containEql({ name: 'FF_DEVICE_TYPE', value: 'PI4', platform: true })
             env.should.containEql({ name: 'FF_SNAPSHOT_ID', value: 'snapshot-id', platform: true })
+            env.should.containEql({ name: 'FF_SNAPSHOT_NAME', value: 'snapshot-name', platform: true })
         })
         it('merges env vars', async function () {
             const device = {
@@ -42,7 +44,7 @@ describe('Device controller', function () {
                 { name: 'two', value: '2' }
             ]
             const env = app.db.controllers.Device.insertPlatformSpecificEnvVars(device, dummyEnvVars)
-            should(env).be.an.Array().with.lengthOf(6)
+            should(env).be.an.Array().with.lengthOf(7)
             env.should.containEql({ name: 'FF_DEVICE_ID', value: device.hashid, platform: true })
             env.should.containEql({ name: 'FF_DEVICE_NAME', value: 'device2', platform: true })
             env.should.containEql({ name: 'FF_DEVICE_TYPE', value: 'PI3b', platform: true })


### PR DESCRIPTION
Closes https://github.com/flowforge/flowforge-device-agent/issues/94

## Description

This adds `FF_SNAPSHOT_ID` to the env passed down to devices. This is set to the id of the targetSnapshot for the device.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
