### PR TITLE
Rename device/provisioningToken project field to instance in api

### DIFF
--- a/forge/db/views/AccessToken.js
+++ b/forge/db/views/AccessToken.js
@@ -6,7 +6,7 @@ module.exports = function (app) {
             id: { type: 'string' },
             name: { type: 'string' },
             team: { type: 'string', nullable: true },
-            project: { type: 'string' },
+            instance: { type: 'string' },
             expiresAt: { type: 'string', nullable: true },
             targetSnapshot: { type: 'string' }
         }
@@ -38,6 +38,8 @@ module.exports = function (app) {
         // look up the snapshot name if a snapshot id is present
         if (tokenSummary.project) {
             const project = await app.db.models.Project.byId(tokenSummary.project)
+            // Map to the external property name
+            tokenSummary.instance = tokenSummary.project
             const deviceSettings = await project?.getSetting('deviceSettings') || {
                 targetSnapshot: null
             }

--- a/forge/db/views/Device.js
+++ b/forge/db/views/Device.js
@@ -23,7 +23,7 @@ module.exports = function (app) {
             mode: { type: 'string' },
             links: { $ref: 'LinksMeta' },
             team: { $ref: 'TeamSummary' },
-            project: { $ref: 'InstanceSummary' },
+            instance: { $ref: 'InstanceSummary' },
             application: { $ref: 'ApplicationSummary' },
             editor: { type: 'object', additionalProperties: true }
         }
@@ -56,7 +56,7 @@ module.exports = function (app) {
             filtered.team = app.db.views.Team.teamSummary(device.Team)
         }
         if (device.Project) {
-            filtered.project = app.db.views.Project.projectSummary(device.Project)
+            filtered.instance = app.db.views.Project.projectSummary(device.Project)
             if (device.Project.Application) {
                 filtered.application = app.db.views.Application.applicationSummary(device.Project.Application)
             }

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -178,12 +178,12 @@ module.exports = async function (app) {
             if (request.session.provisioning.project) {
                 project = await app.db.models.Project.byId(request.session.provisioning.project)
                 if (!project) {
-                    reply.code(400).send({ code: 'invalid_project', error: 'Invalid project' })
+                    reply.code(400).send({ code: 'invalid_instance', error: 'Invalid instance' })
                     return
                 }
                 const projectTeam = await project.getTeam()
                 if (projectTeam.id !== team.id) {
-                    reply.code(400).send({ code: 'invalid_project', error: 'Invalid project' })
+                    reply.code(400).send({ code: 'invalid_instance', error: 'Invalid instance' })
                     return
                 }
             }
@@ -324,7 +324,7 @@ module.exports = async function (app) {
                 properties: {
                     name: { type: 'string' },
                     type: { type: 'string' },
-                    project: { type: 'string', nullable: true }
+                    instance: { type: 'string', nullable: true }
                 }
             },
             response: {
@@ -339,10 +339,10 @@ module.exports = async function (app) {
     }, async (request, reply) => {
         let sendDeviceUpdate = false
         const device = request.device
-        if (request.body.project !== undefined) {
+        if (request.body.instance !== undefined) {
             // ### Add/Remove device to/from project ###
 
-            if (request.body.project === null) {
+            if (request.body.instance === null) {
                 // ### Remove device from project ###
 
                 if (device.Project !== null) {
@@ -367,17 +367,17 @@ module.exports = async function (app) {
                 // ### Add device to project ###
 
                 // Update includes a project id?
-                if (device.Project?.id === request.body.project) {
+                if (device.Project?.id === request.body.instance) {
                     // Project is already assigned to this project - nothing to do
                 } else {
                     // Check if the specified project is in the same team
-                    const project = await app.db.models.Project.byId(request.body.project)
+                    const project = await app.db.models.Project.byId(request.body.instance)
                     if (!project) {
-                        reply.code(400).send({ code: 'invalid_project', error: 'invalid project' })
+                        reply.code(400).send({ code: 'invalid_instance', error: 'invalid instance' })
                         return
                     }
                     if (project.Team.id !== device.Team.id) {
-                        reply.code(400).send({ code: 'invalid_project', error: 'invalid project' })
+                        reply.code(400).send({ code: 'invalid_instance', error: 'invalid instance' })
                         return
                     }
                     // Project exists and is in the right team - assign it to the project

--- a/frontend/src/api/devices.js
+++ b/frontend/src/api/devices.js
@@ -100,7 +100,7 @@ const setMode = async (deviceId, mode) => {
 
 /**
  * create a snapshot from a device
- * @param {string} projectId - the project id
+ * @param {string} instanceId - the project id
  * @param {string} deviceId - the device id
  * @param {object} options - the options
  * @param {string} options.name - the name of the snapshot
@@ -108,7 +108,7 @@ const setMode = async (deviceId, mode) => {
  * @param {boolean} [options.setAsTarget] - set the snapshot as the new target for all devices
  * @see https://docs.flowforge.io/api/#operation/createSnapshot
  */
-const createSnapshot = async (projectId, deviceId, options) => {
+const createSnapshot = async (instanceId, deviceId, options) => {
     const data = {
         name: options.name, // name of the snapshot
         description: options.description, // description of the snapshot
@@ -124,7 +124,7 @@ const createSnapshot = async (projectId, deviceId, options) => {
         res.data.createdSince = daysSince(res.data.createdAt)
         res.data.updatedSince = daysSince(res.data.updatedAt)
         product.capture('$ff-snapshot-device', props, {
-            instance: projectId
+            instance: instanceId
         })
         return res.data
     })

--- a/frontend/src/api/team.js
+++ b/frontend/src/api/team.js
@@ -301,11 +301,11 @@ const getTeamDeviceProvisioningTokens = async (teamId, cursor, limit) => {
  */
 const generateTeamDeviceProvisioningToken = async (teamId, options) => {
     options = options || {}
-    const { name, project, expiresAt } = options
+    const { name, instance, expiresAt } = options
     return client.post(`/api/v1/teams/${teamId}/devices/provisioning`,
         {
             name: name || 'Auto Provisioning Token',
-            project,
+            instance,
             expiresAt
         }
     ).then(res => {
@@ -318,16 +318,16 @@ const generateTeamDeviceProvisioningToken = async (teamId, options) => {
  * @param {string} teamId The team ID (hash)
  * @param {string} tokenId The token ID (hash)
  * @param {object} options
- * @param {string} [options.project] The project ID (hash)
+ * @param {string} [options.instance] The instance ID (hash)
  * @param {string} [options.expiresAt] The expiry date of the token
  * @returns
  */
 const updateTeamDeviceProvisioningToken = async (teamId, tokenId, options) => {
     options = options || {}
-    const { project, expiresAt } = options
+    const { instance, expiresAt } = options
     return client.put(`/api/v1/teams/${teamId}/devices/provisioning/${tokenId}`,
         {
-            project,
+            instance,
             expiresAt
         }
     ).then(res => {

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -410,10 +410,10 @@ export default {
         },
 
         async assignDevice (device, instanceId) {
-            const updatedDevice = await deviceApi.updateDevice(device.id, { project: instanceId })
+            const updatedDevice = await deviceApi.updateDevice(device.id, { instance: instanceId })
 
-            if (updatedDevice.project) {
-                device.instance = updatedDevice.project
+            if (updatedDevice.instance) {
+                device.instance = updatedDevice.instance
             }
 
             if (updatedDevice.application) {
@@ -504,7 +504,7 @@ export default {
                     text: 'Are you sure you want to remove this device from the instance? This will stop the flows running on the device.',
                     confirmLabel: 'Remove'
                 }, async () => {
-                    await deviceApi.updateDevice(device.id, { project: null })
+                    await deviceApi.updateDevice(device.id, { instance: null })
 
                     delete device.instance
                     delete device.application

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -41,18 +41,18 @@
                 <tr class="border-b">
                     <td class="w-1/4 font-medium">Application</td>
                     <td class="py-2">
-                        <router-link v-if="device?.project" :to="{name: 'Application', params: { id: device.project.id }}">
-                            {{ device.project?.name }}
+                        <router-link v-if="device?.instance" :to="{name: 'Application', params: { id: device.instance.id }}">
+                            {{ device.instance?.name }}
                         </router-link>
                         <span v-else>None</span>
                     </td>
                 </tr>
-                <!-- TODO: Currently links to same object as project -->
+                <!-- TODO: Currently links to same object as instance -->
                 <tr class="border-b">
                     <td class="w-1/4 font-medium">Instance</td>
                     <td class="py-2">
-                        <router-link v-if="device?.project" :to="{name: 'Instance', params: { id: device.project.id }}">
-                            {{ device.project?.name }}
+                        <router-link v-if="device?.instance" :to="{name: 'Instance', params: { id: device.instance.id }}">
+                            {{ device.instance?.name }}
                         </router-link>
                         <span v-else>None</span>
                     </td>

--- a/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
+++ b/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
@@ -30,7 +30,7 @@ export default {
     data () {
         return {
             input: {
-                projectName: ''
+                deviceName: ''
             },
             formValid: false,
             device: null

--- a/frontend/src/pages/device/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/device/dialogs/SnapshotCreateDialog.vue
@@ -63,8 +63,8 @@ export default {
         }
     },
     computed: {
-        project () {
-            return this.device?.project
+        instance () {
+            return this.device?.instance
         },
         formValid () {
             return !this.submitted && !!(this.input.name)

--- a/frontend/src/pages/device/dialogs/SnapshotCreateDialog.vue
+++ b/frontend/src/pages/device/dialogs/SnapshotCreateDialog.vue
@@ -81,7 +81,7 @@ export default {
                     description: this.input.description,
                     setAsTarget: this.input.setAsTarget
                 }
-                deviceApi.createSnapshot(this.device.project.id, this.device.id, opts).then((response) => {
+                deviceApi.createSnapshot(this.device.instance.id, this.device.id, opts).then((response) => {
                     this.$emit('device-upload-success', response)
                     this.$refs.dialog.close()
                 }).catch(err => {

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -3,7 +3,6 @@
         <SideNavigationTeamOptions>
             <template #nested-menu>
                 <div class="ff-nested-title">Device</div>
-                <!-- <div class="ff-nested-title">{{ project.name }}</div> -->
                 <router-link v-for="route in navigation" :key="route.label" :to="route.path" :data-nav="route.tag">
                     <nav-item :icon="route.icon" :label="route.label" />
                 </router-link>
@@ -25,9 +24,9 @@
                         <DeviceLastSeenBadge class="mr-6" :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
                         <StatusBadge :status="device.status" />
                         <div class="w-full text-sm mt-1">
-                            <div v-if="device?.project">
+                            <div v-if="device?.instance">
                                 Instance:
-                                <router-link :to="{name: 'Instance', params: {id: device.project.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.project.name }}</router-link>
+                                <router-link :to="{name: 'Instance', params: {id: device.instance.id}}" class="text-blue-600 cursor-pointer hover:text-blue-700 hover:underline">{{ device.instance.name }}</router-link>
                             </div>
                             <span v-else class="text-gray-400 italic">Device Not Assigned to an Instance</span>
                         </div>
@@ -47,7 +46,7 @@
                                 <ExternalLinkIcon />
                             </span>
                         </button>
-                        <ff-button :disabled="hasPermission('device:edit') !== true || !device?.project" :kind="developerMode?'primary':'secondary'" data-action="toggle-mode" @click="showModeChoiceDialog()">
+                        <ff-button :disabled="hasPermission('device:edit') !== true || !device?.instance" :kind="developerMode?'primary':'secondary'" data-action="toggle-mode" @click="showModeChoiceDialog()">
                             Developer Mode
                             <template #icon-right>
                                 <BeakerIcon />
@@ -62,7 +61,7 @@
                 <div class="ff-banner" data-el="banner-device-as-admin">You are viewing this device as an Administrator</div>
             </Teleport>
             <div class="px-3 pb-3 md:px-6 md:pb-6">
-                <router-view :instance="device.project" :device="device" @device-updated="loadDevice()" @device-refresh="loadDevice()" />
+                <router-view :instance="device.instance" :device="device" @device-updated="loadDevice()" @device-refresh="loadDevice()" />
             </div>
         </div>
         <ModeChoiceDialog ref="mode-choice-dialog" :device="device" @mode-change="setDeviceMode" />

--- a/frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue
@@ -5,7 +5,7 @@
             <p>This will generate a <code>device.yml</code> to move to your device, that will auto register with this team.</p>
             <form class="space-y-6 mt-2 mb-2">
                 <FormRow data-form="token-name" v-model="input.name" :error="errors.name" :disabled="editMode">Token Name</FormRow>
-                <FormRow :options="projects" v-model="input.project">Auto assign instance (optional)</FormRow>
+                <FormRow :options="instances" v-model="input.instance">Auto assign instance (optional)</FormRow>
             </form>
         </template>
     </ff-dialog>
@@ -28,10 +28,10 @@ export default {
     data () {
         return {
             token: null,
-            projects: [],
+            instances: [],
             input: {
                 name: '',
-                project: '',
+                instance: '',
                 expiryAt: null
             },
             errors: {}
@@ -52,11 +52,11 @@ export default {
         confirm () {
             const opts = {
                 name: this.input.name.trim(),
-                project: this.input.project,
+                instance: this.input.instance,
                 team: this.team.id,
                 expiryAt: this.input.expiryAt
             }
-
+console.log(opts.instance)
             if (this.editMode) {
                 // Update
                 teamApi.updateTeamDeviceProvisioningToken(this.team.id, this.token.id, opts).then((response) => {
@@ -68,8 +68,8 @@ export default {
                     if (err.response.data) {
                         if (/expiryAt/.test(err.response.data.error)) {
                             this.errors.expiryAt = err.response.data.error
-                        } else if (/project/.test(err.response.data.error)) {
-                            this.errors.project = err.response.data.error
+                        } else if (/instance/.test(err.response.data.error)) {
+                            this.errors.instance = err.response.data.error
                         } else {
                             alerts.emit('Failed to update provisioning token: ' + err.response.data.error, 'warning', 7500)
                         }
@@ -86,8 +86,8 @@ export default {
                     if (err.response.data) {
                         if (/expiryAt/.test(err.response.data.error)) {
                             this.errors.expiryAt = err.response.data.error
-                        } else if (/project/.test(err.response.data.error)) {
-                            this.errors.project = err.response.data.error
+                        } else if (/instance/.test(err.response.data.error)) {
+                            this.errors.instance = err.response.data.error
                         } if (/name/.test(err.response.data.error)) {
                             this.errors.name = err.response.data.error
                         } else {
@@ -103,16 +103,16 @@ export default {
             async show (token) {
                 this.errors = {}
                 this.input.name = ''
-                this.input.project = ''
+                this.input.instance = ''
                 this.token = null
                 if (token) {
                     this.token = token
                     this.input.name = token.name
-                    this.input.project = token.project
+                    this.input.instance = token.instance
                 }
                 const result = await teamApi.getTeamInstancesList(this.team.id)
-                this.projects = result?.map(d => { return { value: d.id, label: d.name } }) || []
-                this.projects.unshift({ value: '', label: 'None' })
+                this.instances = result?.map(d => { return { value: d.id, label: d.name } }) || []
+                this.instances.unshift({ value: '', label: 'None' })
                 this.$refs.dialog.show()
             }
         }

--- a/frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue
@@ -56,7 +56,6 @@ export default {
                 team: this.team.id,
                 expiryAt: this.input.expiryAt
             }
-console.log(opts.instance)
             if (this.editMode) {
                 // Update
                 teamApi.updateTeamDeviceProvisioningToken(this.team.id, this.token.id, opts).then((response) => {

--- a/frontend/src/pages/team/Settings/Devices.vue
+++ b/frontend/src/pages/team/Settings/Devices.vue
@@ -70,13 +70,13 @@ const TokenFieldFormatter = {
     components: { KeyIcon }
 }
 
-const ProjectFieldFormatter = {
+const InstanceFieldFormatter = {
     template: `
-        <template v-if="project">
-            <router-link :to="{ name: 'Instance', params: { id: project }}">{{projectName}}</router-link>
+        <template v-if="instance">
+            <router-link :to="{ name: 'Instance', params: { id: instance }}">{{instanceName}}</router-link>
         </template>
         <template v-else><span class="italic text-gray-500">Don't assign</span></template>`,
-    props: ['project', 'projectName']
+    props: ['instance', 'instanceName']
 }
 
 export default {
@@ -90,7 +90,7 @@ export default {
             tokens: new Map(),
             checkInterval: null,
             nextCursor: null,
-            projectNames: []
+            instanceNames: []
         }
     },
     watch: {
@@ -113,8 +113,8 @@ export default {
             }
         },
         async fetchData (nextCursor = null, polled = false) {
-            // load project names into local cache (TODO: consider moving this to a vuex store for global access)
-            this.projectNames = await teamApi.getTeamInstancesList(this.team.id)
+            // load instance names into local cache (TODO: consider moving this to a vuex store for global access)
+            this.instanceNames = await teamApi.getTeamInstancesList(this.team.id)
             // get the tokens
             const data = await teamApi.getTeamDeviceProvisioningTokens(this.team.id, nextCursor)
 
@@ -131,15 +131,15 @@ export default {
                 this.nextCursor = data.meta.next_cursor
             }
         },
-        getProjectName (id) {
-            const project = this.projectNames?.find(p => p.id === id)
-            return project ? project.name : id
+        getInstanceName (id) {
+            const instance = this.instanceNames?.find(p => p.id === id)
+            return instance ? instance.name : id
         },
         async loadMore () {
             await this.fetchData(this.nextCursor)
         },
         showCreateTokenDialog () {
-            this.$refs.CreateProvisioningTokenDialog.show(null, this.project)
+            this.$refs.CreateProvisioningTokenDialog.show(null, this.instance)
         },
         showEditDialog (token) {
             this.$refs.CreateProvisioningTokenDialog.show(token)
@@ -160,7 +160,7 @@ export default {
             this.updateTokenCache(token)
         },
         updateTokenCache (token) {
-            token.projectName = this.getProjectName(token.project)
+            token.instanceName = this.getInstanceName(token.instance)
             this.tokens.set(token.id, token)
         },
         menuAction (action, tokenId) {
@@ -203,7 +203,7 @@ export default {
         columns: function () {
             return [
                 { label: 'Token Name', class: ['w-64'], key: 'name', sortable: true, component: { is: markRaw(TokenFieldFormatter) } },
-                { label: 'Auto Assign Project', class: ['w-64'], key: 'project', sortable: true, component: { is: markRaw(ProjectFieldFormatter) } },
+                { label: 'Auto Assign Instance', class: ['w-64'], key: 'instance', sortable: true, component: { is: markRaw(InstanceFieldFormatter) } },
                 { label: 'Target Snapshot', class: ['w-64'], key: 'targetSnapshot', sortable: true }
             ]
         }

--- a/test/unit/forge/routes/api/device_spec.js
+++ b/test/unit/forge/routes/api/device_spec.js
@@ -173,7 +173,7 @@ describe('Device API', async function () {
             result.should.have.property('type', 'test device')
             result.should.have.property('links').and.be.an.Object()
             result.should.have.property('team').and.be.an.Object()
-            result.should.not.have.property('project')
+            result.should.not.have.property('instance')
             result.should.have.property('credentials').and.be.an.Object()
 
             result.team.should.have.property('id', TestObjects.ATeam.hashid)
@@ -199,7 +199,7 @@ describe('Device API', async function () {
             result.should.have.property('type', 'test device')
             result.should.have.property('links').and.be.an.Object()
             result.should.have.property('team').and.be.an.Object()
-            result.should.not.have.property('project')
+            result.should.not.have.property('instance')
             result.should.have.property('credentials').and.be.an.Object()
 
             result.team.should.have.property('id', TestObjects.ATeam.hashid)
@@ -226,11 +226,11 @@ describe('Device API', async function () {
             result.should.have.property('lastSeenMs', null) // required for device list UI
             result.should.have.property('links').and.be.an.Object()
             result.should.have.property('team').and.be.an.Object()
-            result.should.have.property('project').and.be.an.Object()
+            result.should.have.property('instance').and.be.an.Object()
             result.should.have.property('credentials').and.be.an.Object()
 
             result.team.should.have.property('id', TestObjects.ATeam.hashid)
-            result.project.should.have.property('id', TestObjects.Project1.id)
+            result.instance.should.have.property('id', TestObjects.Project1.id)
             result.credentials.should.have.property('token')
         })
 
@@ -398,8 +398,8 @@ describe('Device API', async function () {
             result.should.not.have.property('accessToken')
 
             result.team.should.have.property('id', TestObjects.ATeam.hashid)
-            result.should.have.property('project')
-            result.project.should.have.property('id', TestObjects.deviceProject.id)
+            result.should.have.property('instance')
+            result.instance.should.have.property('id', TestObjects.deviceProject.id)
         })
 
         it('provides device details - unassigned project', async function () {
@@ -422,7 +422,7 @@ describe('Device API', async function () {
             result.should.have.property('targetSnapshot')
             result.should.have.property('activeSnapshot')
             result.team.should.have.property('id', TestObjects.ATeam.hashid)
-            result.should.not.have.property('project')
+            result.should.not.have.property('instance')
         })
 
         // GET /api/v1/devices/:deviceId
@@ -493,14 +493,14 @@ describe('Device API', async function () {
                     method: 'PUT',
                     url: `/api/v1/devices/${device.id}`,
                     body: {
-                        project: TestObjects.deviceProject.id
+                        instance: TestObjects.deviceProject.id
                     },
                     cookies: { sid: TestObjects.tokens.bob }
                 })
                 const result = response.json()
-                result.should.have.property('project')
+                result.should.have.property('instance')
                 result.should.have.property('targetSnapshot', null)
-                result.project.should.have.property('id', TestObjects.deviceProject.id)
+                result.instance.should.have.property('id', TestObjects.deviceProject.id)
             })
             it('can assign to a project - with active snapshot', async function () {
                 // Create a project
@@ -511,15 +511,15 @@ describe('Device API', async function () {
                     method: 'PUT',
                     url: `/api/v1/devices/${device.id}`,
                     body: {
-                        project: TestObjects.deviceProject.id
+                        instance: TestObjects.deviceProject.id
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
                 const result = response.json()
-                result.should.have.property('project')
+                result.should.have.property('instance')
                 result.should.have.property('targetSnapshot')
                 result.targetSnapshot.should.have.property('id', TestObjects.deviceProjectSnapshot.id)
-                result.project.should.have.property('id', TestObjects.deviceProject.id)
+                result.instance.should.have.property('id', TestObjects.deviceProject.id)
             })
             it('can unassign from a project', async function () {
                 await setupProjectWithSnapshot(true)
@@ -529,13 +529,13 @@ describe('Device API', async function () {
                     method: 'PUT',
                     url: `/api/v1/devices/${device.id}`,
                     body: {
-                        project: TestObjects.deviceProject.id
+                        instance: TestObjects.deviceProject.id
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
                 const result = response.json()
-                result.should.have.property('project')
-                result.project.should.have.property('id', TestObjects.deviceProject.id)
+                result.should.have.property('instance')
+                result.instance.should.have.property('id', TestObjects.deviceProject.id)
                 result.should.have.property('targetSnapshot')
                 result.targetSnapshot.should.have.property('id', TestObjects.deviceProjectSnapshot.id)
 
@@ -543,12 +543,12 @@ describe('Device API', async function () {
                     method: 'PUT',
                     url: `/api/v1/devices/${device.id}`,
                     body: {
-                        project: null
+                        instance: null
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })
                 const result2 = response2.json()
-                result2.should.not.have.property('project')
+                result2.should.not.have.property('instance')
                 // Check the targetSnapshot has been cleared
                 result2.should.have.property('targetSnapshot', null)
             })
@@ -563,7 +563,7 @@ describe('Device API', async function () {
                     method: 'PUT',
                     url: `/api/v1/devices/${device.id}`,
                     body: {
-                        project: TestObjects.deviceProject.id
+                        instance: TestObjects.deviceProject.id
                     },
                     cookies: { sid: TestObjects.tokens.chris }
                 })
@@ -579,7 +579,7 @@ describe('Device API', async function () {
                     method: 'PUT',
                     url: `/api/v1/devices/${device.id}`,
                     body: {
-                        project: TestObjects.deviceProject.id
+                        instance: TestObjects.deviceProject.id
                     },
                     cookies: { sid: TestObjects.tokens.alice }
                 })

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -172,17 +172,17 @@ describe('Team Devices API', function () {
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
                     name: 'Provisioning Token',
-                    project: TestObjects.Project1.id
+                    instance: TestObjects.Project1.id
                 }
             })
             response.statusCode.should.equal(200)
             const result = response.json()
-            result.should.have.only.keys('token', 'id', 'name', 'expiresAt', 'team', 'project')
+            result.should.have.only.keys('token', 'id', 'name', 'expiresAt', 'team', 'instance')
             result.should.have.property('token').and.be.a.String()
             result.should.have.property('id').and.be.a.String()
             result.should.have.property('name', 'Provisioning Token')
             result.should.have.property('team', TestObjects.ATeam.hashid)
-            result.should.have.property('project', TestObjects.Project1.id)
+            result.should.have.property('instance', TestObjects.Project1.id)
         })
         it('Cannot generate a provisioning token with invalid name', async function () {
             // POST /api/v1/team/:teamId/devices/provisioning
@@ -208,16 +208,16 @@ describe('Team Devices API', function () {
                 url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices/provisioning/${TestObjects.provisioningTokens.token1.id}`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
-                    project: TestObjects.Project1.id
+                    instance: TestObjects.Project1.id
                 }
             })
             response.statusCode.should.equal(200)
             const result = response.json()
-            result.should.have.only.keys('id', 'name', 'expiresAt', 'team', 'project')
+            result.should.have.only.keys('id', 'name', 'expiresAt', 'team', 'instance')
             result.should.have.property('id', TestObjects.provisioningTokens.token1.id)
             result.should.have.property('name', 'Provisioning Token 1')
             result.should.have.property('team', TestObjects.ATeam.hashid)
-            result.should.have.property('project', TestObjects.Project1.id)
+            result.should.have.property('instance', TestObjects.Project1.id)
         })
         it('Edit a provisioning token to unassign a project', async function () {
             // PUT /api/v1/team/:teamId/devices/provisioning/:tokenId
@@ -227,7 +227,7 @@ describe('Team Devices API', function () {
                 url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices/provisioning/${TestObjects.provisioningTokens.token2.id}`,
                 cookies: { sid: TestObjects.tokens.alice },
                 payload: {
-                    project: null
+                    instance: null
                 }
             })
             response.statusCode.should.equal(200)
@@ -245,7 +245,7 @@ describe('Team Devices API', function () {
                 url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices/provisioning/${TestObjects.provisioningTokens.token2.id}`,
                 cookies: { sid: TestObjects.tokens.chris },
                 payload: {
-                    project: null
+                    instance: null
                 }
             })
             response.statusCode.should.equal(401)


### PR DESCRIPTION
## Description

Renames the `project` field in both the Device object and the ProvisioningToken object to `instance` in the public API.

Internally, it is still called `project` in the database.

