### PR TITLE
Add log messages for device agent connect/disconnect events

### DIFF
--- a/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
+++ b/forge/ee/lib/deviceEditor/DeviceTunnelManager.js
@@ -215,6 +215,7 @@ class DeviceTunnelManager {
                 wsSocket.close()
                 delete tunnel.forwardedWS[id]
             }
+            this.app.log.info(`Device ${deviceId} tunnel closed. id:${tunnel.id}`)
         })
 
         /** @type {httpHandler} */
@@ -257,6 +258,8 @@ class DeviceTunnelManager {
             const wsToDevice = connection.socket
             tunnel.forwardedWS[requestId] = wsToDevice
 
+            this.app.log.info(`Device ${deviceId} tunnel id:${tunnel.id} - new editor connection req:${requestId} `)
+
             wsToDevice.on('message', msg => {
                 // Forward messages sent by the editor down to the device
                 // console.log(`[${tunnel.id}] [${requestId}] E>R`, msg.toString())
@@ -267,6 +270,7 @@ class DeviceTunnelManager {
                 }))
             })
             wsToDevice.on('close', msg => {
+                this.app.log.info(`Device ${deviceId} tunnel id:${tunnel.id} - editor connection closed req:${requestId} `)
                 // The editor has closed its websocket. Send notification to the
                 // device so it can close its corresponing connection
                 // console.log(`[${tunnel.id}] [${requestId}] E>R closed`)
@@ -281,6 +285,7 @@ class DeviceTunnelManager {
                 }
             })
         }
+        this.app.log.info(`Device ${deviceId} tunnel connected. id:${tunnel.id}`)
         return true
     }
 


### PR DESCRIPTION
## Description

Adds log events for when the device agent tunnel connects/disconnects and when editor websocket connections connect/disconnect.

We previously had audit event log entries for when the editor mode was enabled - but that didn't report on the websocket events.

This will give better insight on the reliability of the websocket tunnels.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

