### PR TITLE
Update ui-components & utilise new ff-theme-dark on signup/login

### DIFF
--- a/frontend/src/layouts/Box.vue
+++ b/frontend/src/layouts/Box.vue
@@ -7,7 +7,7 @@
                 </div>
             </div>
             <div class="ff-layout--box--right">
-                <div class="ff-layout--box--content">
+                <div class="ff-layout--box--content ff-theme-dark">
                     <div class="ff-logo">
                         <img src="/ff-logo--wordmark-caps--dark.png" />
                     </div>

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -27,13 +27,13 @@
                 <ff-radio-group label="What brings you to FlowForge?" v-model="input.join_reason" orientation="grid"
                                 data-form="signup-join-reason" :options="reasons" />
             </div>
-            <div v-if="settings['user:tcs-required']">
+            <div class="pt-3" v-if="settings['user:tcs-required']">
                 <ff-checkbox v-model="input.tcs_accepted" data-form="signup-accept-tcs">
                     I accept the <a target="_blank" :href="settings['user:tcs-url']">FlowForge Terms &amp; Conditions.</a>
                 </ff-checkbox>
             </div>
-            <label v-if="errors.general" class="pt-4 ff-error-inline">{{ errors.general }}</label>
-            <div class="ff-actions pt-4">
+            <label v-if="errors.general" class="pt-3 ff-error-inline">{{ errors.general }}</label>
+            <div class="ff-actions pt-2">
                 <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
                 <p class="flex text-gray-400 font-light mt-6 gap-2 w-full justify-center">
                     Already registered? <a href="/" data-action="login">Log in here</a>

--- a/frontend/src/stylesheets/layouts.scss
+++ b/frontend/src/stylesheets/layouts.scss
@@ -121,20 +121,11 @@ $nav_height: 60px;
     }
     .ff-radio-btn {
         .checkbox {
-          border: 1px solid $ff-grey-600;
+          border: 1px solid $ff-grey-400;
           background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23374151' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='4'/%3e%3c/svg%3e")    
         }
     }
 
-    .checkbox {
-        &[checked=true] {
-            background-color: $ff-white;
-            border-color: $ff-grey-700;
-        }
-        &[checked=true]:after {
-            display: block;
-        }
-    }
     .ff-error-inline {
         margin-bottom: 12px;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@fastify/swagger": "^8.6.0",
                 "@fastify/swagger-ui": "^1.9.0",
                 "@fastify/websocket": "^8.1.0",
-                "@flowforge/forge-ui-components": "^0.6.4",
+                "@flowforge/forge-ui-components": "^0.7.0",
                 "@flowforge/localfs": "^1.9.0",
                 "@headlessui/vue": "1.7.14",
                 "@heroicons/vue": "1.0.6",
@@ -4245,7 +4245,7 @@
             }
         },
         "node_modules/@flowforge/forge-ui-components": {
-            "version": "0.6.4",
+            "version": "0.7.0",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.x"
@@ -23580,7 +23580,7 @@
             }
         },
         "@flowforge/forge-ui-components": {
-            "version": "0.6.4",
+            "version": "0.7.0",
             "requires": {}
         },
         "@flowforge/localfs": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@fastify/swagger": "^8.6.0",
         "@fastify/swagger-ui": "^1.9.0",
         "@fastify/websocket": "^8.1.0",
-        "@flowforge/forge-ui-components": "^0.6.4",
+        "@flowforge/forge-ui-components": "^0.7.0",
         "@flowforge/localfs": "^1.9.0",
         "@headlessui/vue": "1.7.14",
         "@heroicons/vue": "1.0.6",


### PR DESCRIPTION
## Description

- In fixing #2419 noticed a more fundamental problem that had been bugging me for a while with ui-components in how it deals with dark theming (detailed [here](https://github.com/flowforge/forge-ui-components/pull/147)).
- These issues were meaning we had to write our own dark-them logic in /flowforge in some cases (due to slightly different bg colouring), which is nonsensical
- 0.7.0 of ui-components fixes that, and introduces a new `ff-theme-dark` class which will inherit the correct component-by-component CSS, and consequently fixes #2419

### Examples:

<img width="499" alt="Screenshot 2023-07-06 at 15 21 16" src="https://github.com/flowforge/flowforge/assets/99246719/d84c1e8a-3aea-485c-ac2c-9e43433fd190">

## Related Issue(s)

Fixes #2419

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
     - CSS only changes

## Labels

 - [x] Backport needed? -> add the `backport` label

