### PR TITLE
Reorganise pipeline api structure

### DIFF
--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -132,9 +132,10 @@ const getPipeline = async (applicationId, pipelineId) => {
  */
 const createPipeline = async (applicationId, name) => {
     const options = {
-        name
+        name,
+        applicationId
     }
-    return client.post(`/api/v1/applications/${applicationId}/pipelines`, options)
+    return client.post('/api/v1/pipelines', options)
         .then(res => {
             const props = {
                 'pipeline-id': res.data.id,
@@ -152,7 +153,7 @@ const createPipeline = async (applicationId, name) => {
  * @param {string} pipelineId
  */
 const deletePipeline = async (applicationId, pipelineId) => {
-    return client.delete(`/api/v1/applications/${applicationId}/pipelines/${pipelineId}`)
+    return client.delete(`/api/v1/pipelines/${pipelineId}`)
         .then(res => {
             const props = {
                 'pipeline-id': pipelineId,
@@ -175,7 +176,7 @@ const updatePipeline = async (applicationId, pipeline) => {
             name: pipeline.name
         }
     }
-    return client.put(`/api/v1/applications/${applicationId}/pipelines/${pipeline.id}`, body)
+    return client.put(`/api/v1/pipelines/${pipeline.id}`, body)
         .then(res => {
             return res.data
         })

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -33,7 +33,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
     it('can create pipelines containing stages', () => {
         cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
-        cy.intercept('POST', '/api/v1/applications/*/pipelines').as('createPipeline')
+        cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
 
         cy.visit(`/application/${application.id}/pipelines`)
         cy.wait('@getPipelines')
@@ -97,7 +97,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
     it('can edit the instance assigned to a stage', () => {
         cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
-        cy.intercept('POST', '/api/v1/applications/*/pipelines').as('createPipeline')
+        cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
 
         cy.visit(`/application/${application.id}/pipelines`)
         cy.wait('@getPipelines')

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -462,8 +462,9 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
+                    url: '/api/v1/pipelines',
                     payload: {
+                        applicationId,
                         name: pipelineName
                     },
                     cookies: { sid: TestObjects.tokens.alice }
@@ -485,8 +486,10 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
-                    payload: {},
+                    url: '/api/v1/pipelines',
+                    payload: {
+                        applicationId
+                    },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
 
@@ -503,9 +506,10 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
+                    url: '/api/v1/pipelines',
                     payload: {
-                        name: ' '
+                        name: ' ',
+                        applicationId
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -526,9 +530,10 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
+                    url: '/api/v1/pipelines',
                     payload: {
-                        name: pipelineName
+                        name: pipelineName,
+                        applicationId
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -546,9 +551,10 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
+                    url: '/api/v1/pipelines',
                     payload: {
-                        name: pipelineName
+                        name: pipelineName,
+                        applicationId
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
@@ -568,9 +574,10 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
+                    url: '/api/v1/pipelines',
                     payload: {
-                        name: pipelineName
+                        name: pipelineName,
+                        applicationId
                     },
                     cookies: { sid: TestObjects.tokens.pez }
                 })
@@ -590,9 +597,10 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'POST',
-                    url: `/api/v1/applications/${applicationId}/pipelines`,
+                    url: '/api/v1/pipelines',
                     payload: {
-                        name: pipelineName
+                        name: pipelineName,
+                        applicationId
                     }
                 })
 
@@ -614,7 +622,7 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'DELETE',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${pipeline.hashid}`,
                     cookies: { sid: TestObjects.tokens.alice }
                 })
 
@@ -641,7 +649,7 @@ describe('Pipelines API', function () {
 
                 const response = await app.inject({
                     method: 'DELETE',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${pipeline.hashid}`,
                     cookies: { sid: TestObjects.tokens.alice }
                 })
 
@@ -666,7 +674,7 @@ describe('Pipelines API', function () {
             it('Should fail gracefully', async function () {
                 const response = await app.inject({
                     method: 'DELETE',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/`,
+                    url: '/api/v1/pipelines/',
                     cookies: { sid: TestObjects.tokens.alice }
                 })
 
@@ -680,7 +688,7 @@ describe('Pipelines API', function () {
             it('Should fail gracefully', async function () {
                 const response = await app.inject({
                     method: 'DELETE',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/doesnotexist`,
+                    url: '/api/v1/pipelines/doesnotexist',
                     cookies: { sid: TestObjects.tokens.alice }
                 })
 
@@ -694,7 +702,7 @@ describe('Pipelines API', function () {
             it('Should fail validation', async function () {
                 const response = await app.inject({
                     method: 'DELETE',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${TestObjects.pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${TestObjects.pipeline.hashid}`,
                     cookies: { sid: TestObjects.tokens.pez }
                 })
 
@@ -718,7 +726,7 @@ describe('Pipelines API', function () {
             it('Should update the name of the pipeline', async function () {
                 const response = await app.inject({
                     method: 'PUT',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${TestObjects.pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${TestObjects.pipeline.hashid}`,
                     payload: {
                         pipeline: { name: 'new-name' }
                     },
@@ -739,7 +747,7 @@ describe('Pipelines API', function () {
             it('Unset - Should fail gracefully', async function () {
                 const response = await app.inject({
                     method: 'PUT',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${TestObjects.pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${TestObjects.pipeline.hashid}`,
                     payload: {
                         pipeline: {}
                     },
@@ -755,7 +763,7 @@ describe('Pipelines API', function () {
             it('Blank - Should fail gracefully', async function () {
                 const response = await app.inject({
                     method: 'PUT',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${TestObjects.pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${TestObjects.pipeline.hashid}`,
                     payload: {
                         pipeline: {
                             name: ''
@@ -773,7 +781,7 @@ describe('Pipelines API', function () {
             it('String of spaces - Should fail gracefully', async function () {
                 const response = await app.inject({
                     method: 'PUT',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${TestObjects.pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${TestObjects.pipeline.hashid}`,
                     payload: {
                         pipeline: {
                             name: '    '
@@ -793,7 +801,7 @@ describe('Pipelines API', function () {
             it('Should fail validation', async function () {
                 const response = await app.inject({
                     method: 'PUT',
-                    url: `/api/v1/applications/${TestObjects.application.hashid}/pipelines/${TestObjects.pipeline.hashid}`,
+                    url: `/api/v1/pipelines/${TestObjects.pipeline.hashid}`,
                     payload: {
                         name: 'haxor'
                     },

--- a/test/unit/frontend/api/pipelines.spec.js
+++ b/test/unit/frontend/api/pipelines.spec.js
@@ -119,7 +119,7 @@ describe('Applications API', async () => {
         const pipelineName = 'My Pipeline'
         ApplicationsAPI.default.createPipeline(applicationId, pipelineName)
         expect(mockPost).toHaveBeenCalledOnce()
-        expect(mockPost).toHaveBeenCalledWith(`/api/v1/applications/${applicationId}/pipelines`, { name: pipelineName })
+        expect(mockPost).toHaveBeenCalledWith('/api/v1/pipelines', { name: pipelineName, applicationId })
     })
 
     test('deletePipeline calls the correct API endpoint', () => {
@@ -127,6 +127,6 @@ describe('Applications API', async () => {
         const pipelineId = 'application-id'
         ApplicationsAPI.default.deletePipeline(applicationId, pipelineId)
         expect(mockDelete).toHaveBeenCalledOnce()
-        expect(mockDelete).toHaveBeenCalledWith(`/api/v1/applications/${applicationId}/pipelines/${pipelineId}`)
+        expect(mockDelete).toHaveBeenCalledWith(`/api/v1/pipelines/${pipelineId}`)
     })
 })


### PR DESCRIPTION
## Description

Whilst documenting the pipeline apis, I found some general inconsistencies with how we approach objects in the API. Primarily, hanging *some* apis under `/api/v1/applications/:id/pipelines` and others under `/api/v1/pipelines/:id` looked out of place once they had been documented and sat next to each other in the docs.

In summary, this is the existing api:

<img width="939" alt="pipelines-api-pre" src="https://github.com/flowforge/flowforge/assets/51083/3eb49188-38fb-4ee3-b466-76e226482e1e">

This is how it looks after this PR:

<img width="865" alt="pipelines-api-post" src="https://github.com/flowforge/flowforge/assets/51083/4f2bb8de-4ad3-4b7b-b8f7-bc0185c69571">

To summarise:

 - All pipeline operations now live under `/api/v1/pipelines/...`
 - Listing the pipelines that belong to an application stays where it was - `/api/v1/applications/:id/pipelines` - as that is consistent with other apis for listing resources owned by the application
 - Creating a pipeline (`PUT /api/v1/pipelines`) now expects an `applicationId` property in the body (where it was previously one of the url params)

I have also reordered the routes in the file so they appear in a more logic order in the swagger output.

Unit tests updated to handle changed routes. UI updated as well. Although, as I type this, I realise I haven't run the `e2e` tests locally... will do so next.