### PR TITLE
Make the response log entry contains the real source IP address

### DIFF
--- a/forge/forge.js
+++ b/forge/forge.js
@@ -60,7 +60,7 @@ module.exports = async (options = {}) => {
                         request: {
                             url: reply.request?.raw?.url,
                             method: reply.request?.method,
-                            remoteAddress: reply.request?.socket.remoteAddress,
+                            remoteAddress: reply.request?.ip,
                             remotePort: reply.request?.socket.remotePort
                         }
                     }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Noticed that using the raw socket will always logs the loadbalancer.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

