### PR TITLE
remove billing confirmation

### DIFF
--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -47,7 +47,11 @@
             </template>
         </div>
     </div>
-    <div v-if="!trialMode && selectedCostAfterCredit >= 0" class="text-right ff-description mb-2 space-y-1">
+    <div
+        v-if="!trialMode && selectedCostAfterCredit >= 0"
+        class="text-right ff-description mb-2 space-y-1"
+        data-el="payable-now-summary"
+    >
         {{ formatCurrency(selectedCostAfterCredit) }} now
         <span v-if="pricingDetails?.interval">
             then {{ formatCurrency(pricingDetails.cost) }} / {{ pricingDetails.interval }}

--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -54,7 +54,7 @@
     >
         {{ formatCurrency(selectedCostAfterCredit) }} now
         <span v-if="pricingDetails?.interval">
-            then {{ formatCurrency(pricingDetails.cost) }} / {{ pricingDetails.interval }}
+            then {{ formatCurrency(pricingDetails.cost) }} /{{ pricingDetails.interval }}
         </span>
     </div>
 </template>

--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -44,48 +44,33 @@
                     {{ formatCurrency(subscription?.customer?.balance) }}
                 </div>
                 <div />
+                <div v-if="payableNow" data-el="payable-now-row">
+                    Payable Now
+                </div>
+                <div
+                    v-if="payableNow"
+                    data-el="payable-now-amount"
+                    class="text-right"
+                >
+                    {{ payableNow }}
+                </div>
+                <div v-if="payableNow" />
             </template>
         </div>
     </div>
-    <FormRow
-        v-if="!trialMode"
-        id="billing-confirmation"
-        v-model="localConfirmed"
-        type="checkbox"
-    >
-        Confirm additional charges
-        <template
-            v-if="selectedCostAfterCredit >= 0"
-            #description
-        >
-            {{ formatCurrency(selectedCostAfterCredit) }} now
-            <span v-if="pricingDetails?.interval">
-                then {{ formatCurrency(pricingDetails.cost) }}/{{ pricingDetails.interval }}
-            </span>
-        </template>
-    </FormRow>
 </template>
 
 <script>
