### PR TITLE
Tidy spacing & bolden the "make note" messaging

### DIFF
--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -1,23 +1,26 @@
 <template>
     <ff-dialog ref="dialog" header="Device Credentials">
         <template v-slot:default>
-            <form class="space-y-6 mt-2">
+            <form class="text-gray-800">
                 <template v-if="!hasCredentials">
-                    <p class="text-sm text-gray-500">
+                    <p>
                         Are you sure you want to regenerate credentials for this device?
                     </p>
-                    <p class="text-sm text-gray-500">
+                    <p class="mt-3 mb-6">
                         The existing credentials will be reset and the device will not
                         be able to reconnect until it has been given its new credentials.
                     </p>
                 </template>
                 <template v-if="hasCredentials">
-                    <p class="text-sm text-gray-500">
+                    <p>
                         To connect your device to the platform, use the following
-                        credentials. Make a note of them as this is the only
+                        credentials.
+                    </p>
+                    <p class="font-bold italic mt-3 mb-6">
+                        Make a note of them as this is the only
                         time you will see them.
                     </p>
-                    <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
+                    <pre class="overflow-auto text-sm p-4 mt-6 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
                 </template>
             </form>
         </template>

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -16,7 +16,7 @@
                         To connect your device to the platform, use the following
                         credentials.
                     </p>
-                    <p class="font-bold italic mt-3 mb-6">
+                    <p class="font-bold mt-3 mb-6">
                         Make a note of them as this is the only
                         time you will see them.
                     </p>


### PR DESCRIPTION
## Description

Re-works the spacing, and adds **bold** font to the "make note" messaging so that it isn't missed, and better draws the user's eye.

<img width="1728" alt="Screenshot 2023-07-07 at 13 22 50" src="https://github.com/flowforge/flowforge/assets/99246719/60e2fdaa-13b7-401d-b407-25f7b5cc57b8">

#2430 will cover additional changes to this dialog.

## Related Issue(s)

Closes #2429

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
     - Text change & minor margin changes only 