### PR TITLE
Allow Postgres DB connection to enable SSL

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -57,6 +57,7 @@ Option       | Description
 `db.database`| Database name on Postgres Server. Default: `flowforge`.
 `db.user`    | Username used when connecting to Postgres Server. 
 `db.password`| Password used when connecting to Postgres Server.
+`db.ssl`     | Client should connect with SSL/TLS. Default: `false`
 
 ## Node-RED Driver configuration
 

--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -50,7 +50,9 @@ module.exports = fp(async function (app, _opts, next) {
         dbOptions.password = /* app.secrets.dbPassword || */ app.config.db.password
         dbOptions.database = app.config.db.database || 'flowforge'
         dbOptions.dialectOptions = {
-            sslmode: 'prefer'
+            ssl: {
+                sslmode: 'prefer'
+            }
         }
     }
 

--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -49,6 +49,9 @@ module.exports = fp(async function (app, _opts, next) {
         dbOptions.username = app.config.db.user
         dbOptions.password = /* app.secrets.dbPassword || */ app.config.db.password
         dbOptions.database = app.config.db.database || 'flowforge'
+        dbOptions.dialectOptions = {
+            sslmode: 'prefer'
+        }
     }
 
     dbOptions.logging = !!app.config.db.logging

--- a/forge/db/index.js
+++ b/forge/db/index.js
@@ -49,9 +49,9 @@ module.exports = fp(async function (app, _opts, next) {
         dbOptions.username = app.config.db.user
         dbOptions.password = /* app.secrets.dbPassword || */ app.config.db.password
         dbOptions.database = app.config.db.database || 'flowforge'
-        dbOptions.dialectOptions = {
-            ssl: {
-                sslmode: 'prefer'
+        if (app.config.db.ssl) {
+            dbOptions.dialectOptions = {
+                ssl: true
             }
         }
     }


### PR DESCRIPTION
part of flowforge/helm#151

This should make sequelize try and connect with SSL first then fall back to plain.

## Description

<!-- Describe your changes in detail -->
This should make sequelize try and connect with SSL first then fall back to plain.

Shouldn't need a doc upgrade as this should "just work"

Likewise this shouldn't need a test change
## Related Issue(s)

<!-- What issue does this PR relate to? -->
flowforge/helm#151

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

