### PR TITLE
Replace projectCount with instanceCount on public api

### DIFF
--- a/forge/db/views/ProjectStack.js
+++ b/forge/db/views/ProjectStack.js
@@ -11,7 +11,7 @@ module.exports = function (app) {
             properties: { type: 'object', additionalProperties: true },
             replacedBy: { type: 'string' },
             createdAt: { type: 'string' },
-            projectCount: { type: 'number' },
+            instanceCount: { type: 'number' },
             links: { $ref: 'LinksMeta' }
         }
     })
@@ -31,7 +31,7 @@ module.exports = function (app) {
                 links: stack.links
             }
             if (includeCount) {
-                filtered.projectCount = parseInt(result.projectCount) || 0
+                filtered.instanceCount = parseInt(result.projectCount) || 0
             }
             return filtered
         } else {

--- a/forge/db/views/ProjectTemplate.js
+++ b/forge/db/views/ProjectTemplate.js
@@ -16,7 +16,7 @@ module.exports = function (app) {
                 name: result.name,
                 description: result.description,
                 active: result.active,
-                projectCount: result.projectCount,
+                instanceCount: result.projectCount,
                 settings: result.settings || {},
                 policy: result.policy || {},
                 createdAt: result.createdAt,
@@ -42,7 +42,7 @@ module.exports = function (app) {
             name: { type: 'string' },
             description: { type: 'string' },
             active: { type: 'boolean' },
-            projectCount: { type: 'number' },
+            instanceCount: { type: 'number' },
             createdAt: { type: 'string' },
             links: { $ref: 'LinksMeta' },
             owner: { $ref: 'UserSummary' }
@@ -56,7 +56,7 @@ module.exports = function (app) {
                 name: result.name,
                 description: result.description,
                 active: result.active,
-                projectCount: result.projectCount,
+                instanceCount: result.projectCount,
                 createdAt: result.createdAt,
                 links: result.links
             }

--- a/forge/db/views/ProjectType.js
+++ b/forge/db/views/ProjectType.js
@@ -28,7 +28,7 @@ module.exports = function (app) {
             properties: { type: 'object', additionalProperties: true },
             createdAt: { type: 'string' },
             defaultStack: { type: 'string', nullable: true },
-            projectCount: { type: 'number' },
+            instanceCount: { type: 'number' },
             stackCount: { type: 'number' }
 
         }
@@ -47,7 +47,7 @@ module.exports = function (app) {
                 defaultStack: app.db.models.ProjectStack.encodeHashid(result.defaultStackId) || null
             }
             if (includeCount) {
-                filtered.projectCount = parseInt(result.projectCount) || 0
+                filtered.instanceCount = parseInt(result.projectCount) || 0
                 filtered.stackCount = parseInt(result.stackCount) || 0
             }
             return filtered

--- a/forge/db/views/Team.js
+++ b/forge/db/views/Team.js
@@ -36,7 +36,7 @@ module.exports = function (app) {
                     name: { type: 'string' }
                 }
             },
-            projectCount: { type: 'number' },
+            instanceCount: { type: 'number' },
             memberCount: { type: 'number' },
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' },
@@ -54,7 +54,7 @@ module.exports = function (app) {
                 type: app.db.views.TeamType.teamType(result.TeamType),
                 slug: result.slug,
                 avatar: result.avatar,
-                projectCount: result.projectCount,
+                instanceCount: result.projectCount,
                 memberCount: result.memberCount,
                 createdAt: result.createdAt,
                 updatedAt: result.updatedAt,
@@ -85,7 +85,7 @@ module.exports = function (app) {
                 slug: d.Team.slug,
                 avatar: d.Team.avatar,
                 role: d.role,
-                projectCount: d.projectCount,
+                instanceCount: d.projectCount,
                 memberCount: d.memberCount,
                 links: d.Team.links
             }

--- a/forge/routes/api/admin.js
+++ b/forge/routes/api/admin.js
@@ -12,9 +12,9 @@ module.exports = async function (app) {
             adminCount: 0,
             teamCount: await app.db.models.Team.count(),
             maxTeams: license.teams,
-            projectCount: 0,
-            maxProjects: license.projects,
-            projectsByState: {}
+            instanceCount: 0,
+            maxInstances: license.projects,
+            instancesByState: {}
         }
         userCount.forEach(u => {
             result.userCount += u.count
@@ -24,8 +24,8 @@ module.exports = async function (app) {
         })
 
         projectStateCounts.forEach(projectState => {
-            result.projectCount += projectState.count
-            result.projectsByState[projectState.state] = projectState.count
+            result.instanceCount += projectState.count
+            result.instancesByState[projectState.state] = projectState.count
         })
         if (app.billing) {
             const teamStateCounts = await app.db.models.Subscription.count({ attributes: ['status'], group: 'status' })

--- a/forge/routes/api/stack.js
+++ b/forge/routes/api/stack.js
@@ -184,7 +184,7 @@ module.exports = async function (app) {
                 await replacedStack.save()
             }
             const response = app.db.views.ProjectStack.stack(stack)
-            response.projectCount = 0
+            response.instanceCount = 0
             reply.send(response)
         } catch (err) {
             let responseMessage

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -32,8 +32,8 @@ const getTeam = (team) => {
         const props = {
             'team-name': res.data.name,
             'created-at': res.data.createdAt,
-            'count-applications': res.data.projectCount,
-            'count-instances': res.data.projectCount,
+            'count-applications': res.data.instanceCount,
+            'count-instances': res.data.instanceCount,
             'count-members': res.data.memberCount
         }
         if ('billing' in res.data) {

--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -35,7 +35,7 @@ export default {
         return {
             columns: [
                 { label: 'Name', key: 'name', class: ['flex-grow'], component: { is: markRaw(TeamCell) } },
-                { label: 'Application Instances', key: 'projectCount', class: ['w-32', 'text-center'] },
+                { label: 'Application Instances', key: 'instanceCount', class: ['w-32', 'text-center'] },
                 { label: 'Members', key: 'memberCount', class: ['w-32', 'text-center'] },
                 { label: 'Role', key: 'roleName', class: ['w-40'] }
             ]

--- a/frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue
+++ b/frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue
@@ -143,7 +143,7 @@ export default {
                 this.instanceType = instanceType
                 this.stacks = []
                 if (instanceType) {
-                    this.editDisabled = instanceType.projectCount > 0
+                    this.editDisabled = instanceType.instanceCount > 0
                     this.input = {
                         name: instanceType.name,
                         active: instanceType.active,

--- a/frontend/src/pages/admin/InstanceTypes/index.vue
+++ b/frontend/src/pages/admin/InstanceTypes/index.vue
@@ -15,7 +15,7 @@
                                       :editable="true" @edit="showEditInstanceTypeDialog(instanceType)" :price="instanceType.properties?.billingDescription?.split('/')[0]"
                                       :price-interval="instanceType.properties?.billingDescription?.split('/')[1]"
                                       :label="instanceType.name" :description="instanceType.description"
-                                      :meta="[{key: 'Instance Count', value: instanceType.projectCount}, {key: 'Stack Count', value: instanceType.stackCount}]"/>
+                                      :meta="[{key: 'Instance Count', value: instanceType.instanceCount}, {key: 'Stack Count', value: instanceType.stackCount}]"/>
         </ff-tile-selection>
         <div v-if="nextCursor">
             <a v-if="!loading" @click.stop="loadItems" class="forge-button-inline">Load more...</a>
@@ -62,7 +62,7 @@ export default {
                 { label: 'Type', key: 'name', sortable: true },
                 { label: 'Description', key: 'description', sortable: true, component: { is: markRaw(InstanceTypeDescriptionCell) } },
                 { label: 'Default Stack', class: ['w-48'], key: 'defaultStack', sortable: true },
-                { label: 'Application Instances', class: ['w-32', 'text-center'], key: 'projectCount', sortable: true },
+                { label: 'Application Instances', class: ['w-32', 'text-center'], key: 'instanceCount', sortable: true },
                 { label: 'Stacks', class: ['w-32', 'text-center'], key: 'stackCount', sortable: true }
             ]
         }
@@ -103,13 +103,13 @@ export default {
             this.$refs.adminInstanceTypeEditDialog.show(instanceType)
         },
         showConfirmInstanceTypeDeleteDialog (instanceType) {
-            const text = instanceType.projectCount > 0 ? 'You cannot delete an instance type that is still being used by instances.' : 'Are you sure you want to delete this instance type?'
+            const text = instanceType.instanceCount > 0 ? 'You cannot delete an instance type that is still being used by instances.' : 'Are you sure you want to delete this instance type?'
             Dialog.show({
                 header: 'Delete Instance Type',
                 kind: 'danger',
                 text,
                 confirmLabel: 'Delete',
-                disablePrimary: instanceType.projectCount > 0
+                disablePrimary: instanceType.instanceCount > 0
             }, async () => {
                 // on confirm - delete the instance type
                 await instanceTypesApi.deleteInstanceType(instanceType.id)

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -13,15 +13,15 @@
         </div>
         <div class="border rounded p-4 text-center">
             <router-link to="/admin/teams">
-                <div class="text-xl">{{stats.teamCount}}/{{stats.maxProjects}}</div>
+                <div class="text-xl">{{stats.teamCount}}/{{stats.maxTeams}}</div>
                 <div>{{ $filters.pluralize(stats.teamCount,'Team')}}</div>
             </router-link>
         </div>
         <div class="border rounded p-4 text-center">
-            <div class="text-xl">{{stats.projectCount}}/{{stats.maxProjects}}</div>
-            <div>{{ $filters.pluralize(stats.projectCount,'Project')}}</div>
-            <div v-if="stats.projectsByState && Object.keys(stats.projectsByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
-                <div v-for="(count, state) in stats.projectsByState" :key="state">
+            <div class="text-xl">{{stats.instanceCount}}/{{stats.maxInstances}}</div>
+            <div>{{ $filters.pluralize(stats.instanceCount,'Project')}}</div>
+            <div v-if="stats.instancesByState && Object.keys(stats.instancesByState).length > 0" class="w-full grid grid-cols-1 pt-1 mt-2 border-t">
+                <div v-for="(count, state) in stats.instancesByState" :key="state">
                     {{ count }} {{ state }}
                 </div>
             </div>

--- a/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
+++ b/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
@@ -225,7 +225,7 @@ export default {
             showEdit (stack) {
                 this.$refs.dialog.show()
                 this.stack = stack
-                this.editDisabled = stack.projectCount > 0
+                this.editDisabled = stack.instanceCount > 0
                 this.editTypeDisabled = !!stack.projectType
                 this.input = {
                     name: stack.name,

--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -96,13 +96,13 @@ export default {
             activeColumns: [
                 { label: 'Stack', key: 'name', component: { is: markRaw(StackName) } },
                 { label: 'Properties', component: { is: markRaw(StackPropertiesCell) } },
-                { label: 'Project Count', key: 'projectCount', class: ['w-32', 'text-center'] }
+                { label: 'Instance Count', key: 'instanceCount', class: ['w-32', 'text-center'] }
             ],
             inactiveColumns: [
                 { label: 'Stack', component: { is: markRaw(StackName) } },
                 { label: 'Properties', component: { is: markRaw(StackPropertiesCell) } },
                 { label: 'Replaced By', key: 'replacedBy', class: ['w-56'] },
-                { label: 'Project Count', key: 'projectCount', class: ['w-32', 'text-center'] }
+                { label: 'Instance Count', key: 'instanceCount', class: ['w-32', 'text-center'] }
             ]
         }
     },
@@ -135,13 +135,13 @@ export default {
                     this.$refs.adminStackEditDialog.showEdit(stack)
                     break
                 case 'delete': {
-                    const text = stack.projectCount > 0 ? 'You cannot delete a stack that is still being used by projects.' : 'Are you sure you want to delete this stack?'
+                    const text = stack.instanceCount > 0 ? 'You cannot delete a stack that is still being used by instances.' : 'Are you sure you want to delete this stack?'
                     Dialog.show({
                         header: 'Delete Stack',
                         kind: 'danger',
                         text,
                         confirmLabel: 'Delete',
-                        disablePrimary: stack.projectCount > 0
+                        disablePrimary: stack.instanceCount > 0
                     }, async () => {
                         // on confirm - delete the stack
                         stacksApi.deleteStack(stack.id)

--- a/frontend/src/pages/admin/Teams.vue
+++ b/frontend/src/pages/admin/Teams.vue
@@ -42,7 +42,7 @@ export default {
                 { label: 'Name', class: ['w-full'], component: { is: markRaw(TeamCell) }, sortable: true },
                 { label: 'Type', key: 'type', component: { is: markRaw(TeamTypeCell) }, sortable: true },
                 { label: 'Members', class: ['w-54', 'text-center'], key: 'memberCount', sortable: true },
-                { label: 'Application Instances', class: ['w-54', 'text-center'], key: 'projectCount', sortable: true }
+                { label: 'Application Instances', class: ['w-54', 'text-center'], key: 'instanceCount', sortable: true }
             ]
         }
     },

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -65,7 +65,7 @@ export default {
                         }
                     }
                 },
-                { label: 'Project Count', key: 'projectCount', class: ['w-32'], sortable: true }
+                { label: 'Instance Count', key: 'instanceCount', class: ['w-32'], sortable: true }
             ]
         }
     },
@@ -97,13 +97,13 @@ export default {
             })
         },
         showDeleteDialog (template) {
-            const text = template.projectCount > 0 ? 'You cannot delete a template that is still being used by projects.' : 'Are you sure you want to delete this template?'
+            const text = template.instanceCount > 0 ? 'You cannot delete a template that is still being used by instances.' : 'Are you sure you want to delete this template?'
             Dialog.show({
                 header: 'Delete Template',
                 kind: 'danger',
                 text,
                 confirmLabel: 'Delete',
-                disablePrimary: template.projectCount > 0
+                disablePrimary: template.instanceCount > 0
             }, async () => {
                 await templatesApi.deleteTemplate(template.id)
                 const index = this.templates.indexOf(template)

--- a/frontend/src/pages/admin/Users/UserDetails.vue
+++ b/frontend/src/pages/admin/Users/UserDetails.vue
@@ -88,7 +88,7 @@ export default {
                 { label: 'Role', component: { is: markRaw(UserRoleCell) }, sortable: true },
                 { label: 'Type', key: 'type', component: { is: markRaw(TeamTypeCell) }, sortable: true },
                 { label: 'Members', class: ['w-54', 'text-center'], key: 'memberCount', sortable: true },
-                { label: 'Application Instances', class: ['w-54', 'text-center'], key: 'projectCount', sortable: true }
+                { label: 'Application Instances', class: ['w-54', 'text-center'], key: 'instanceCount', sortable: true }
             ]
         }
     },

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -483,7 +483,7 @@ export default {
         //     - already has a instance created
         if (this.team.billing?.canceled ||
             !this.team.billing?.trial ||
-            (this.team.billing?.trialEnded || this.team.projectCount > 0)
+            (this.team.billing?.trialEnded || this.team.instanceCount > 0)
         ) {
             this.$router.push({
                 path: `/team/${this.team.slug}/billing`

--- a/test/e2e/frontend/cypress/fixtures/admin/stacks/stack-active.json
+++ b/test/e2e/frontend/cypress/fixtures/admin/stacks/stack-active.json
@@ -9,5 +9,5 @@
   },
   "replacedBy": "",
   "createdAt": "2022-10-19T13:58:45.241Z",
-  "projectCount": 0
+  "instanceCount": 0
 }

--- a/test/e2e/frontend/cypress/fixtures/admin/stacks/stack-inactive.json
+++ b/test/e2e/frontend/cypress/fixtures/admin/stacks/stack-inactive.json
@@ -9,5 +9,5 @@
   },
   "replacedBy": 1,
   "createdAt": "2022-10-19T13:58:45.241Z",
-  "projectCount": 0
+  "instanceCount": 0
 }

--- a/test/unit/forge/routes/api/projectType_spec.js
+++ b/test/unit/forge/routes/api/projectType_spec.js
@@ -60,7 +60,7 @@ describe('Project Type API', function () {
             result.should.have.property('name', name)
             result.should.have.property('active', true)
             result.should.have.property('description', 'another-project-type')
-            result.should.have.property('projectCount', 0)
+            result.should.have.property('instanceCount', 0)
             result.should.have.property('stackCount', 0)
             result.should.have.property('properties')
             result.should.have.property('defaultStack', null)

--- a/test/unit/forge/routes/api/stack_spec.js
+++ b/test/unit/forge/routes/api/stack_spec.js
@@ -77,7 +77,7 @@ describe('Stack API', function () {
             result.should.have.property('name', stackName)
             result.should.have.property('active', true)
             result.should.have.property('projectType', TestObjects.projectType1.hashid)
-            result.should.have.property('projectCount', 0)
+            result.should.have.property('instanceCount', 0)
             result.should.have.property('properties')
             result.properties.should.have.property('foo', 'bar')
             result.should.not.have.property('replacedBy')
@@ -245,7 +245,7 @@ describe('Stack API', function () {
     })
 
     describe('Get stack info', async function () {
-        it('Includes projectCount for admin user', async function () {
+        it('Includes instanceCount for admin user', async function () {
             const response = await app.inject({
                 method: 'GET',
                 url: `/api/v1/stacks/${TestObjects.stack1.hashid}`,
@@ -255,9 +255,9 @@ describe('Stack API', function () {
             result.should.have.property('id')
             result.should.have.property('name', 'stack1')
             result.should.have.property('active', true)
-            result.should.have.property('projectCount', 1)
+            result.should.have.property('instanceCount', 1)
         })
-        it('Excludes projectCount for non-admin user', async function () {
+        it('Excludes instanceCount for non-admin user', async function () {
             const response = await app.inject({
                 method: 'GET',
                 url: `/api/v1/stacks/${TestObjects.stack1.hashid}`,
@@ -267,7 +267,7 @@ describe('Stack API', function () {
             result.should.have.property('id')
             result.should.have.property('name', 'stack1')
             result.should.have.property('active', true)
-            result.should.not.have.property('projectCount')
+            result.should.not.have.property('instanceCount')
         })
     })
 
@@ -311,7 +311,7 @@ describe('Stack API', function () {
             result.should.have.property('id')
             result.should.have.property('name', 'stack1')
             result.should.have.property('active', false)
-            result.should.have.property('projectCount', 1)
+            result.should.have.property('instanceCount', 1)
 
             // Restore the flag for later tests
             await app.inject({


### PR DESCRIPTION
## Description

This PR renames `projectCount` to `instanceCount` across all public api end points. Making this change prior to us formally documenting the API.

Note this does not change the internal APIs on the Team object (and others) that still provide a `projectCount()` function used to get the value.

Making this change against the `1556-api-docs` branch so the swagger doc is updated to match.

Runtime unit tests updated and checked. Ui tests will run on the PR; also done some click testing around the affected frontend files.