### PR TITLE
Add docs about swagger ui

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -8,5 +8,44 @@ navTitle: FlowForge API
 The platform provides a REST API that makes it possible to create integrations and
 custom workflows.
 
-Until we reach 1.0, the API is subject to breaking changes between releases. We
-will get some documentation in place over the coming releases.
+The API comes with an OpenAPI 3.0 Specification that can be viewed [here](https://app.flowforge.com/api/),
+or on any FlowForge instance on the path `/api/`.
+
+### Accessing the API
+
+Currently, all routes require a valid session cookie to be included in the request.
+
+A [future roadmap item](https://github.com/flowforge/flowforge/issues/14) will
+introduce personal access tokens that will make it easier to access the API.
+
+To get a session cookie, the `/account/login` endpoint can be used. The following
+command will create a file `cookies.txt` containing the session cookie that can
+be used for subsequent requests.
+
+```
+curl -X POST -H 'Content-type: application/json' \
+     -d '{"username": "USER", "password": "PASSWORD"}' \
+     -c cookies.txt \
+     http://localhost:3000/account/login
+```
+
+Note that if SSO is enabled for this user, this request will fail. The user
+will have to login via a browser and extract the cookie value from the browser.
+
+
+To get the profile of the current logged in user, using the saved cookie file:
+
+```
+curl -b cookies.txt \
+     -X 'GET' http://localhost:3000/api/v1/user/
+```
+
+Alternatively:
+
+```
+curl -X 'GET' 'http://localhost:3000/api/v1/user/' \
+     -H 'Cookie: sid=<SESSION_TOKEN>'
+```
+
+
+

--- a/docs/contribute/api-design.md
+++ b/docs/contribute/api-design.md
@@ -4,6 +4,30 @@ navTitle: API Design
 
 # HTTP API of the FlowForge platform
 
+## API documentation
+
+All public API routes should include a `schema` as part of their definition. This
+serves a number of purposes:
+
+ - It will be included in the auto-generated OpenAPI 3.0 spec
+ - Fastify will validate requests include any required properties
+ - Fastify will ensure the response object matches the defined schema
+
+Some general guidance:
+
+ - Ensure the routes have an approriate tag set - this determines where in the
+   Swagger UI it gets displayed.
+ - Ensure the tag is listed in `forge/routes/api-docs.js` so it appears in the right place
+ - We define view schemas under `forge/db/views/*` alongside the code that generates the view.
+   Keep the naming consistent with other views.
+ - Learn from the existing schemas - be consistent in style.
+ 
+References:
+
+ - [Fastify Validation and Serialization](https://fastify.dev/docs/latest/Reference/Validation-and-Serialization)
+ - [OpenAPI 3.0 spec](https://swagger.io/specification/)
+
+
 ## Object Ids
 
 Most database models have a primary key of an auto-incrementing integer stored in


### PR DESCRIPTION
## Description

Adds docs to both contrib/develop docs and user docs on API (https://flowforge.com/docs/api/)

Very high-level - just acknowledges the swagger doc exists with a very simply curl example for accessing it today with session cookies.