### PR TITLE
Ensure pipeline stages are listed in the correct order

### DIFF
--- a/forge/ee/db/views/PipelineStage.js
+++ b/forge/ee/db/views/PipelineStage.js
@@ -7,6 +7,8 @@ module.exports = {
         }
 
         if (stage.Instances?.length > 0) {
+            // TODO: this should be an instanceSummaryList - back that doesn't
+            // exist in 1.8, so minimising the changes for this backport.
             filtered.instances = await app.db.views.Project.instancesList(stage.Instances)
         }
 
@@ -21,6 +23,28 @@ module.exports = {
         return filtered
     },
     async stageList (app, stages) {
-        return await Promise.all(stages.map(app.db.views.PipelineStage.stage))
+        // Must ensure the stages are listed in the correct order
+        const stagesById = {}
+        const backReferences = {}
+        let pointer = null
+        // Scan the list of stages
+        //  - build an id->stage reference table
+        //  - find the last stage (!NextStageId) and set pointer
+        //  - build a reference table of which stage points at which
+        stages.forEach(stage => {
+            stagesById[stage.id] = stage
+            if (!stage.NextStageId) {
+                pointer = stage
+            } else {
+                backReferences[stage.NextStageId] = stage.id
+            }
+        })
+        const orderedStages = []
+        // Starting at the last stage, work back through the references
+        while (pointer) {
+            orderedStages.unshift(pointer)
+            pointer = stagesById[backReferences[pointer.id]]
+        }
+        return await Promise.all(orderedStages.map(app.db.views.PipelineStage.stage))
     }
 }

--- a/test/unit/forge/ee/db/views/PipelineStage_spec.js
+++ b/test/unit/forge/ee/db/views/PipelineStage_spec.js
@@ -1,0 +1,68 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../../setup')
+
+describe('PipelineStage view', function () {
+    let app
+    before(async function () {
+        app = await setup()
+    })
+
+    after(async function () {
+        await app.close()
+    })
+
+    describe('stageList', function () {
+        it('returns stages in the correct order', async function () {
+            const pipeline = await app.factory.createPipeline({
+                name: 'pipeline-1'
+            },
+            app.application)
+
+            const stage1 = await app.factory.createPipelineStage({
+                name: 's1',
+                instanceId: app.instance.id
+            }, pipeline)
+            const stage2 = await app.factory.createPipelineStage({
+                name: 's2',
+                instanceId: app.instance.id
+            }, pipeline)
+            const stage3 = await app.factory.createPipelineStage({
+                name: 's3',
+                instanceId: app.instance.id
+            }, pipeline)
+
+            stage1.NextStageId = stage2.id
+            stage2.NextStageId = stage3.id
+            await stage1.save()
+            await stage2.save()
+
+            function validateList (list) {
+                list.should.have.length(3)
+                list[0].should.have.property('id', stage1.hashid)
+                list[1].should.have.property('id', stage2.hashid)
+                list[2].should.have.property('id', stage3.hashid)
+            }
+
+            validateList(await app.db.views.PipelineStage.stageList([
+                stage1,
+                stage2,
+                stage3
+            ]))
+            validateList(await app.db.views.PipelineStage.stageList([
+                stage3,
+                stage2,
+                stage1
+            ]))
+            validateList(await app.db.views.PipelineStage.stageList([
+                stage2,
+                stage1,
+                stage3
+            ]))
+            validateList(await app.db.views.PipelineStage.stageList([
+                stage1,
+                stage3,
+                stage2
+            ]))
+        })
+    })
+})


### PR DESCRIPTION
Fixes #2363

## Description

Ensures the stages in a pipeline are returned in the correct order.

Previously, they were returned in the order the database returned them and didn't take into account `NextStageId`. This was generally based on creation time, so our testing never saw this issue. For some reason, in some cases, the database is returning them in a different order.

The fix was to either fix the API to ensure the order, or fix the frontend to sort the list itself (or both). It felt more correct for the API to return a properly ordered list.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x]  Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why ## Labels

 - [x] Backport needed? -> add the `backport` label

