### PR TITLE
Fix swagger validation errors

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -89,7 +89,7 @@ module.exports = async function (app) {
             params: {
                 type: 'object',
                 properties: {
-                    teamId: { type: 'string' }
+                    instanceId: { type: 'string' }
                 }
             },
             response: {

--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -158,7 +158,7 @@ module.exports = async function (app) {
                 properties: {
                     name: { type: 'string' },
                     description: { type: 'string' },
-                    flows: { type: 'array' },
+                    flows: { type: 'array', items: { type: 'object' } },
                     credentials: { type: 'object' },
                     credentialSecret: { type: 'string' },
                     settings: {

--- a/forge/routes/api/projectType.js
+++ b/forge/routes/api/projectType.js
@@ -163,6 +163,12 @@ module.exports = async function (app) {
         schema: {
             summary: 'Update an instance type - admin-only',
             tags: ['Instance Types'],
+            params: {
+                type: 'object',
+                properties: {
+                    instanceTypeId: { type: 'string' }
+                }
+            },
             body: {
                 type: 'object',
                 properties: {

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -612,6 +612,12 @@ module.exports = async function (app) {
                     { $ref: 'AuditLogQueryParams' }
                 ]
             },
+            params: {
+                type: 'object',
+                properties: {
+                    teamId: { type: 'string' }
+                }
+            },
             response: {
                 200: {
                     type: 'object',

--- a/forge/routes/api/teamMembers.js
+++ b/forge/routes/api/teamMembers.js
@@ -82,6 +82,7 @@ module.exports = async function (app) {
             params: {
                 type: 'object',
                 properties: {
+                    teamId: { type: 'string' },
                     userId: { type: 'string' }
                 }
             },
@@ -123,6 +124,7 @@ module.exports = async function (app) {
             params: {
                 type: 'object',
                 properties: {
+                    teamId: { type: 'string' },
                     userId: { type: 'string' }
                 }
             },

--- a/forge/routes/api/template.js
+++ b/forge/routes/api/template.js
@@ -183,6 +183,12 @@ module.exports = async function (app) {
         schema: {
             summary: 'Update a template - admin-only',
             tags: ['Templates'],
+            params: {
+                type: 'object',
+                properties: {
+                    templateId: { type: 'string' }
+                }
+            },
             body: {
                 type: 'object',
                 required: ['name', 'settings', 'policy'],


### PR DESCRIPTION
Part of #2397 

## Description

Fixes the validation errors identified in #2397 

The swagger doc ui includes a validation icon at the bottom. However it doesn't do this when on localhost as the external validator cannot access localhost.

But this raises a separate issue - for self-hosted instances, having the page ping out to an external service not controlled by the custom (or flowforge) may be a cause for concern. So I have disabled the validation in the UI.

I'm looking for a way to validate the generated openapi spec as part of a unit test - that doesn't rely on the external service to do it. The only module I've found does schema validation (is the json structured properly) but *not* spec validation (does it have all the `params` it should). We already know the json will be well formed as it is generated by fastify-swagger - we need to know if it is spec compliant. I'll keep looking, but lets get this fixes in now.

