### PR TITLE
Lockfile audit and dedupe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -282,7 +282,7 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sso": {
+        "node_modules/@aws-sdk/client-sso": {
             "version": "3.358.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
             "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
@@ -325,7 +325,7 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sso-oidc": {
+        "node_modules/@aws-sdk/client-sso-oidc": {
             "version": "3.358.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
             "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
@@ -362,318 +362,6 @@
                 "@aws-sdk/util-utf8": "3.310.0",
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
-            "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.358.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
-            "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-ini": "3.358.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.358.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
-            "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
-            "dependencies": {
-                "@aws-sdk/client-sso": "3.358.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/token-providers": "3.358.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/token-providers": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
-            "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
-            "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.358.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.360.0.tgz",
-            "integrity": "sha512-0f6eG+6XFbDxrma5xxNGg/FJxh/OHC6h8AkfNms9Lv1gBoQSagpcTor+ax0z9F6lypOjaelX6k4DpeKAp4PZeA==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.360.0",
-                "@aws-sdk/smithy-client": "3.360.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
-                "@aws-sdk/util-defaults-mode-node": "3.360.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.360.0.tgz",
-            "integrity": "sha512-czIpPt75fS3gH3vgFz76+WTaKcvPxC/DnPuqVyHdihMmP0UuwGPU9jn+Xx9RdUw7Yay3+rJRe3AYgBn4Xb220g==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.360.0",
-                "@aws-sdk/smithy-client": "3.360.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
-                "@aws-sdk/util-defaults-mode-node": "3.360.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
-            "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
-            "dependencies": {
-                "@aws-sdk/abort-controller": "3.357.0",
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/querystring-builder": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
-            "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-stream": "3.360.0",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
-            "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
-            "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
-            "dependencies": {
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-stream": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
-            "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
-            "dependencies": {
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.360.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
-            "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
-            "dependencies": {
-                "@aws-sdk/abort-controller": "3.357.0",
-                "@aws-sdk/protocol-http": "3.357.0",
-                "@aws-sdk/querystring-builder": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/smithy-client": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
-            "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-stream": "3.360.0",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
-            "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
-            "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
-            "dependencies": {
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-stream": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
-            "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
-            "dependencies": {
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.360.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-buffer-from": "3.310.0",
-                "@aws-sdk/util-hex-encoding": "3.310.0",
-                "@aws-sdk/util-utf8": "3.310.0",
                 "tslib": "^2.5.0"
             },
             "engines": {
@@ -727,162 +415,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
-            "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.358.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-                "@aws-sdk/util-defaults-mode-node": "3.358.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
-            "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/config-resolver": "3.357.0",
-                "@aws-sdk/fetch-http-handler": "3.357.0",
-                "@aws-sdk/hash-node": "3.357.0",
-                "@aws-sdk/invalid-dependency": "3.357.0",
-                "@aws-sdk/middleware-content-length": "3.357.0",
-                "@aws-sdk/middleware-endpoint": "3.357.0",
-                "@aws-sdk/middleware-host-header": "3.357.0",
-                "@aws-sdk/middleware-logger": "3.357.0",
-                "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                "@aws-sdk/middleware-retry": "3.357.0",
-                "@aws-sdk/middleware-serde": "3.357.0",
-                "@aws-sdk/middleware-stack": "3.357.0",
-                "@aws-sdk/middleware-user-agent": "3.357.0",
-                "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.357.0",
-                "@aws-sdk/smithy-client": "3.358.0",
-                "@aws-sdk/types": "3.357.0",
-                "@aws-sdk/url-parser": "3.357.0",
-                "@aws-sdk/util-base64": "3.310.0",
-                "@aws-sdk/util-body-length-browser": "3.310.0",
-                "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-                "@aws-sdk/util-defaults-mode-node": "3.358.0",
-                "@aws-sdk/util-endpoints": "3.357.0",
-                "@aws-sdk/util-retry": "3.357.0",
-                "@aws-sdk/util-user-agent-browser": "3.357.0",
-                "@aws-sdk/util-user-agent-node": "3.357.0",
-                "@aws-sdk/util-utf8": "3.310.0",
-                "@smithy/protocol-http": "^1.0.1",
-                "@smithy/types": "^1.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
-            "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.358.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
-            "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.357.0",
-                "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-ini": "3.358.0",
-                "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.358.0",
-                "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
-            "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
-            "dependencies": {
-                "@aws-sdk/client-sso": "3.358.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/token-providers": "3.358.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
-            "version": "3.358.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
-            "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
-            "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.358.0",
-                "@aws-sdk/property-provider": "3.357.0",
-                "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/types": "3.357.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@aws-sdk/config-resolver": {
             "version": "3.357.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
@@ -926,14 +458,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.360.0.tgz",
-            "integrity": "sha512-pWuLTq+yjSFssPGhDJ8oxvZsu7/F1KissGRt65G4qrfxHhoiMRcLF1GtFJueDQpitZ1i3mZXHVn/OSv4LPQ1Lw==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
+            "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.357.0",
                 "@aws-sdk/credential-provider-imds": "3.357.0",
                 "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.360.0",
+                "@aws-sdk/credential-provider-sso": "3.358.0",
                 "@aws-sdk/credential-provider-web-identity": "3.357.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
@@ -945,15 +477,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.360.0.tgz",
-            "integrity": "sha512-j4Lu5vXkdzz/L6fGKKxnL0vcwAGHlwFHjTg9nRagMn1lvaVjtktXeM30duHTBQq9i+ejdFxpVNWYrmHGaWPNdg==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
+            "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.357.0",
                 "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-ini": "3.360.0",
+                "@aws-sdk/credential-provider-ini": "3.358.0",
                 "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.360.0",
+                "@aws-sdk/credential-provider-sso": "3.358.0",
                 "@aws-sdk/credential-provider-web-identity": "3.357.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
@@ -979,14 +511,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.360.0.tgz",
-            "integrity": "sha512-kW0FR8AbMQrJxADxIqYSjHVN2RXwHmA5DzogYm1AjOkYRMN9JHDVOMQP2K2M6FCynZqTYsKW5lzjPOjS0fu8Dw==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
+            "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.360.0",
+                "@aws-sdk/client-sso": "3.358.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/token-providers": "3.360.0",
+                "@aws-sdk/token-providers": "3.358.0",
                 "@aws-sdk/types": "3.357.0",
                 "tslib": "^2.5.0"
             },
@@ -1353,11 +885,11 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.360.0.tgz",
-            "integrity": "sha512-gtnCmn2NL7uSwadqQPeU74Wo7Wf1NMJtui+KSWPYpc3joRZqIYj0kL5w0IT2S9tPQwCFerWVfhkvRkSGJ4nZ/g==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
+            "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.360.0",
+                "@aws-sdk/client-sso-oidc": "3.358.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
                 "@aws-sdk/types": "3.357.0",
@@ -10841,9 +10373,9 @@
             }
         },
         "node_modules/globby": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
-            "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.1.tgz",
+            "integrity": "sha512-DPCBxctI7dN4EeIqjW2KGqgdcUMbrhJ9AzON+PlxCtvppWhubTLD4+a0GFxiym14ZvacUydTPjLPc2DlKz7EIg==",
             "dev": true,
             "dependencies": {
                 "dir-glob": "^3.0.1",
@@ -17289,14 +16821,15 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-            "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
                 "events": "^3.3.0",
-                "process": "^0.11.10"
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -17323,6 +16856,14 @@
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/readable-stream/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/readdirp": {
@@ -18131,9 +17672,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -19744,9 +19285,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -21396,152 +20937,12 @@
                 "@smithy/types": "^1.0.0",
                 "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/client-sso": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
-                    "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
-                    "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/config-resolver": "3.357.0",
-                        "@aws-sdk/fetch-http-handler": "3.357.0",
-                        "@aws-sdk/hash-node": "3.357.0",
-                        "@aws-sdk/invalid-dependency": "3.357.0",
-                        "@aws-sdk/middleware-content-length": "3.357.0",
-                        "@aws-sdk/middleware-endpoint": "3.357.0",
-                        "@aws-sdk/middleware-host-header": "3.357.0",
-                        "@aws-sdk/middleware-logger": "3.357.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                        "@aws-sdk/middleware-retry": "3.357.0",
-                        "@aws-sdk/middleware-serde": "3.357.0",
-                        "@aws-sdk/middleware-stack": "3.357.0",
-                        "@aws-sdk/middleware-user-agent": "3.357.0",
-                        "@aws-sdk/node-config-provider": "3.357.0",
-                        "@aws-sdk/node-http-handler": "3.357.0",
-                        "@aws-sdk/smithy-client": "3.358.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/url-parser": "3.357.0",
-                        "@aws-sdk/util-base64": "3.310.0",
-                        "@aws-sdk/util-body-length-browser": "3.310.0",
-                        "@aws-sdk/util-body-length-node": "3.310.0",
-                        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-                        "@aws-sdk/util-defaults-mode-node": "3.358.0",
-                        "@aws-sdk/util-endpoints": "3.357.0",
-                        "@aws-sdk/util-retry": "3.357.0",
-                        "@aws-sdk/util-user-agent-browser": "3.357.0",
-                        "@aws-sdk/util-user-agent-node": "3.357.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "@smithy/protocol-http": "^1.0.1",
-                        "@smithy/types": "^1.0.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/client-sso-oidc": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
-                    "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
-                    "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/config-resolver": "3.357.0",
-                        "@aws-sdk/fetch-http-handler": "3.357.0",
-                        "@aws-sdk/hash-node": "3.357.0",
-                        "@aws-sdk/invalid-dependency": "3.357.0",
-                        "@aws-sdk/middleware-content-length": "3.357.0",
-                        "@aws-sdk/middleware-endpoint": "3.357.0",
-                        "@aws-sdk/middleware-host-header": "3.357.0",
-                        "@aws-sdk/middleware-logger": "3.357.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                        "@aws-sdk/middleware-retry": "3.357.0",
-                        "@aws-sdk/middleware-serde": "3.357.0",
-                        "@aws-sdk/middleware-stack": "3.357.0",
-                        "@aws-sdk/middleware-user-agent": "3.357.0",
-                        "@aws-sdk/node-config-provider": "3.357.0",
-                        "@aws-sdk/node-http-handler": "3.357.0",
-                        "@aws-sdk/smithy-client": "3.358.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/url-parser": "3.357.0",
-                        "@aws-sdk/util-base64": "3.310.0",
-                        "@aws-sdk/util-body-length-browser": "3.310.0",
-                        "@aws-sdk/util-body-length-node": "3.310.0",
-                        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-                        "@aws-sdk/util-defaults-mode-node": "3.358.0",
-                        "@aws-sdk/util-endpoints": "3.357.0",
-                        "@aws-sdk/util-retry": "3.357.0",
-                        "@aws-sdk/util-user-agent-browser": "3.357.0",
-                        "@aws-sdk/util-user-agent-node": "3.357.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "@smithy/protocol-http": "^1.0.1",
-                        "@smithy/types": "^1.0.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/credential-provider-ini": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
-                    "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
-                    "requires": {
-                        "@aws-sdk/credential-provider-env": "3.357.0",
-                        "@aws-sdk/credential-provider-imds": "3.357.0",
-                        "@aws-sdk/credential-provider-process": "3.357.0",
-                        "@aws-sdk/credential-provider-sso": "3.358.0",
-                        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/credential-provider-node": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
-                    "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
-                    "requires": {
-                        "@aws-sdk/credential-provider-env": "3.357.0",
-                        "@aws-sdk/credential-provider-imds": "3.357.0",
-                        "@aws-sdk/credential-provider-ini": "3.358.0",
-                        "@aws-sdk/credential-provider-process": "3.357.0",
-                        "@aws-sdk/credential-provider-sso": "3.358.0",
-                        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/credential-provider-sso": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
-                    "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
-                    "requires": {
-                        "@aws-sdk/client-sso": "3.358.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/token-providers": "3.358.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/token-providers": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
-                    "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
-                    "requires": {
-                        "@aws-sdk/client-sso-oidc": "3.358.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                }
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.360.0.tgz",
-            "integrity": "sha512-0f6eG+6XFbDxrma5xxNGg/FJxh/OHC6h8AkfNms9Lv1gBoQSagpcTor+ax0z9F6lypOjaelX6k4DpeKAp4PZeA==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
+            "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -21559,15 +20960,15 @@
                 "@aws-sdk/middleware-stack": "3.357.0",
                 "@aws-sdk/middleware-user-agent": "3.357.0",
                 "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.360.0",
-                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/node-http-handler": "3.357.0",
+                "@aws-sdk/smithy-client": "3.358.0",
                 "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/url-parser": "3.357.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
-                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+                "@aws-sdk/util-defaults-mode-node": "3.358.0",
                 "@aws-sdk/util-endpoints": "3.357.0",
                 "@aws-sdk/util-retry": "3.357.0",
                 "@aws-sdk/util-user-agent-browser": "3.357.0",
@@ -21576,77 +20977,12 @@
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/node-http-handler": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
-                    "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
-                    "requires": {
-                        "@aws-sdk/abort-controller": "3.357.0",
-                        "@aws-sdk/protocol-http": "3.357.0",
-                        "@aws-sdk/querystring-builder": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/smithy-client": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
-                    "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
-                    "requires": {
-                        "@aws-sdk/middleware-stack": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/util-stream": "3.360.0",
-                        "@smithy/types": "^1.0.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-defaults-mode-browser": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
-                    "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
-                    "requires": {
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "bowser": "^2.11.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-defaults-mode-node": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
-                    "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
-                    "requires": {
-                        "@aws-sdk/config-resolver": "3.357.0",
-                        "@aws-sdk/credential-provider-imds": "3.357.0",
-                        "@aws-sdk/node-config-provider": "3.357.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-stream": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
-                    "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
-                    "requires": {
-                        "@aws-sdk/fetch-http-handler": "3.357.0",
-                        "@aws-sdk/node-http-handler": "3.360.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/util-base64": "3.310.0",
-                        "@aws-sdk/util-buffer-from": "3.310.0",
-                        "@aws-sdk/util-hex-encoding": "3.310.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "tslib": "^2.5.0"
-                    }
-                }
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.360.0.tgz",
-            "integrity": "sha512-czIpPt75fS3gH3vgFz76+WTaKcvPxC/DnPuqVyHdihMmP0UuwGPU9jn+Xx9RdUw7Yay3+rJRe3AYgBn4Xb220g==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
+            "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
             "requires": {
                 "@aws-crypto/sha256-browser": "3.0.0",
                 "@aws-crypto/sha256-js": "3.0.0",
@@ -21664,15 +21000,15 @@
                 "@aws-sdk/middleware-stack": "3.357.0",
                 "@aws-sdk/middleware-user-agent": "3.357.0",
                 "@aws-sdk/node-config-provider": "3.357.0",
-                "@aws-sdk/node-http-handler": "3.360.0",
-                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/node-http-handler": "3.357.0",
+                "@aws-sdk/smithy-client": "3.358.0",
                 "@aws-sdk/types": "3.357.0",
                 "@aws-sdk/url-parser": "3.357.0",
                 "@aws-sdk/util-base64": "3.310.0",
                 "@aws-sdk/util-body-length-browser": "3.310.0",
                 "@aws-sdk/util-body-length-node": "3.310.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
-                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.358.0",
+                "@aws-sdk/util-defaults-mode-node": "3.358.0",
                 "@aws-sdk/util-endpoints": "3.357.0",
                 "@aws-sdk/util-retry": "3.357.0",
                 "@aws-sdk/util-user-agent-browser": "3.357.0",
@@ -21681,71 +21017,6 @@
                 "@smithy/protocol-http": "^1.0.1",
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/node-http-handler": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
-                    "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
-                    "requires": {
-                        "@aws-sdk/abort-controller": "3.357.0",
-                        "@aws-sdk/protocol-http": "3.357.0",
-                        "@aws-sdk/querystring-builder": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/smithy-client": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
-                    "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
-                    "requires": {
-                        "@aws-sdk/middleware-stack": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/util-stream": "3.360.0",
-                        "@smithy/types": "^1.0.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-defaults-mode-browser": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
-                    "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
-                    "requires": {
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "bowser": "^2.11.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-defaults-mode-node": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
-                    "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
-                    "requires": {
-                        "@aws-sdk/config-resolver": "3.357.0",
-                        "@aws-sdk/credential-provider-imds": "3.357.0",
-                        "@aws-sdk/node-config-provider": "3.357.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/util-stream": {
-                    "version": "3.360.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
-                    "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
-                    "requires": {
-                        "@aws-sdk/fetch-http-handler": "3.357.0",
-                        "@aws-sdk/node-http-handler": "3.360.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/util-base64": "3.310.0",
-                        "@aws-sdk/util-buffer-from": "3.310.0",
-                        "@aws-sdk/util-hex-encoding": "3.310.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "tslib": "^2.5.0"
-                    }
-                }
             }
         },
         "@aws-sdk/client-sts": {
@@ -21790,146 +21061,6 @@
                 "@smithy/types": "^1.0.0",
                 "fast-xml-parser": "4.2.5",
                 "tslib": "^2.5.0"
-            },
-            "dependencies": {
-                "@aws-sdk/client-sso": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.358.0.tgz",
-                    "integrity": "sha512-Kc9IsoPIHJfkjDuStyItwQAOpnxw/I9xfF3vvukeN9vkXcRiWeMDhEXACN4L1AYFlU9FHQSRdNwpYTIz7OrD2A==",
-                    "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/config-resolver": "3.357.0",
-                        "@aws-sdk/fetch-http-handler": "3.357.0",
-                        "@aws-sdk/hash-node": "3.357.0",
-                        "@aws-sdk/invalid-dependency": "3.357.0",
-                        "@aws-sdk/middleware-content-length": "3.357.0",
-                        "@aws-sdk/middleware-endpoint": "3.357.0",
-                        "@aws-sdk/middleware-host-header": "3.357.0",
-                        "@aws-sdk/middleware-logger": "3.357.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                        "@aws-sdk/middleware-retry": "3.357.0",
-                        "@aws-sdk/middleware-serde": "3.357.0",
-                        "@aws-sdk/middleware-stack": "3.357.0",
-                        "@aws-sdk/middleware-user-agent": "3.357.0",
-                        "@aws-sdk/node-config-provider": "3.357.0",
-                        "@aws-sdk/node-http-handler": "3.357.0",
-                        "@aws-sdk/smithy-client": "3.358.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/url-parser": "3.357.0",
-                        "@aws-sdk/util-base64": "3.310.0",
-                        "@aws-sdk/util-body-length-browser": "3.310.0",
-                        "@aws-sdk/util-body-length-node": "3.310.0",
-                        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-                        "@aws-sdk/util-defaults-mode-node": "3.358.0",
-                        "@aws-sdk/util-endpoints": "3.357.0",
-                        "@aws-sdk/util-retry": "3.357.0",
-                        "@aws-sdk/util-user-agent-browser": "3.357.0",
-                        "@aws-sdk/util-user-agent-node": "3.357.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "@smithy/protocol-http": "^1.0.1",
-                        "@smithy/types": "^1.0.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/client-sso-oidc": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.358.0.tgz",
-                    "integrity": "sha512-Gy09fSlhJdGbr8rNNR8EdLaUynB1B34nw8kN1aFT4CdAnjFKxTainqG6Aq4vx64TbMDMhvMYWpNAluvq7UHVhw==",
-                    "requires": {
-                        "@aws-crypto/sha256-browser": "3.0.0",
-                        "@aws-crypto/sha256-js": "3.0.0",
-                        "@aws-sdk/config-resolver": "3.357.0",
-                        "@aws-sdk/fetch-http-handler": "3.357.0",
-                        "@aws-sdk/hash-node": "3.357.0",
-                        "@aws-sdk/invalid-dependency": "3.357.0",
-                        "@aws-sdk/middleware-content-length": "3.357.0",
-                        "@aws-sdk/middleware-endpoint": "3.357.0",
-                        "@aws-sdk/middleware-host-header": "3.357.0",
-                        "@aws-sdk/middleware-logger": "3.357.0",
-                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
-                        "@aws-sdk/middleware-retry": "3.357.0",
-                        "@aws-sdk/middleware-serde": "3.357.0",
-                        "@aws-sdk/middleware-stack": "3.357.0",
-                        "@aws-sdk/middleware-user-agent": "3.357.0",
-                        "@aws-sdk/node-config-provider": "3.357.0",
-                        "@aws-sdk/node-http-handler": "3.357.0",
-                        "@aws-sdk/smithy-client": "3.358.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "@aws-sdk/url-parser": "3.357.0",
-                        "@aws-sdk/util-base64": "3.310.0",
-                        "@aws-sdk/util-body-length-browser": "3.310.0",
-                        "@aws-sdk/util-body-length-node": "3.310.0",
-                        "@aws-sdk/util-defaults-mode-browser": "3.358.0",
-                        "@aws-sdk/util-defaults-mode-node": "3.358.0",
-                        "@aws-sdk/util-endpoints": "3.357.0",
-                        "@aws-sdk/util-retry": "3.357.0",
-                        "@aws-sdk/util-user-agent-browser": "3.357.0",
-                        "@aws-sdk/util-user-agent-node": "3.357.0",
-                        "@aws-sdk/util-utf8": "3.310.0",
-                        "@smithy/protocol-http": "^1.0.1",
-                        "@smithy/types": "^1.0.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/credential-provider-ini": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
-                    "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
-                    "requires": {
-                        "@aws-sdk/credential-provider-env": "3.357.0",
-                        "@aws-sdk/credential-provider-imds": "3.357.0",
-                        "@aws-sdk/credential-provider-process": "3.357.0",
-                        "@aws-sdk/credential-provider-sso": "3.358.0",
-                        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/credential-provider-node": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
-                    "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
-                    "requires": {
-                        "@aws-sdk/credential-provider-env": "3.357.0",
-                        "@aws-sdk/credential-provider-imds": "3.357.0",
-                        "@aws-sdk/credential-provider-ini": "3.358.0",
-                        "@aws-sdk/credential-provider-process": "3.357.0",
-                        "@aws-sdk/credential-provider-sso": "3.358.0",
-                        "@aws-sdk/credential-provider-web-identity": "3.357.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/credential-provider-sso": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
-                    "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
-                    "requires": {
-                        "@aws-sdk/client-sso": "3.358.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/token-providers": "3.358.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                },
-                "@aws-sdk/token-providers": {
-                    "version": "3.358.0",
-                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
-                    "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
-                    "requires": {
-                        "@aws-sdk/client-sso-oidc": "3.358.0",
-                        "@aws-sdk/property-provider": "3.357.0",
-                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                        "@aws-sdk/types": "3.357.0",
-                        "tslib": "^2.5.0"
-                    }
-                }
             }
         },
         "@aws-sdk/config-resolver": {
@@ -21966,14 +21097,14 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.360.0.tgz",
-            "integrity": "sha512-pWuLTq+yjSFssPGhDJ8oxvZsu7/F1KissGRt65G4qrfxHhoiMRcLF1GtFJueDQpitZ1i3mZXHVn/OSv4LPQ1Lw==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.358.0.tgz",
+            "integrity": "sha512-Blmw4bhGxpaYvPmrbRKAltqnNDDSf6ZegNqJasc5OWvAlHJNvB/hYPmyQN0oFy79BXn7PbBip1QaLWaEhJvpAA==",
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.357.0",
                 "@aws-sdk/credential-provider-imds": "3.357.0",
                 "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.360.0",
+                "@aws-sdk/credential-provider-sso": "3.358.0",
                 "@aws-sdk/credential-provider-web-identity": "3.357.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
@@ -21982,15 +21113,15 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.360.0.tgz",
-            "integrity": "sha512-j4Lu5vXkdzz/L6fGKKxnL0vcwAGHlwFHjTg9nRagMn1lvaVjtktXeM30duHTBQq9i+ejdFxpVNWYrmHGaWPNdg==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.358.0.tgz",
+            "integrity": "sha512-iLjyRNOT0ycdLqkzXNW+V2zibVljkLjL8j45FpK6mNrAwc/Ynr7EYuRRp5OuRiiYDO3ZoneAxpBJQ5SqmK2Jfg==",
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.357.0",
                 "@aws-sdk/credential-provider-imds": "3.357.0",
-                "@aws-sdk/credential-provider-ini": "3.360.0",
+                "@aws-sdk/credential-provider-ini": "3.358.0",
                 "@aws-sdk/credential-provider-process": "3.357.0",
-                "@aws-sdk/credential-provider-sso": "3.360.0",
+                "@aws-sdk/credential-provider-sso": "3.358.0",
                 "@aws-sdk/credential-provider-web-identity": "3.357.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
@@ -22010,14 +21141,14 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.360.0.tgz",
-            "integrity": "sha512-kW0FR8AbMQrJxADxIqYSjHVN2RXwHmA5DzogYm1AjOkYRMN9JHDVOMQP2K2M6FCynZqTYsKW5lzjPOjS0fu8Dw==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.358.0.tgz",
+            "integrity": "sha512-hKu5NshKohSDoHaXKyeCW88J8dBt4TMljrL+WswTMifuThO9ptyMq4PCdl4z7CNjIq6zo3ftc/uNf8TY7Ga8+w==",
             "requires": {
-                "@aws-sdk/client-sso": "3.360.0",
+                "@aws-sdk/client-sso": "3.358.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
-                "@aws-sdk/token-providers": "3.360.0",
+                "@aws-sdk/token-providers": "3.358.0",
                 "@aws-sdk/types": "3.357.0",
                 "tslib": "^2.5.0"
             }
@@ -22308,11 +21439,11 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.360.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.360.0.tgz",
-            "integrity": "sha512-gtnCmn2NL7uSwadqQPeU74Wo7Wf1NMJtui+KSWPYpc3joRZqIYj0kL5w0IT2S9tPQwCFerWVfhkvRkSGJ4nZ/g==",
+            "version": "3.358.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.358.0.tgz",
+            "integrity": "sha512-vATKNCwNhCSo2LzvtkIzW9Yp2/aKNR032VPtIWlDtWGGFhkzGi4FPS0VTdfefxz4rqPWfBz53mh54d9xylsWVw==",
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.360.0",
+                "@aws-sdk/client-sso-oidc": "3.358.0",
                 "@aws-sdk/property-provider": "3.357.0",
                 "@aws-sdk/shared-ini-file-loader": "3.357.0",
                 "@aws-sdk/types": "3.357.0",
@@ -29171,9 +28302,9 @@
             }
         },
         "globby": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
-            "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.1.tgz",
+            "integrity": "sha512-DPCBxctI7dN4EeIqjW2KGqgdcUMbrhJ9AzON+PlxCtvppWhubTLD4+a0GFxiym14ZvacUydTPjLPc2DlKz7EIg==",
             "dev": true,
             "requires": {
                 "dir-glob": "^3.0.1",
@@ -33859,14 +32990,15 @@
             }
         },
         "readable-stream": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-            "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
             "requires": {
                 "abort-controller": "^3.0.0",
                 "buffer": "^6.0.3",
                 "events": "^3.3.0",
-                "process": "^0.11.10"
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
             },
             "dependencies": {
                 "buffer": {
@@ -33876,6 +33008,14 @@
                     "requires": {
                         "base64-js": "^1.3.1",
                         "ieee754": "^1.2.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
                     }
                 }
             }
@@ -34479,9 +33619,9 @@
             }
         },
         "semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
             "requires": {
                 "lru-cache": "^6.0.0"
             },
@@ -35744,9 +34884,9 @@
             }
         },
         "tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         },
         "tunnel-agent": {
             "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,15 @@
                 "node": ">=16.x"
             }
         },
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@ampproject/remapping": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -1626,35 +1635,35 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
-            "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
+            "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
-            "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
+            "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.5",
                 "@babel/generator": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-module-transforms": "^7.22.5",
-                "@babel/helpers": "^7.22.5",
-                "@babel/parser": "^7.22.5",
+                "@babel/helpers": "^7.22.6",
+                "@babel/parser": "^7.22.6",
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
+                "@babel/traverse": "^7.22.6",
                 "@babel/types": "^7.22.5",
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.2",
-                "semver": "^6.3.0"
+                "json5": "^2.2.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1662,15 +1671,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/generator": {
@@ -1713,16 +1713,16 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
-            "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
+            "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.5",
+                "@babel/compat-data": "^7.22.6",
                 "@babel/helper-validator-option": "^7.22.5",
-                "browserslist": "^4.21.3",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.0"
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
+                "browserslist": "^4.21.9",
+                "lru-cache": "^5.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1740,15 +1740,6 @@
                 "yallist": "^3.0.2"
             }
         },
-        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -1756,9 +1747,9 @@
             "dev": true
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.5.tgz",
-            "integrity": "sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.6.tgz",
+            "integrity": "sha512-iwdzgtSiBxF6ni6mzVnZCF3xt5qE6cEA0J7nFt8QOAWZ0zjCFceEgpn3vtb2V7WFR6QzP2jmIFOHMTRo7eNJjQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1768,49 +1759,31 @@
                 "@babel/helper-optimise-call-expression": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
-                "semver": "^6.3.0"
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@nicolo-ribaudo/semver-v6": "^6.3.3"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.5.tgz",
-            "integrity": "sha512-1VpEFOIbMRaXyDeUwUfmTIxExLwQ+zkW+Bh5zXpApA3oQedBx9v/updixWxnx/bZpKw7u8VxWjb/qWpIcmPq8A==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.6.tgz",
+            "integrity": "sha512-nBookhLKxAWo/TUCmhnaEJyLz2dekjQvv5SRpE9epWQBcpedWLKt8aZdsuT9XV5ovzR3fENLjRXVT0GsSlGGhA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "regexpu-core": "^5.3.1",
-                "semver": "^6.3.0"
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
+                "regexpu-core": "^5.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
@@ -1997,9 +1970,9 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-            "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
@@ -2051,13 +2024,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
-            "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
+            "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
+                "@babel/traverse": "^7.22.6",
                 "@babel/types": "^7.22.5"
             },
             "engines": {
@@ -2079,9 +2052,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-            "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+            "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -2498,19 +2471,19 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.5.tgz",
-            "integrity": "sha512-2edQhLfibpWpsVBx2n/GKOz6JdGQvLruZQfGr9l1qes2KQaWswjBzhQF7UDUZMNaMMQeYnQzxwOMPsbYF7wqPQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
+            "integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-environment-visitor": "^7.22.5",
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/helper-optimise-call-expression": "^7.22.5",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -2906,9 +2879,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.5.tgz",
-            "integrity": "sha512-AconbMKOMkyG+xCng2JogMCDcqW8wedQAqpVIL4cOSescZ7+iW8utC6YDZLMCSUIReEA733gzRSaOSXMAt/4WQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz",
+            "integrity": "sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -3157,13 +3130,13 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.5.tgz",
-            "integrity": "sha512-fj06hw89dpiZzGZtxn+QybifF07nNiZjZ7sazs2aVDcysAZVGjW7+7iFYxg6GLNM47R/thYfLdrXc+2f11Vi9A==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.6.tgz",
+            "integrity": "sha512-IHr0AXHGk8oh8HYSs45Mxuv6iySUBwDTIzJSnXN7PURqHdxJVQlCoXmKJgyvSS9bcNf9NVRVE35z+LkCvGmi6w==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/compat-data": "^7.22.6",
+                "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-validator-option": "^7.22.5",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -3194,7 +3167,7 @@
                 "@babel/plugin-transform-block-scoping": "^7.22.5",
                 "@babel/plugin-transform-class-properties": "^7.22.5",
                 "@babel/plugin-transform-class-static-block": "^7.22.5",
-                "@babel/plugin-transform-classes": "^7.22.5",
+                "@babel/plugin-transform-classes": "^7.22.6",
                 "@babel/plugin-transform-computed-properties": "^7.22.5",
                 "@babel/plugin-transform-destructuring": "^7.22.5",
                 "@babel/plugin-transform-dotall-regex": "^7.22.5",
@@ -3219,7 +3192,7 @@
                 "@babel/plugin-transform-object-rest-spread": "^7.22.5",
                 "@babel/plugin-transform-object-super": "^7.22.5",
                 "@babel/plugin-transform-optional-catch-binding": "^7.22.5",
-                "@babel/plugin-transform-optional-chaining": "^7.22.5",
+                "@babel/plugin-transform-optional-chaining": "^7.22.6",
                 "@babel/plugin-transform-parameters": "^7.22.5",
                 "@babel/plugin-transform-private-methods": "^7.22.5",
                 "@babel/plugin-transform-private-property-in-object": "^7.22.5",
@@ -3237,26 +3210,17 @@
                 "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
                 "@babel/preset-modules": "^0.1.5",
                 "@babel/types": "^7.22.5",
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
                 "babel-plugin-polyfill-corejs2": "^0.4.3",
                 "babel-plugin-polyfill-corejs3": "^0.8.1",
                 "babel-plugin-polyfill-regenerator": "^0.5.0",
-                "core-js-compat": "^3.30.2",
-                "semver": "^6.3.0"
+                "core-js-compat": "^3.31.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/preset-env/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/preset-modules": {
@@ -3307,9 +3271,9 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-            "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.6.tgz",
+            "integrity": "sha512-53CijMvKlLIDlOTrdWiHileRddlIiwUIyCKqYa7lYnnPldXCG5dUSN38uT0cA6i7rHWNKJLH0VU/Kxdr1GzB3w==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.22.5",
@@ -3317,8 +3281,8 @@
                 "@babel/helper-environment-visitor": "^7.22.5",
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
-                "@babel/parser": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.22.6",
                 "@babel/types": "^7.22.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
@@ -5130,6 +5094,15 @@
             },
             "bin": {
                 "node-pre-gyp": "bin/node-pre-gyp"
+            }
+        },
+        "node_modules/@nicolo-ribaudo/semver-v6": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
+            "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@node-red/util": {
@@ -15276,17 +15249,17 @@
             "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -20934,15 +20907,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -21261,6 +21225,12 @@
         }
     },
     "dependencies": {
+        "@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true
+        },
         "@ampproject/remapping": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -22555,40 +22525,32 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.5.tgz",
-            "integrity": "sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
+            "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.5.tgz",
-            "integrity": "sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
+            "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.22.5",
                 "@babel/generator": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-module-transforms": "^7.22.5",
-                "@babel/helpers": "^7.22.5",
-                "@babel/parser": "^7.22.5",
+                "@babel/helpers": "^7.22.6",
+                "@babel/parser": "^7.22.6",
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
+                "@babel/traverse": "^7.22.6",
                 "@babel/types": "^7.22.5",
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.2",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
+                "json5": "^2.2.2"
             }
         },
         "@babel/generator": {
@@ -22622,16 +22584,16 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz",
-            "integrity": "sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
+            "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.22.5",
+                "@babel/compat-data": "^7.22.6",
                 "@babel/helper-validator-option": "^7.22.5",
-                "browserslist": "^4.21.3",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.0"
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
+                "browserslist": "^4.21.9",
+                "lru-cache": "^5.1.1"
             },
             "dependencies": {
                 "lru-cache": {
@@ -22643,12 +22605,6 @@
                         "yallist": "^3.0.2"
                     }
                 },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                },
                 "yallist": {
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -22658,9 +22614,9 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.5.tgz",
-            "integrity": "sha512-xkb58MyOYIslxu3gKmVXmjTtUPvBU4odYzbiIQbWwLKIHCsx6UGZGX6F1IznMFVnDdirseUZopzN+ZRt8Xb33Q==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.6.tgz",
+            "integrity": "sha512-iwdzgtSiBxF6ni6mzVnZCF3xt5qE6cEA0J7nFt8QOAWZ0zjCFceEgpn3vtb2V7WFR6QzP2jmIFOHMTRo7eNJjQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -22670,35 +22626,19 @@
                 "@babel/helper-optimise-call-expression": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.22.5",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@nicolo-ribaudo/semver-v6": "^6.3.3"
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.5.tgz",
-            "integrity": "sha512-1VpEFOIbMRaXyDeUwUfmTIxExLwQ+zkW+Bh5zXpApA3oQedBx9v/updixWxnx/bZpKw7u8VxWjb/qWpIcmPq8A==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.6.tgz",
+            "integrity": "sha512-nBookhLKxAWo/TUCmhnaEJyLz2dekjQvv5SRpE9epWQBcpedWLKt8aZdsuT9XV5ovzR3fENLjRXVT0GsSlGGhA==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "regexpu-core": "^5.3.1",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
+                "regexpu-core": "^5.3.1"
             }
         },
         "@babel/helper-define-polyfill-provider": {
@@ -22842,9 +22782,9 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-            "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.22.5"
@@ -22881,13 +22821,13 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.5.tgz",
-            "integrity": "sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
+            "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
+                "@babel/traverse": "^7.22.6",
                 "@babel/types": "^7.22.5"
             }
         },
@@ -22903,9 +22843,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-            "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q=="
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+            "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw=="
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
             "version": "7.22.5",
@@ -23179,19 +23119,19 @@
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.5.tgz",
-            "integrity": "sha512-2edQhLfibpWpsVBx2n/GKOz6JdGQvLruZQfGr9l1qes2KQaWswjBzhQF7UDUZMNaMMQeYnQzxwOMPsbYF7wqPQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
+            "integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-environment-visitor": "^7.22.5",
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/helper-optimise-call-expression": "^7.22.5",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-replace-supers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
                 "globals": "^11.1.0"
             }
         },
@@ -23437,9 +23377,9 @@
             }
         },
         "@babel/plugin-transform-optional-chaining": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.5.tgz",
-            "integrity": "sha512-AconbMKOMkyG+xCng2JogMCDcqW8wedQAqpVIL4cOSescZ7+iW8utC6YDZLMCSUIReEA733gzRSaOSXMAt/4WQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.22.6.tgz",
+            "integrity": "sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -23592,13 +23532,13 @@
             }
         },
         "@babel/preset-env": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.5.tgz",
-            "integrity": "sha512-fj06hw89dpiZzGZtxn+QybifF07nNiZjZ7sazs2aVDcysAZVGjW7+7iFYxg6GLNM47R/thYfLdrXc+2f11Vi9A==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.6.tgz",
+            "integrity": "sha512-IHr0AXHGk8oh8HYSs45Mxuv6iySUBwDTIzJSnXN7PURqHdxJVQlCoXmKJgyvSS9bcNf9NVRVE35z+LkCvGmi6w==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.5",
+                "@babel/compat-data": "^7.22.6",
+                "@babel/helper-compilation-targets": "^7.22.6",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-validator-option": "^7.22.5",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.22.5",
@@ -23629,7 +23569,7 @@
                 "@babel/plugin-transform-block-scoping": "^7.22.5",
                 "@babel/plugin-transform-class-properties": "^7.22.5",
                 "@babel/plugin-transform-class-static-block": "^7.22.5",
-                "@babel/plugin-transform-classes": "^7.22.5",
+                "@babel/plugin-transform-classes": "^7.22.6",
                 "@babel/plugin-transform-computed-properties": "^7.22.5",
                 "@babel/plugin-transform-destructuring": "^7.22.5",
                 "@babel/plugin-transform-dotall-regex": "^7.22.5",
@@ -23654,7 +23594,7 @@
                 "@babel/plugin-transform-object-rest-spread": "^7.22.5",
                 "@babel/plugin-transform-object-super": "^7.22.5",
                 "@babel/plugin-transform-optional-catch-binding": "^7.22.5",
-                "@babel/plugin-transform-optional-chaining": "^7.22.5",
+                "@babel/plugin-transform-optional-chaining": "^7.22.6",
                 "@babel/plugin-transform-parameters": "^7.22.5",
                 "@babel/plugin-transform-private-methods": "^7.22.5",
                 "@babel/plugin-transform-private-property-in-object": "^7.22.5",
@@ -23672,19 +23612,11 @@
                 "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
                 "@babel/preset-modules": "^0.1.5",
                 "@babel/types": "^7.22.5",
+                "@nicolo-ribaudo/semver-v6": "^6.3.3",
                 "babel-plugin-polyfill-corejs2": "^0.4.3",
                 "babel-plugin-polyfill-corejs3": "^0.8.1",
                 "babel-plugin-polyfill-regenerator": "^0.5.0",
-                "core-js-compat": "^3.30.2",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
+                "core-js-compat": "^3.31.0"
             }
         },
         "@babel/preset-modules": {
@@ -23726,9 +23658,9 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-            "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.6.tgz",
+            "integrity": "sha512-53CijMvKlLIDlOTrdWiHileRddlIiwUIyCKqYa7lYnnPldXCG5dUSN38uT0cA6i7rHWNKJLH0VU/Kxdr1GzB3w==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.22.5",
@@ -23736,8 +23668,8 @@
                 "@babel/helper-environment-visitor": "^7.22.5",
                 "@babel/helper-function-name": "^7.22.5",
                 "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
-                "@babel/parser": "^7.22.5",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.22.6",
                 "@babel/types": "^7.22.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
@@ -24814,6 +24746,12 @@
                 "semver": "^7.3.5",
                 "tar": "^6.1.11"
             }
+        },
+        "@nicolo-ribaudo/semver-v6": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
+            "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+            "dev": true
         },
         "@node-red/util": {
             "version": "3.0.2",
@@ -32545,17 +32483,17 @@
             "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
         },
         "optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "requires": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             }
         },
         "ospath": {
@@ -36596,12 +36534,6 @@
             "requires": {
                 "@types/node": "*"
             }
-        },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
         },
         "wordwrap": {
             "version": "1.0.0",


### PR DESCRIPTION
## Description

Follow up to https://github.com/flowforge/flowforge/pull/2410 (**merge target**) that removes duplicates and auto-avoids dependencies with known CVE's.

```bash
npm dedupe
npm audit fix
```

## Related Issue(s)

N/a

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass - Not relevant
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

