### PR TITLE
Rename build/test gh actions for consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Default Build & Test
+name: Backend Tests
 
 on:
   push:

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -1,4 +1,4 @@
-name: Test Postgress
+name: Backend Tests - postgres
 
 on:
   push:


### PR DESCRIPTION
## Description

This renames our `Default Build & Test` and `Test Postgress` (typo in original...) actions to be `Backend Tests` and `Backend Tests - postgres` for consistency and clarity.