### PR TITLE
Post Billing Setup - Empty State & Alert

### DIFF
--- a/frontend/src/layouts/Platform.vue
+++ b/frontend/src/layouts/Platform.vue
@@ -11,7 +11,7 @@
             </div>
             <TransitionGroup class="ff-notifications" name="notifications-list" tag="div">
                 <ff-notification-toast v-for="(a, $index) in alertsReversed" :key="a.timestamp"
-                                       :type="a.type" :message="a.message"
+                                       :type="a.type" :message="a.message" data-el="notification-alert"
                                        :countdown="a.countdown || 3000" @close="clear($index)"></ff-notification-toast>
             </TransitionGroup>
             <interview-popup v-if="interview?.enabled" :flag="interview.flag" :payload="interview.payload"></interview-popup>

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -150,7 +150,10 @@ export default {
     mounted () {
         this.fetchData()
         if ('billing_session' in this.$route.query) {
-            Alerts.emit('Thanks for signing up to FlowForge!', 'confirmation')
+            this.$nextTick(() => {
+                // allow the Alerts servcie to have subscription by wrapping in nextTick
+                Alerts.emit('Thanks for signing up to FlowForge!', 'confirmation')
+            })
         }
     },
     methods: {

--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -70,12 +70,6 @@
                 </li>
             </ul>
         </template>
-        <div v-else-if="justSetupBilling">
-            <div class=" mt-8 text-center text-lg">
-                <strong class="mb-2 block">Thank you for signing up to FlowForge!</strong>
-                You are now able to create applications, instances & devices.
-            </div>
-        </div>
         <div v-else>
             <EmptyState>
                 <template #img>
@@ -124,6 +118,7 @@ import InstanceStatusPolling from '../../components/InstanceStatusPolling.vue'
 import SectionTopMenu from '../../components/SectionTopMenu.vue'
 import ProjectIcon from '../../components/icons/Projects.js'
 import permissionsMixin from '../../mixins/Permissions.js'
+import Alerts from '../../services/alerts.js'
 import InstanceStatusBadge from '../instance/components/InstanceStatusBadge.vue'
 import InstanceEditorLinkCell from '../instance/components/cells/InstanceEditorLink.vue'
 export default {
@@ -149,16 +144,14 @@ export default {
             ]
         }
     },
-    computed: {
-        justSetupBilling () {
-            return 'billing_session' in this.$route.query
-        }
-    },
     watch: {
         team: 'fetchData'
     },
     mounted () {
         this.fetchData()
+        if ('billing_session' in this.$route.query) {
+            Alerts.emit('Thanks for signing up to FlowForge!', 'confirmation')
+        }
     },
     methods: {
         async fetchData () {

--- a/test/e2e/frontend/cypress/tests-ee/applications/empty-state.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/empty-state.spec.js
@@ -1,0 +1,30 @@
+describe('FlowForge - Application - Empty State', () => {
+    beforeEach(() => {
+        cy.login('bob', 'bbPassword')
+        cy.intercept('GET', '/api/v1/teams/*/applications', (req) => {
+            // stub an empty state response
+            req.reply({
+                count: 0,
+                applications: []
+            })
+        }).as('getTeamApplications')
+        cy.intercept('GET', '/api/v1/teams/*/applications/status', (req) => {
+            // stub an empty state response
+            req.reply({
+                count: 0,
+                applications: []
+            })
+        }).as('getTeamApplicationsStatus')
+        cy.home()
+    })
+
+    it('is shown when a user navigates to the Applications view and has no applications', () => {
+        cy.get('[data-el="empty-state"]').should('exist')
+    })
+
+    it('is shown when a user navigates to the Applications view and has no applications', () => {
+        cy.visit('/team/ateam/applications?billing_session=BILLING_SESSION')
+        cy.get('[data-el="notification-alert"]').should('exist')
+        cy.get('[data-el="notification-alert"]').contains('Thanks for signing up to FlowForge!')
+    })
+})


### PR DESCRIPTION
# Description

- Reverts to the default "Get Started with your First Application" after billing is setup, rather than bespoke post-billing state.
- Introduces an Alert that confirms setup of billing when a billing_session is present, which will always be the case after being redirected from Stripe.
- Add E2E test to check empty state & alert showing

## Related Issue(s)

Fixes #2133

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
