### PR TITLE
Fix LottieAnimations import and assignment at app-level

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -13,14 +13,13 @@ import Alerts from './services/alerts.js'
 import store from './store/index.js'
 import './index.css'
 
-// Globally available FF Components
-
 const app = createApp(App)
     .use(ForgeUIComponents)
-    .use(LottieAnimation)
     .use(store)
     .use(router)
 
+// Globally available FF Components
+app.component('lottie-animation', LottieAnimation)
 app.component('ff-loading', Loading)
 
 app.config.errorHandler = function (err, vm, info) {

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -24,7 +24,7 @@
         </template>
     </SectionTopMenu>
     <div class="space-y-6">
-        <ff-loading v-if="loading" message="Loading Applications..." />
+        <ff-loading v-if="true" message="Loading Applications..." />
         <template v-else-if="!loading && applications.size > 0">
             <ul class="ff-applications-list">
                 <li v-for="application in Array.from(applications.values())" :key="application.id">

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -24,7 +24,7 @@
         </template>
     </SectionTopMenu>
     <div class="space-y-6">
-        <ff-loading v-if="true" message="Loading Applications..." />
+        <ff-loading v-if="loading" message="Loading Applications..." />
         <template v-else-if="!loading && applications.size > 0">
             <ul class="ff-applications-list">
                 <li v-for="application in Array.from(applications.values())" :key="application.id">


### PR DESCRIPTION
## Description

With recent updates to LottieAnimations, we no longer append LottieAnimations to our application using `.use()`, instead, we have to import the specific component with `import { LottieAnimation } from 'lottie-web-vue'` and then append it to our application with `app.component('lottie-animation', LottieAnimation)`

## Related Issue(s)

Fixes #2354 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

