### PR TITLE
Update node version statement in devices docs

### DIFF
--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -11,7 +11,7 @@ This guide explains how to get starting with the Devices feature.
 
 ## Prerequisites
 
- - NodeJS v16 or later
+ - NodeJS v14 or later
  
 ## Supported Operating Systems
 

--- a/docs/user/devices.md
+++ b/docs/user/devices.md
@@ -11,7 +11,10 @@ This guide explains how to get starting with the Devices feature.
 
 ## Prerequisites
 
- - NodeJS v14 or later
+ - NodeJS v16 or later
+
+Device Agent v1.9.3+ also supports running on NodeJS v14 for hardware devices that are not
+able to update to more recent versions.
  
 ## Supported Operating Systems
 


### PR DESCRIPTION
## Description

Updating to sync with the Device Agent support. Decided to keep the top line saying we support 16, but with a note about 14 support for older hardware. We don't want to encourage Node 14 use if it can be avoided.