### PR TITLE
Fix sign-up form when posthog not enabled

### DIFF
--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -102,7 +102,7 @@ export default {
             return (this.input.email && !this.errors.email) &&
                    (this.input.username && !this.errors.username) &&
                    this.input.password.length >= 8 &&
-                   (this.input.join_reason) &&
+                   (this.askJoinReason ? this.input.join_reason : true) &&
                    (this.settings['user:tcs-required'] ? this.input.tcs_accepted : true) &&
                    (!this.errors.name)
         },

--- a/test/e2e/frontend/cypress/tests/registration.spec.js
+++ b/test/e2e/frontend/cypress/tests/registration.spec.js
@@ -11,6 +11,37 @@ describe('FlowForge - Sign Up Page', () => {
 
         cy.get('[data-form="signup-join-reason"]').should('not.exist')
         cy.get('[data-form="signup-accept-tcs"]').should('not.exist')
+
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+
+        // Check sign-up button is enabled only when all the required fields are filled in
+        cy.get('[data-form="signup-username"] input').type('username')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+        cy.get('[data-form="signup-fullname"] input').type('fullname')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+        cy.get('[data-form="signup-email"] input').type('email@example.com')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+        cy.get('[data-form="signup-password"] input').type('password')
+        cy.get('[data-action="sign-up"]').should('not.be.disabled')
+
+        // Now the form is valid, check additional constraints
+
+        // Valid email
+        cy.get('[data-form="signup-email"] + span.ff-error-inline').should('be.empty')
+        cy.get('[data-form="signup-email"] input').clear()
+        cy.get('[data-form="signup-email"] input').type('email')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+        cy.get('[data-form="signup-email"] + span.ff-error-inline').should('not.be.empty')
+        cy.get('[data-form="signup-email"] input').type('@example.com')
+        cy.get('[data-action="sign-up"]').should('not.be.disabled')
+        cy.get('[data-form="signup-email"] + span.ff-error-inline').should('be.empty')
+
+        // Password length
+        cy.get('[data-form="signup-password"] input').clear()
+        cy.get('[data-form="signup-password"] input').type('1234')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+        cy.get('[data-form="signup-password"] input').type('5678')
+        cy.get('[data-action="sign-up"]').should('not.be.disabled')
     })
 
     it('should present the option to accept the T&Cs if user settings are set accordingly', () => {
@@ -27,6 +58,15 @@ describe('FlowForge - Sign Up Page', () => {
 
         cy.get('[data-form="signup-accept-tcs"]').should('be.visible')
         cy.get('[data-form="signup-accept-tcs"] a').should('have.attr', 'href', EXAMPLE_TCS_URL)
+
+        // Check sign-up button is enabled only when all the required fields are filled in
+        cy.get('[data-form="signup-username"] input').type('username')
+        cy.get('[data-form="signup-fullname"] input').type('fullname')
+        cy.get('[data-form="signup-email"] input').type('email@example.com')
+        cy.get('[data-form="signup-password"] input').type('password')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+        cy.get('[data-form="signup-accept-tcs"] span.checkbox').click()
+        cy.get('[data-action="sign-up"]').should('not.be.disabled')
     })
 
     it('should present the "What brings you to FlowForge" question if configured', () => {
@@ -43,6 +83,16 @@ describe('FlowForge - Sign Up Page', () => {
         cy.wait('@getUserSettings')
 
         cy.get('[data-form="signup-join-reason"]').should('be.visible')
+
+        // Check sign-up button is enabled only when all the required fields are filled in
+        cy.get('[data-form="signup-username"] input').type('username')
+        cy.get('[data-form="signup-fullname"] input').type('fullname')
+        cy.get('[data-form="signup-email"] input').type('email@example.com')
+        cy.get('[data-form="signup-password"] input').type('password')
+        cy.get('[data-action="sign-up"]').should('be.disabled')
+
+        cy.get('[data-form="signup-join-reason"] span.checkbox').first().click()
+        cy.get('[data-action="sign-up"]').should('not.be.disabled')
     })
 
     // it('requires a password', () => {


### PR DESCRIPTION
## Description

Without posthog enabled, the sign-up button was never becoming enabled.

This was a regression introduced in #2378.

This fixes it, plus adds better test coverage of the sign-up form to ensure the button becomes enabled when the form is filled in under various conditions.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
