### PR TITLE
Doc Fixes: Remove trailing / on links with # and broken device-agent link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,8 @@ Node-RED application development and delivery.
 
 ## FlowForge Cloud
  - [FlowForge Cloud](./cloud/) - find out how we've configured FlowForge for FlowForge Cloud.
- - [Network Connections](./cloud/#network-connections/) - Details what connections can and cannot be established to Node-RED instances running in FlowForge Cloud.
- - [Single Sign On](./cloud/#single-sign-on/) - FlowForge supports configuring SAML-based Single Sign-On for particular email domains. Contact us to configure for your team.
+ - [Network Connections](./cloud/#network-connections) - Details what connections can and cannot be established to Node-RED instances running in FlowForge Cloud.
+ - [Single Sign On](./cloud/#single-sign-on) - FlowForge supports configuring SAML-based Single Sign-On for particular email domains. Contact us to configure for your team.
  - [Billing](./cloud/) - find out how we've configured FlowForge for FlowForge Cloud.
 
 ## Managing FlowForge
@@ -46,9 +46,9 @@ Node-RED application development and delivery.
 - [From Open Source to Premium](./upgrade/open-source-to-premium.md)
 
  ## Contributing to FlowForge
- - [Useful Information](./contribute/#contributing-to-flowforge/) - Learn the foundational concepts of how FlowForge is built & structured. 
- - [Development Setup](./contribute/#development-setup/) - Configure your local development environment to contribute to FlowForge.
- - [Testing](./contribute/#testing/) - Understand our testing philosophy at FlowForge.
+ - [Useful Information](./contribute/#contributing-to-flowforge) - Learn the foundational concepts of how FlowForge is built & structured. 
+ - [Development Setup](./contribute/#development-setup) - Configure your local development environment to contribute to FlowForge.
+ - [Testing](./contribute/#testing) - Understand our testing philosophy at FlowForge.
  
 ## Support
 

--- a/docs/device-agent/install.md
+++ b/docs/device-agent/install.md
@@ -34,14 +34,14 @@ npm install -g @flowforge/flowforge-device-agent
 
 
 Or you can chose to run the Docker container. When you do, you'll need to mount
-the `device.yaml` obtained when [Registering the device](#register-the-device):
+the `device.yaml` obtained when [Registering the device](./register.md):
 
 ```bash
 docker run --mount /path/to/device.yml:/opt/flowforge-device/device.yml -p 1880:1880 flowforge/device-agent:latest
 ```
 
 Or you can chose to run the Docker-Compose via a docker-compose.yml file. When you do, you'll need to mount
-the `device.yaml` as in Docker obtained when [Registering the device](#register-the-device):
+the `device.yaml` as in Docker obtained when [Registering the device](./register.md):
 
 ```yaml
 version: '3.9'


### PR DESCRIPTION
## Description

Fix the errors flagged in https://github.com/flowforge/website/pull/953#issuecomment-1630783979

For the device agent link, this was a broken/404 error, for the others, they were all valid links to # anchors that existed, so the only thing I could think of that caused them to trip was the trailing / after the #, so have removed those.

## Related Issue(s)

https://github.com/flowforge/website/pull/953#issuecomment-1630783979

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated

## Labels

 - [x] Backport needed? -> add the `backport` label

