### PR TITLE
Treat disabling an already disabled editor tunnel as a no-op

### DIFF
--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -76,7 +76,8 @@ module.exports = async function (app) {
 
         const currentState = tunnelManager.getTunnelStatus(deviceId)
         if (currentState.enabled === mode) {
-            reply.code(400).send({ code: 'invalid_request', error: 'Device Editor already ' + (mode ? 'enabled' : 'disabled') })
+            const tunnelStatus = tunnelManager.getTunnelStatus(request.device.hashid) || { enabled: false }
+            reply.send(tunnelStatus)
             return
         }
 

--- a/test/unit/forge/ee/routes/deviceEditor/index_spec.js
+++ b/test/unit/forge/ee/routes/deviceEditor/index_spec.js
@@ -123,7 +123,23 @@ describe('Device Editor API', function () {
             TestObjects.tokens.should.have.property(app.device.hashid)
         })
 
+        it('can enable an already enabled editor mode', async function () {
+            const result = await setDeviceEditorStatus(app.device.hashid, TestObjects.tokens.alice, true)
+            result.should.have.property('enabled', true)
+            result.should.have.property('connected', false)
+            result.should.have.property('url')
+            TestObjects.tokens.should.have.property(app.device.hashid)
+        })
+
         it('disable editor mode', async function () {
+            const result = await setDeviceEditorStatus(app.device.hashid, TestObjects.tokens.alice, false)
+            result.should.have.property('enabled', false)
+            result.should.not.have.property('connected')
+            result.should.not.have.property('url')
+            TestObjects.tokens.should.not.have.property(app.device.hashid)
+        })
+
+        it('can disable and already disabled editor mode', async function () {
             const result = await setDeviceEditorStatus(app.device.hashid, TestObjects.tokens.alice, false)
             result.should.have.property('enabled', false)
             result.should.not.have.property('connected')


### PR DESCRIPTION
## Description

Regression identified in staging. Attempting to put a new device into Dev mode was hitting an error as it was trying to disable an already disabled editor tunnel.

Rather than treat that as an error case, we should no-op it as the desired state is already present.