-
-import FormRow from '../../../components/FormRow.vue'
 
 import formatCurrency from '../../../mixins/Currency.js'
 
 export default {
     name: 'InstanceChargesTable',
-    components: {
-        FormRow
-    },
     mixins: [formatCurrency],
     props: {
         subscription: {
             type: Object,
             default: null
-        },
-        confirmed: {
-            type: Boolean,
-            default: false
         },
         projectType: {
             type: Object,
@@ -96,20 +81,15 @@ export default {
             default: false
         }
     },
-    emits: [
-        'update:confirmed'
-    ],
     computed: {
+        payableNow () {
+            if (!this.projectType || this.trialMode || this.selectedCostAfterCredit <= 0) {
+                return ''
+            }
+            return `${this.formatCurrency(this.selectedCostAfterCredit)} `
+        },
         selectedCostAfterCredit () {
             return (this.pricingDetails?.cost ?? 0) + (this.subscription?.customer?.balance ?? 0)
-        },
-        localConfirmed: {
-            get () {
-                return this.confirmed
-            },
-            set (value) {
-                this.$emit('update:confirmed', value)
-            }
         },
         pricingDetails () {
             if (!this.projectType) {

--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -44,19 +44,14 @@
                     {{ formatCurrency(subscription?.customer?.balance) }}
                 </div>
                 <div />
-                <div v-if="payableNow" data-el="payable-now-row">
-                    Payable Now
-                </div>
-                <div
-                    v-if="payableNow"
-                    data-el="payable-now-amount"
-                    class="text-right"
-                >
-                    {{ payableNow }}
-                </div>
-                <div v-if="payableNow" />
             </template>
         </div>
+    </div>
+    <div v-if="!trialMode && selectedCostAfterCredit >= 0" class="text-right ff-description mb-2 space-y-1">
+        {{ formatCurrency(selectedCostAfterCredit) }} now
+        <span v-if="pricingDetails?.interval">
+            then {{ formatCurrency(pricingDetails.cost) }} / {{ pricingDetails.interval }}
+        </span>
     </div>
 </template>
 
@@ -82,12 +77,6 @@ export default {
         }
     },
     computed: {
-        payableNow () {
-            if (!this.projectType || this.trialMode || this.selectedCostAfterCredit <= 0) {
-                return ''
-            }
-            return `${this.formatCurrency(this.selectedCostAfterCredit)} `
-        },
         selectedCostAfterCredit () {
             return (this.pricingDetails?.cost ?? 0) + (this.subscription?.customer?.balance ?? 0)
         },

--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -150,7 +150,7 @@
         >
             <label class="w-full block text-sm font-medium text-gray-700 mb-1">Template</label>
             <label
-                v-if="!input.projectType && !input.stack"
+                v-if="!input.projectType || !input.stack"
                 class="text-sm text-gray-400"
             >Please select a Instance Type &amp; Stack first.</label>
             <label
@@ -158,7 +158,7 @@
                 class="text-sm text-gray-400"
             >{{ errors.template }}</label>
             <ff-tile-selection
-                v-if="input.projectType"
+                v-if="input.projectType && input.stack"
                 v-model="input.template"
                 data-form="project-template"
             >
@@ -187,7 +187,7 @@
         <!-- Billing details -->
         <div v-if="showBilling">
             <InstanceChargesTable
-                v-model:confirmed="input.billingConfirmation"
+                v-model:confirmed="submitEnabled"
                 :project-type="selectedProjectType"
                 :subscription="subscription"
                 :trialMode="isTrialProjectSelected"
@@ -313,8 +313,6 @@ export default {
             projectTypes: [],
             subscription: null,
             input: {
-                billingConfirmation: false,
-
                 applicationName,
                 applicationId,
 
@@ -373,8 +371,7 @@ export default {
               (this.applicationSelection ? this.input.applicationId : true)
         },
         submitEnabled () {
-            const billingConfirmed = !this.showBilling || this.team.billing?.trial || this.input.billingConfirmation
-            return billingConfirmed && this.formValid && this.formDirty
+            return this.formValid && this.formDirty
         },
         isTrialProjectSelected () {
             //  - Team is in trial mode, and
@@ -401,6 +398,8 @@ export default {
         'input.projectType': async function (value, oldValue) {
             if (value) {
                 await this.updateInstanceType(value)
+            } else {
+                this.selectedProjectType = null
             }
         }
     },

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -9,7 +9,7 @@
                 <FormRow v-model="input.name" data-form="device-name" :error="errors.name" :disabled="editDisabled">Name</FormRow>
                 <FormRow v-model="input.type" data-form="device-type" :error="errors.type" :disabled="editDisabled">Type</FormRow>
                 <div v-if="billingDescription">
-                   <b>Price: {{ billingDescription }}</b>
+                    <b>Price: {{ billingDescription }}</b>
                 </div>
             </form>
         </template>

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -80,7 +80,7 @@ export default {
         },
         billingDescription () {
             if (this.deviceIsBillable && this.team.type.properties.billing?.deviceCost > 0) {
-                return `${this.formatCurrency(this.team.type.properties.billing?.deviceCost * 100)}/month`
+                return `${this.formatCurrency(this.team.type.properties.billing?.deviceCost * 100)} /month`
             }
             return ''
         },

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -9,7 +9,7 @@
                 <FormRow v-model="input.name" data-form="device-name" :error="errors.name" :disabled="editDisabled">Name</FormRow>
                 <FormRow v-model="input.type" data-form="device-type" :error="errors.type" :disabled="editDisabled">Type</FormRow>
                 <div v-if="billingDescription">
-                    Additional charges: {{ billingDescription }}
+                   <b>Price: {{ billingDescription }}</b>
                 </div>
             </form>
         </template>

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -282,7 +282,7 @@ describe('FlowForge - Applications - With Billing', () => {
             cy.get('[data-el="selected-instance-type-cost"]').contains('$15.00')
             cy.get('[data-el="selected-instance-type-interval"]').contains('/mo')
 
-            cy.get('[data-el="payable-now-summary"]').contains('$15.00 now').contains('$15.00 / month')
+            cy.get('[data-el="payable-now-summary"]').contains('$15.00 now').contains('$15.00 /month')
 
             cy.get('[data-action="create-project"]').should('not.be.disabled').click()
         })

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -282,8 +282,7 @@ describe('FlowForge - Applications - With Billing', () => {
             cy.get('[data-el="selected-instance-type-cost"]').contains('$15.00')
             cy.get('[data-el="selected-instance-type-interval"]').contains('/mo')
 
-            // No credit balance, so payable now row is not shown
-            cy.get('[data-el="payable-now-amount"]').should('not.exist')
+            cy.get('[data-el="payable-now-summary"]').contains('$15.00 now').contains('$15.00 / month')
 
             cy.get('[data-action="create-project"]').should('not.be.disabled').click()
         })
@@ -319,7 +318,7 @@ describe('FlowForge - Applications - With Billing', () => {
             cy.get('[data-el="credit-balance-row"]').should('exist')
             cy.get('[data-el="credit-balance-amount"]').contains('$10.01')
 
-            cy.get('[data-el="payable-now-amount"]').contains('$4.99')
+            cy.get('[data-el="payable-now-summary"]').contains('$4.99')
 
             cy.get('[data-action="create-project"]').should('not.be.disabled').click()
         })

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -282,11 +282,8 @@ describe('FlowForge - Applications - With Billing', () => {
             cy.get('[data-el="selected-instance-type-cost"]').contains('$15.00')
             cy.get('[data-el="selected-instance-type-interval"]').contains('/mo')
 
-            cy.get('[data-el="form-row-description"]').contains('$15.00 now').contains('$15.00/month')
-
-            cy.get('[data-action="create-project"]').should('be.disabled')
-
-            cy.get('[id="billing-confirmation"][data-el="form-row-title"]').click()
+            // No credit balance, so payable now row is not shown
+            cy.get('[data-el="payable-now-amount"]').should('not.exist')
 
             cy.get('[data-action="create-project"]').should('not.be.disabled').click()
         })
@@ -322,11 +319,7 @@ describe('FlowForge - Applications - With Billing', () => {
             cy.get('[data-el="credit-balance-row"]').should('exist')
             cy.get('[data-el="credit-balance-amount"]').contains('$10.01')
 
-            cy.get('[data-el="form-row-description"]').contains('$4.99 now').contains('$15.00/month')
-
-            cy.get('[data-action="create-project"]').should('be.disabled')
-
-            cy.get('[id="billing-confirmation"][data-el="form-row-title"]').click()
+            cy.get('[data-el="payable-now-amount"]').contains('$4.99')
 
             cy.get('[data-action="create-project"]').should('not.be.disabled').click()
         })

--- a/test/e2e/frontend/cypress/tests/instances.spec.js
+++ b/test/e2e/frontend/cypress/tests/instances.spec.js
@@ -91,7 +91,6 @@ describe('FlowForge - Instances', () => {
                     name: INSTANCE_NAME,
                     stack: stack.id,
                     template: template.id,
-                    billingConfirmation: false,
                     projectType: type.id,
                     team: team.id,
                     applicationId: application.id


### PR DESCRIPTION
## Description

* Removes the confirmation Check box from instances AND devices
* Moves additional costs to the costs table
* Several bug fixes
   * cost table not hidden when no project type selected
   * sub text under the section headers were randomly shown/not shown
   * Use the formatCurreny mixin for devices - same as instances

### Before
https://github.com/flowforge/flowforge/assets/44235289/cc1bf475-d078-4a14-a03d-9e790560f29d



### After

#### Create Application
https://github.com/flowforge/flowforge/assets/44235289/10de6fa1-68f5-482c-a26e-399ad98445c5

#### Create Instance

https://github.com/flowforge/flowforge/assets/44235289/149a300c-3ebf-48f5-b6f6-28daf38d29ea

#### Add Device
![image](https://github.com/flowforge/flowforge/assets/44235289/0f284052-c43a-458d-8915-dd2585e58c0c)


## Related Issue(s)

#2206 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

