### PR TITLE
Improve instruction & labelling on "Add Device" dialog

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -173,7 +173,7 @@
                 placed on the target device.
             </p>
             <p class="my-4">
-                If you want to devices to be automatically registered, you can use provisioning tokens
+                If you want your device to be automatically registered to an instance, in order to remotely deploy flows, you can use provisioning tokens
                 in your <router-link :to="{'name': 'TeamSettingsDevices', 'params': {team_slug: team.slug}}">Team Settings</router-link>
             </p>
             <p class="my-4">

--- a/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/TeamDeviceCreateDialog.vue
@@ -6,8 +6,14 @@
         <template #default>
             <slot name="description" />
             <form class="space-y-6 mt-2">
-                <FormRow v-model="input.name" data-form="device-name" :error="errors.name" :disabled="editDisabled">Name</FormRow>
-                <FormRow v-model="input.type" data-form="device-type" :error="errors.type" :disabled="editDisabled">Type</FormRow>
+                <FormRow v-model="input.name" data-form="device-name" :error="errors.name" :disabled="editDisabled" container-class="w-full">
+                    <template #default>Name</template>
+                    <template #description>Provide a unique, identifiable name for your device.</template>
+                </FormRow>
+                <FormRow v-model="input.type" data-form="device-type" :error="errors.type" :disabled="editDisabled" container-class="w-full">
+                    <template #default>Type</template>
+                    <template #description>Use this field to better identify your device, and sort/filter in your device list.</template>
+                </FormRow>
                 <div v-if="billingDescription">
                     <b>Price: {{ billingDescription }}</b>
                 </div>


### PR DESCRIPTION
## Description

Improve the language & labelling on the "Add Device" modals. Better informing users of functionality available.

## Related Issue(s)

Fixed #2428 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

