### PR TITLE
Fix incorrect 'start-failed' notifications

### DIFF
--- a/frontend/src/pages/application/index.vue
+++ b/frontend/src/pages/application/index.vue
@@ -230,30 +230,28 @@ export default {
         async instanceStart (instance) {
             const mutator = new InstanceStateMutator(instance)
             mutator.setStateOptimistically('starting')
-
-            const err = await InstanceApi.startInstance(instance)
-            if (err) {
+            try {
+                await InstanceApi.startInstance(instance)
+                mutator.setStateAsPendingFromServer()
+            } catch (err) {
                 console.warn('Instance start failed.', err)
                 alerts.emit('Instance start failed.', 'warning')
 
                 mutator.restoreState()
-            } else {
-                mutator.setStateAsPendingFromServer()
             }
         },
 
         async instanceRestart (instance) {
             const mutator = new InstanceStateMutator(instance)
             mutator.setStateOptimistically('restarting')
-
-            const err = await InstanceApi.restartInstance(instance)
-            if (err) {
+            try {
+                await InstanceApi.restartInstance(instance)
+                mutator.setStateAsPendingFromServer()
+            } catch (err) {
                 console.warn('Instance restart failed.', err)
                 alerts.emit('Instance restart failed.', 'warning')
 
                 mutator.restoreState()
-            } else {
-                mutator.setStateAsPendingFromServer()
             }
         },
 

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -234,27 +234,24 @@ export default {
         async startInstance () {
             this.instanceStateMutator.setStateOptimistically('starting')
 
-            const err = await InstanceApi.startInstance(this.instance)
-            if (err) {
+            try {
+                await InstanceApi.startInstance(this.instance)
+                this.instanceStateMutator.setStateAsPendingFromServer()
+            } catch (err) {
                 console.warn('Instance start failed.', err)
                 alerts.emit('Instance start failed.', 'warning')
-
                 this.instanceStateMutator.restoreState()
-            } else {
-                this.instanceStateMutator.setStateAsPendingFromServer()
             }
         },
         async restartInstance () {
             this.instanceStateMutator.setStateOptimistically('restarting')
-
-            const err = await InstanceApi.restartInstance(this.instance)
-            if (err) {
+            try {
+                await InstanceApi.restartInstance(this.instance)
+                this.instanceStateMutator.setStateAsPendingFromServer()
+            } catch (err) {
                 console.warn('Instance restart failed.', err)
                 alerts.emit('Instance restart failed.', 'warning')
-
                 this.instanceStateMutator.restoreState()
-            } else {
-                this.instanceStateMutator.setStateAsPendingFromServer()
             }
         },
         showConfirmDeleteDialog () {


### PR DESCRIPTION
## Description

When starting a suspended instance, I was getting a 'Start Failed' notification even though it had succeeded.

This fixes that. The API returns a proper status object, whereas the code was treating any non-blank response as an error.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

