### PR TITLE
Ensure Team Billing link is present on initial page load

### DIFF
--- a/frontend/src/components/SideNavigationTeamOptions.vue
+++ b/frontend/src/components/SideNavigationTeamOptions.vue
@@ -69,7 +69,7 @@ export default {
             return (this.$slots['nested-menu'] && this.loaded) || this.closeNested
         },
         navigation () {
-            return {
+            const result = {
                 general: [{
                     label: 'Applications',
                     to: '/applications',
@@ -116,13 +116,20 @@ export default {
                     icon: CogIcon
                 }]
             }
+            if (this.features?.billing) {
+                // insert billing in second slot of admin
+                result.admin.splice(1, 0, {
+                    label: 'Billing',
+                    to: '/billing',
+                    tag: 'team-billing',
+                    icon: CurrencyDollarIcon
+                })
+            }
+            return result
         }
     },
     mounted () {
-        this.checkFeatures()
-        window.setTimeout(() => {
-            this.loaded = true
-        }, 0)
+        this.loaded = true
     },
     beforeMount () {
         const lastUrl = this.$router.options.history.state.back
@@ -162,17 +169,6 @@ export default {
                 if (this.$route.path.indexOf('/instance') === 0) {
                     return true
                 }
-            }
-        },
-        checkFeatures () {
-            if (this.features.billing) {
-                // insert billing in second slot of admin
-                this.navigation.admin.splice(1, 0, {
-                    label: 'Billing',
-                    to: '/billing',
-                    tag: 'team-billing',
-                    icon: CurrencyDollarIcon
-                })
             }
         },
         switchTeam () {


### PR DESCRIPTION
Fixes #2398

## Description

When loading any team page, the Billing link was missing. As soon as you navigated to another team view, the billing link would appear.

Having added a bunch of debug, I could see the `checkFeatures` call being made, and `this.navigation.admin` was being updated to add the billing link. However the rendered view wasn't changing in response. As soon as you click around, it rerenders the sidebar and displays the link correctly.

Exactly why vue isn't refreshing the component when one of its computed props changes, I'm not entirely sure. And why it has started happening now, when it doesn't happen on production is also unknown.

The fix is to do the `this.features.billing` check in the original computed property function - it was already doing that for the shared library. That means we don't do any mutation of the computed property outside of the function.

Have click tested this locally.

