### PR TITLE
Route rate limits (sec #18)

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -146,8 +146,6 @@ To enable rate limiting, you can set the `rate_limits.enabled` option to `true`.
 
 When enabled, all routes will be limited to 1000 requests per 1 minute window. These defaults can be adjusted by setting values in the configuration options listed below.
 
-NOTE: Some routes are prohibited from being rate limited, such as the logout and acl routes.
-
 Option        | Description
 --------------|------------
 `rate_limits.enabled` | Enables rate limiting. Default: `false`

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -138,6 +138,26 @@ Option        | Description
 `telemetry.frontend.posthog.capture_pageview` | FlowForge is designed as to provide custom posthog `$pageview` events that provide more detail on navigation than the default, and suit a single page application better. As such, we recommend setting this to false in order to prevent duplicate `pageleave`/`pageview` events firing. Default: `true`
 
 
+## Rate Limiting configuration
+
+By default, rate limiting is disabled and the platform will not rate limit any requests.
+
+To enable rate limiting, you can set the `rate_limits.enabled` option to `true`. This will enable rate limiting for all routes unless explicitly disabled (see note below).
+By default, all routes will be limited requests to 1000 per 1 minute window for logged in users, and 60 per 1 minute window for anonymous users.
+
+NOTE: Some routes are prohibited from being rate limited, such as the logout and acl routes.
+
+Option        | Description
+--------------|------------
+`rate_limits.enabled` | Enables rate limiting. Default: `false`
+`rate_limits.global` | Enables rate limiting for all routes. Default: `true` (defaults to all routes being rate limited)
+`rate_limits.timeWindow` | The time window in which requests are counted. Default: `60000` (1 minute)
+`rate_limits.max` | The maximum number of requests allowed in the time window. Default: `1000`
+`rate_limits.maxAnonymous` | The maximum number of requests allowed in the time window for anonymous users. Default: not configured (defaults to `rate_limits.max`)
+
+For additional options, see [fastify-rate-limit](https://github.com/fastify/fastify-rate-limit#options) documentation.
+
+
 ## Support configuration
 
 It is possible to add a [HubSpot Support Widget](https://knowledge.hubspot.com/chatflows/create-a-live-chat) into FlowForge. This will appear as a floating chat bubble on the bottom-right corner of the screen. To enable this, you'll need to provide the 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -18,7 +18,7 @@ Option | Description
 `host` | The address to serve the web ui on. This defaults to `localhost` which means the ui will only be available when browsing from the same server that is running the platform. To make it accessible to other devices on the network, set it to `0.0.0.0`. <br>NOTE: If `host` is changed, please also update `base_url` to match e.g.  `http://[ip-address-of-host]:3000`
 `port` | The TCP port the platform serves its web ui. Default: `3000`
 `base_url` | The url to access the platform. This defaults to `http://localhost:3000` which means a number of internally generated URLs will only work when browsing on the same device as is running the platform. To be able to access the platform remotely, replace `localhost` with the ip address of the device running FlowForge. 
-`domain` | The domain that instance names will be pre-pended to on Docker & Kubernetes platforms to create a hostname to access the instance. A wildcard DNS A record should point be configured to point to the FlowForge entry IP Address.
+`domain` | The domain that instance names will be prepended to on Docker & Kubernetes platforms to create a hostname to access the instance. A wildcard DNS A record should point be configured to point to the FlowForge entry IP Address.
 `support_contact` | a URL or string with contact details for the administrator e.g `mailto:support@example.com` or `https://support.example.com` . Defaults to the email address of the first admin user or `the administrator` if no email address set.
 
 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -142,8 +142,9 @@ Option        | Description
 
 By default, rate limiting is disabled and the platform will not rate limit any requests.
 
-To enable rate limiting, you can set the `rate_limits.enabled` option to `true`. This will enable rate limiting for all routes unless explicitly disabled (see note below).
-By default, all routes will be limited requests to 1000 per 1 minute window for logged in users, and 60 per 1 minute window for anonymous users.
+To enable rate limiting, you can set the `rate_limits.enabled` option to `true`. 
+
+When enabled, all routes will be limited to 1000 requests per 1 minute window. These defaults can be adjusted by setting values in the configuration options listed below.
 
 NOTE: Some routes are prohibited from being rate limited, such as the logout and acl routes.
 

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -14,6 +14,12 @@ for each version you are upgrading across.
 Note that we do not support downgrading FlowForge to previous levels once an upgrade
 has been performed.
 
+### Upgrading to 1.10
+
+Endpoint Rate Limiting is now available to FlowForge. This is disabled by default, but can be enabled by setting the `rate_limits.enabled` config setting to `true`.
+The documentation for this is available [here](../install/configuration.md#rate-limiting-configuration).
+
+
 ### Upgrading to 1.5
 
 The main change in this release was a change in our terminology around the individual

--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -95,3 +95,13 @@ email:
 #################################################
 telemetry:
   enabled: true
+
+#################################################
+# Route Rate Limits                             #
+#################################################
+rate_limits:
+  enabled: false
+  # global: true
+  # timeWindow: '1 minute'
+  # max: 1000
+  # maxAnonymous: 10 # optional

--- a/forge/comms/authRoutes.js
+++ b/forge/comms/authRoutes.js
@@ -8,6 +8,9 @@
 
 module.exports = async function (app) {
     app.post('/client', {
+        config: {
+            rateLimit: false // never rate limit this route
+        },
         schema: {
             body: {
                 type: 'object',
@@ -32,6 +35,9 @@ module.exports = async function (app) {
     })
 
     app.post('/acl', {
+        config: {
+            rateLimit: false // never rate limit this route
+        },
         schema: {
             body: {
                 type: 'object',

--- a/forge/config/index.js
+++ b/forge/config/index.js
@@ -20,6 +20,8 @@ const path = require('path')
 const fp = require('fastify-plugin')
 const YAML = require('yaml')
 
+const rateLimits = require('../routes/rateLimits.js')
+
 const features = require('./features')
 
 // const FastifySecrets = require('fastify-secrets-env')
@@ -118,6 +120,8 @@ module.exports = fp(async function (app, opts, next) {
                 config.logging.http = 'warn'
             }
         }
+
+        config.rate_limits = rateLimits.getLimits(app, config.rate_limits)
 
         config.features = features(app, config)
 

--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -51,6 +51,7 @@ module.exports = async function (app) {
      */
     app.put('/', {
         preHandler: app.needsPermission('device:editor'),
+        config: { rateLimit: false }, // never rate limit this route
         schema: {
             params: {
                 type: 'object',
@@ -124,7 +125,8 @@ module.exports = async function (app) {
      * @memberof module:forge/routes/api/device
      */
     app.get('/', {
-        preHandler: app.needsPermission('device:editor')
+        preHandler: app.needsPermission('device:editor'),
+        config: { rateLimit: false } // never rate limit this route
     }, async (request, reply) => {
         /** @type {DeviceTunnelManager} */
         const tunnelManager = app.comms.devices.tunnelManager
@@ -138,7 +140,10 @@ module.exports = async function (app) {
      * @name /api/v1/devices/:deviceId/editor/token
      */
     app.get('/token', {
-        config: { allowAnonymous: true }
+        config: {
+            allowAnonymous: true,
+            rateLimit: false // never rate limit this route
+        }
     }, async (request, reply) => {
         const tunnelManager = getTunnelManager()
         if (tunnelManager.verifyToken(request.params.deviceId, request.headers['x-access-token'])) {
@@ -154,7 +159,10 @@ module.exports = async function (app) {
      * @name /api/v1/devices/:deviceId/editor/comms/:access_token
      */
     app.get('/comms/:access_token', {
-        config: { allowAnonymous: true },
+        config: {
+            allowAnonymous: true,
+            rateLimit: false // never rate limit this route
+        },
         websocket: true
     }, (connection, request) => {
         // * Enable Device Editor (Step 9) - (device:WS->forge) websocket connect request from device
@@ -187,7 +195,10 @@ module.exports = async function (app) {
         // Set 'allowAnonymous' as we don't want to return the standard API
         // response object. Instead, we will use the preHandler to detect
         // there's no session user and redirect to the device overview
-        config: { allowAnonymous: true },
+        config: {
+            allowAnonymous: true,
+            rateLimit: false // never rate limit this route
+        },
         preHandler: async (request, reply) => {
             if (!request.teamMembership) {
                 // Failed authentication. Redirect to the device overview page
@@ -236,7 +247,10 @@ module.exports = async function (app) {
     app.route({
         method: ['POST', 'DELETE', 'PUT', 'HEAD', 'OPTIONS'],
         url: '/proxy/*',
-        config: { allowAnonymous: true },
+        config: {
+            allowAnonymous: true,
+            rateLimit: false // never rate limit this route
+        },
         preHandler: async (request, reply) => {
             if (!request.teamMembership) {
                 // Failed authentication. Redirect to the device overview page

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -79,6 +79,13 @@ module.exports = async (options = {}) => {
         if (server.config.logging?.level) {
             server.log.level = server.config.logging.level
         }
+
+        // Rate Limits: rate limiting for the server end points
+        if (server.config.rate_limits?.enabled) {
+            // for rate_limits, see [routes/rateLimits.js].getLimits()
+            await server.register(require('@fastify/rate-limit'), server.config.rate_limits)
+        }
+
         // DB : the database connection/models/views/controllers
         await server.register(db)
         // Settings

--- a/forge/forge.js
+++ b/forge/forge.js
@@ -80,6 +80,12 @@ module.exports = async (options = {}) => {
             server.log.level = server.config.logging.level
         }
 
+        // Test Only. Permit access to app.routes - for evaluating routes in tests
+        if (options.config?.test?.fastifyRoutes) {
+            // since @fastify/routes is a dev dependency, we only load it when requested in test
+            server.register(require('@fastify/routes')) // eslint-disable-line n/no-unpublished-require
+        }
+
         // Rate Limits: rate limiting for the server end points
         if (server.config.rate_limits?.enabled) {
             // for rate_limits, see [routes/rateLimits.js].getLimits()

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -35,7 +35,15 @@ const SESSION_COOKIE_OPTIONS = {
  * @typedef {import('../../db/controllers/User')} UserController
  */
 
-module.exports = fp(async function (app, opts, done) {
+module.exports = fp(init)
+
+/**
+ * Initialize the auth plugin
+ * @param {import('forge/forge').ForgeApplication} app
+ * @param {Object} opts
+ * @param {Function} done
+ */
+async function init (app, opts, done) {
     await app.register(require('./oauth'), { logLevel: app.config.logging.http })
     await app.register(require('./permissions'))
 
@@ -170,6 +178,9 @@ module.exports = fp(async function (app, opts, done) {
      * @memberof forge.routes.session
      */
     app.post('/account/login', {
+        config: {
+            rateLimit: app.config.rate_limits // rate limit this route regardless of global/per-route mode (if enabled)
+        },
         schema: {
             summary: 'Log in to the platform',
             description: 'Log in to the platform. If SSO is enabled for this user, the response will prompt the user to retry via the SSO login mechanism.',
@@ -226,6 +237,9 @@ module.exports = fp(async function (app, opts, done) {
      * @memberof forge.routes.session
      */
     app.post('/account/logout', {
+        config: {
+            rateLimit: false // never rate limit this route
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN']
         }
@@ -272,6 +286,9 @@ module.exports = fp(async function (app, opts, done) {
      * @memberof forge.routes.session
      */
     app.post('/account/register', {
+        config: {
+            rateLimit: app.config.rate_limits // rate limit this route regardless of global/per-route mode (if enabled)
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN'],
             body: {
@@ -410,6 +427,9 @@ module.exports = fp(async function (app, opts, done) {
      * Perform email verification
      */
     app.post('/account/verify/:token', {
+        config: {
+            rateLimit: false // never rate limit this route
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN']
         }
@@ -483,8 +503,13 @@ module.exports = fp(async function (app, opts, done) {
      * Generate verification email
      */
     app.post('/account/verify', {
-        preHandler: app.verifySession,
-        config: { allowUnverifiedEmail: true },
+        preHandler: function (request, reply, done) {
+            app.verifySession(request, reply).then(() => done()).catch(done)
+        },
+        config: {
+            rateLimit: false, // never rate limit this route
+            allowUnverifiedEmail: true
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN']
         }
@@ -563,6 +588,9 @@ module.exports = fp(async function (app, opts, done) {
     })
 
     app.post('/account/forgot_password', {
+        config: {
+            rateLimit: app.config.rate_limits // rate limit this route regardless of global/per-route mode (if enabled)
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN'],
             body: {
@@ -607,6 +635,9 @@ module.exports = fp(async function (app, opts, done) {
     })
 
     app.post('/account/reset_password/:token', {
+        config: {
+            rateLimit: app.config.rate_limits // rate limit this route regardless of global/per-route mode (if enabled)
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN'],
             body: {
@@ -658,4 +689,4 @@ module.exports = fp(async function (app, opts, done) {
     })
 
     done()
-})
+}

--- a/forge/routes/auth/oauth.js
+++ b/forge/routes/auth/oauth.js
@@ -41,6 +41,9 @@ module.exports = async function (app) {
     })
 
     app.get('/account/authorize', {
+        config: {
+            rateLimit: false // never rate limit this route
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN'],
             querystring: {
@@ -223,6 +226,9 @@ module.exports = async function (app) {
     })
 
     app.post('/account/token', {
+        config: {
+            rateLimit: false // never rate limit this route
+        },
         schema: {
             tags: ['Authentication', 'X-HIDDEN'],
             body: {

--- a/forge/routes/rateLimits.js
+++ b/forge/routes/rateLimits.js
@@ -1,0 +1,79 @@
+/**
+ * Rate limiting for the server end points
+ * `getLimits` returns the rate limit configuration object based on
+ * settings in the config file under section `rate_limits`
+ * @see https://github.com/fastify/fastify-rate-limit or the intellisense completions for additional options
+ * @namespace routes
+ * @memberof forge
+ */
+
+module.exports = {
+    getLimits
+}
+
+/**
+ * @typedef {Object} RLExtra - additional options for rate-limit
+ * @property {Boolean} enabled - enable rate limiting
+ * @property {Number} [maxAnonymous] - max requests per window for anonymous users (optional)
+ *
+ * @typedef {import('@fastify/rate-limit').RateLimitPluginOptions & RLExtra} RateLimitConfig
+ * @typedef {import('forge/forge').ForgeApplication} ForgeApplication
+ */
+
+/**
+ * @typedef RateLimitConfig2
+ * @type {Object}
+ * @augments RateLimitConfig
+ * @property {Number} value
+ */
+
+/**
+ * Prepare configuration settings for the rate-limit plugin
+ * @param {ForgeApplication} app The app object
+ * @param {RateLimitConfig} configLimits The rate-limit plugin options
+ * @returns {RateLimitConfig | false}
+ */
+function getLimits (app, configLimits) {
+    if (!configLimits || !configLimits.enabled) {
+        return false
+    }
+
+    /** @type {RateLimitConfig} */
+    const defaults = {
+        global: true, // default to rate limiting all routes (except those explicitly excluded by `{ config { rateLimit: false } }`)
+        timeWindow: '1 minute', // default window - 1 minute
+        max: 1000 // max requests per window
+        // maxAnonymous: 60 // max requests per window for anonymous users
+    }
+
+    /** @type {RateLimitConfig} */
+    const limits = Object.assign({}, defaults, configLimits || {})
+
+    // if settings specify `maxAnonymous`, setup a dynamic max function.
+    // Essentially, if the user is not logged in, use the maxAnonymous value
+    // otherwise use the max value
+    // e.g: maxAnonymous: 10, max: 100
+    //      if user is not logged in, max = 10
+    //      if user is logged in, max = 100
+    if (typeof limits.max !== 'function' && typeof limits.maxAnonymous === 'number' && limits.maxAnonymous > 0) {
+        const _max = typeof limits.max === 'number' && limits.max > 0 ? limits.max : defaults.max
+        limits.max = (request) => {
+            if (!request || !request.sid) {
+                return limits.maxAnonymous
+            }
+            return _max
+        }
+    }
+
+    // setup the key generator for per-visitor rate limiting
+    limits.keyGenerator = limits.keyGenerator || function (request) {
+        return request.sid || request.headers['x-real-ip'] || request.headers['x-forwarded-for'] || request.ip
+    }
+
+    // log rate limit exceeded
+    limits.onExceeded = limits.onExceeded || function (req, key) {
+        app?.log?.warn?.(`Rate limit exceeded for '${key}' on ${req.raw.url}`)
+    }
+
+    return limits
+}

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -185,7 +185,7 @@ export default {
                     } else if (/email/.test(err.response.data.error)) {
                         this.errors.email = 'Email unavailable'
                     } else if (err.response.data.statusCode === 429) {
-                        this.errors.general = 'Too many login attempts. Try again later.'
+                        this.errors.general = 'Too many attempts. Try again later.'
                         this.tooManyRequests = true
                         setTimeout(() => {
                             this.tooManyRequests = false

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -34,7 +34,12 @@
             </div>
             <label v-if="errors.general" class="pt-3 ff-error-inline">{{ errors.general }}</label>
             <div class="ff-actions pt-2">
-                <ff-button :disabled="!formValid" @click="registerUser()" data-action="sign-up">Sign Up</ff-button>
+                <ff-button :disabled="!formValid || busy || tooManyRequests" @click="registerUser()" data-action="sign-up">
+                    <span>Sign Up</span>
+                    <span class="w-4">
+                        <SpinnerIcon v-if="busy || tooManyRequests" class="ff-icon ml-3 !w-3.5" />
+                    </span>
+                </ff-button>
                 <p class="flex text-gray-400 font-light mt-6 gap-2 w-full justify-center">
                     Already registered? <a href="/" data-action="login">Log in here</a>
                 </p>
@@ -57,15 +62,20 @@ import { mapState } from 'vuex'
 
 import userApi from '../../api/user.js'
 
+import SpinnerIcon from '../../components/icons/Spinner.js'
 import FFLayoutBox from '../../layouts/Box.vue'
 
 export default {
     name: 'AccountCreate',
     components: {
-        'ff-layout-box': FFLayoutBox
+        'ff-layout-box': FFLayoutBox,
+        SpinnerIcon
     },
     data () {
         return {
+            busy: false,
+            tooManyRequests: false,
+            createDisabled: false,
             teams: [],
             emailSent: false,
             ssoCreated: false,
@@ -151,14 +161,18 @@ export default {
                 this.input.code = this.$route.query.code
             }
             const opts = { ...this.input, name: this.input.name || this.input.username }
+            this.busy = true // show spinner
+            this.errors.general = '' // clear any previous errors
             userApi.registerUser(opts).then(result => {
                 if (result.sso_enabled) {
                     this.ssoCreated = true
                 } else {
                     this.emailSent = true
                 }
+                this.busy = false
             }).catch(err => {
                 console.error(err.response.data)
+                this.busy = false
                 if (err.response.data) {
                     if (/username/.test(err.response.data.error)) {
                         this.errors.username = 'Username unavailable'
@@ -170,9 +184,15 @@ export default {
                         this.errors.email = err.response.data.error
                     } else if (/email/.test(err.response.data.error)) {
                         this.errors.email = 'Email unavailable'
-                    }
-                    if (err.response.data.error === 'user registration not enabled') {
+                    } else if (err.response.data.statusCode === 429) {
+                        this.errors.general = 'Too many login attempts. Try again later.'
+                        this.tooManyRequests = true
+                        setTimeout(() => {
+                            this.tooManyRequests = false
+                        }, 10000)
+                    } else if (err.response.data.error === 'user registration not enabled') {
                         // TODO Where to show this error?
+                        this.errors.general = 'User registration is not enabled'
                     }
                 }
             })

--- a/frontend/src/store/account.js
+++ b/frontend/src/store/account.js
@@ -249,7 +249,7 @@ const actions = {
             await userApi.login(credentials.username, credentials.password)
             state.dispatch('checkState', state.getters.redirectUrlAfterLogin)
         } catch (err) {
-            if (err.response.status === 401) {
+            if (err.response.status >= 401) {
                 state.commit('loginFailed', err.response.data)
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@fastify/formbody": "^7.4.0",
                 "@fastify/helmet": "^11.0.0",
                 "@fastify/passport": "^2.3.0",
+                "@fastify/rate-limit": "^8.0.3",
                 "@fastify/static": "^6.10.2",
                 "@fastify/swagger": "^8.6.0",
                 "@fastify/swagger-ui": "^1.9.0",
@@ -56,6 +57,7 @@
             "devDependencies": {
                 "@babel/core": "^7.22.1",
                 "@babel/preset-env": "^7.22.4",
+                "@fastify/routes": "^5.1.0",
                 "@vitejs/plugin-vue": "^4.2.3",
                 "@vitest/coverage-istanbul": "^0.33.0",
                 "@vue/test-utils": "^2.3.2",
@@ -3886,6 +3888,30 @@
             "integrity": "sha512-OVTUXyAm7Tx194RJiJrzSvM8m5O8TR0CIc9ewKDZWjQcFs+MNiVURdjpIm28l7oY2o19TV9XANutfSH/ngEd+A==",
             "dependencies": {
                 "@fastify/flash": "^5.0.0",
+                "fastify-plugin": "^4.0.0"
+            }
+        },
+        "node_modules/@fastify/rate-limit": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-8.0.3.tgz",
+            "integrity": "sha512-7wbSKXGKKLI1VkpW2XvS7SFg4n4/uzYt0YA5O2pfCcM6PYaBSV3VhSKGJ9/hJceCSH+zNEDRrWpufqxbcDkTZg==",
+            "dependencies": {
+                "fastify-plugin": "^4.0.0",
+                "ms": "^2.1.3",
+                "tiny-lru": "^11.0.0"
+            }
+        },
+        "node_modules/@fastify/rate-limit/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "node_modules/@fastify/routes": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/routes/-/routes-5.1.0.tgz",
+            "integrity": "sha512-SbQRVcLnGKXz12jVcFikFQmiBxypqrqYLlytnfsv29kXAqz/d/E1olu2wBBEZVdkbbBk+E0eu+t7ug3nMnGL/Q==",
+            "dev": true,
+            "dependencies": {
                 "fastify-plugin": "^4.0.0"
             }
         },
@@ -23512,6 +23538,32 @@
             "integrity": "sha512-OVTUXyAm7Tx194RJiJrzSvM8m5O8TR0CIc9ewKDZWjQcFs+MNiVURdjpIm28l7oY2o19TV9XANutfSH/ngEd+A==",
             "requires": {
                 "@fastify/flash": "^5.0.0",
+                "fastify-plugin": "^4.0.0"
+            }
+        },
+        "@fastify/rate-limit": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@fastify/rate-limit/-/rate-limit-8.0.3.tgz",
+            "integrity": "sha512-7wbSKXGKKLI1VkpW2XvS7SFg4n4/uzYt0YA5O2pfCcM6PYaBSV3VhSKGJ9/hJceCSH+zNEDRrWpufqxbcDkTZg==",
+            "requires": {
+                "fastify-plugin": "^4.0.0",
+                "ms": "^2.1.3",
+                "tiny-lru": "^11.0.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+                }
+            }
+        },
+        "@fastify/routes": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/routes/-/routes-5.1.0.tgz",
+            "integrity": "sha512-SbQRVcLnGKXz12jVcFikFQmiBxypqrqYLlytnfsv29kXAqz/d/E1olu2wBBEZVdkbbBk+E0eu+t7ug3nMnGL/Q==",
+            "dev": true,
+            "requires": {
                 "fastify-plugin": "^4.0.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@fastify/formbody": "^7.4.0",
         "@fastify/helmet": "^11.0.0",
         "@fastify/passport": "^2.3.0",
+        "@fastify/rate-limit": "^8.0.3",
         "@fastify/static": "^6.10.2",
         "@fastify/swagger": "^8.6.0",
         "@fastify/swagger-ui": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "devDependencies": {
         "@babel/core": "^7.22.1",
         "@babel/preset-env": "^7.22.4",
+        "@fastify/routes": "^5.1.0",
         "@vitejs/plugin-vue": "^4.2.3",
         "@vitest/coverage-istanbul": "^0.33.0",
         "@vue/test-utils": "^2.3.2",

--- a/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
+++ b/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
@@ -1,0 +1,429 @@
+const should = require('should') // eslint-disable-line
+const rateLimits = require('../../../../../../forge/routes/rateLimits.js')
+const setup = require('../../setup.js')
+
+describe('Endpoint Rate Limiting', () => {
+    describe('getLimits unit tests', () => {
+        const app = {}
+        let config = {}
+
+        it('should be disabled by default', () => {
+            config = {}
+            const result = rateLimits.getLimits(app, config)
+            result.should.be.false('getLimits should return `false` when not enabled')
+        })
+        it('should get correct default values', () => {
+            config = { enabled: true }
+            const result = rateLimits.getLimits(app, config)
+            result.should.be.an.Object() // getLimits should return an `object` when enabled
+            result.should.only.have.keys('enabled', 'global', 'timeWindow', 'max', 'keyGenerator', 'onExceeded')
+
+            result.enabled.should.be.true('enabled should be true')
+            result.global.should.be.true('global should be true')
+            result.timeWindow.should.be.equal('1 minute')
+            result.max.should.be.equal(1000)
+            result.keyGenerator.should.be.a.Function()
+            result.onExceeded.should.be.a.Function()
+        })
+        it('max should be a function when maxAnonymous is set', () => {
+            config = {
+                enabled: true,
+                global: false,
+                timeWindow: '2 minutes',
+                max: 2000,
+                maxAnonymous: 100
+            }
+            const result = rateLimits.getLimits(app, config)
+            result.should.be.an.Object()
+            result.should.only.have.keys('enabled', 'global', 'timeWindow', 'max', 'maxAnonymous', 'keyGenerator', 'onExceeded')
+
+            result.enabled.should.be.true('enabled should be true')
+            result.global.should.be.false('global should be false')
+            result.timeWindow.should.be.equal('2 minutes')
+            result.max.should.be.a.Function() // 'max should be a function when maxAnonymous is set'
+            result.keyGenerator.should.be.a.Function()
+            result.onExceeded.should.be.a.Function()
+            result.max({ sid: '123' }).should.be.equal(2000) // query max as a logged in user - gets higher `max` value
+            result.max().should.be.equal(100) // query max as an anonymous user - gets lower `maxAnonymous` value
+        })
+        it('keyGenerator should return sid if logged in, ip if not', () => {
+            config = {
+                enabled: true,
+                global: false,
+                timeWindow: '2 minutes',
+                max: 2000,
+                maxAnonymous: 100
+            }
+            const result = rateLimits.getLimits(app, config)
+            result.should.be.an.Object()
+            result.should.have.keys('keyGenerator')
+            result.keyGenerator.should.be.a.Function() // 'keyGenerator should be a function'
+
+            const reqWithoutSid = {
+                headers: {
+                    'x-real-ip': '1.1.1.1',
+                    'x-forwarded-for': '2.2.2.2'
+                },
+                ip: '3.3.3.3'
+            }
+            const reqWithSid = {
+                sid: '123',
+                headers: {
+                    'x-real-ip': '1.1.1.1',
+                    'x-forwarded-for': '2.2.2.2'
+                },
+                ip: '3.3.3.3'
+            }
+            result.keyGenerator(reqWithoutSid).should.be.equal('1.1.1.1') // query max as an anonymous user
+            result.keyGenerator(reqWithSid).should.be.equal('123') // query max as a logged in user
+        })
+        it('keyGenerator should return x-real-ip first, then x-forwarded-for, then ip', () => {
+            config = {
+                enabled: true,
+                global: false,
+                timeWindow: '2 minutes',
+                max: 2000,
+                maxAnonymous: 100
+            }
+            const result = rateLimits.getLimits(app, config)
+            result.should.be.an.Object()
+            result.should.have.keys('keyGenerator')
+
+            const req1 = {
+                ip: '3.3.3.3',
+                headers: {
+                    'x-forwarded-for': '2.2.2.2',
+                    'x-real-ip': '1.1.1.1'
+                }
+            }
+            const req2 = {
+                ip: '5.5.5.5',
+                headers: {
+                    'x-forwarded-for': '4.4.4.4'
+                }
+            }
+            const req3 = {
+                ip: '6.6.6.6',
+                headers: {}
+            }
+            result.keyGenerator(req1).should.be.equal('1.1.1.1') // x-real-ip first
+            result.keyGenerator(req2).should.be.equal('4.4.4.4') // x-forwarded-for second
+            result.keyGenerator(req3).should.be.equal('6.6.6.6') // ip is fallback
+        })
+    })
+
+    describe('Rate Limiting plugin', () => {
+        // These tests are to ensure that the no routes are using the rate limits
+        // when the rate limits are disabled
+
+        it('Plugin is not loaded when config settings are not specified (implicitly disabled)', async function () {
+            const app = await setup()
+            const isPluginLoaded = app.hasDecorator('rateLimit')
+            isPluginLoaded.should.be.false('rateLimit plugin should not be loaded')
+            app.should.not.have.property('rateLimit')
+            app.config.should.have.property('rate_limits', false) // rate_limits should be false / not an object with limits etc
+            app.close()
+        })
+        it('Plugin is not loaded when config settings explicitly disables rate limits', async function () {
+            const app = await setup({
+                rate_limits: {
+                    enabled: false
+                }
+            })
+            const isPluginLoaded = app.hasDecorator('rateLimit')
+            isPluginLoaded.should.be.false('rateLimit plugin should not be loaded')
+            app.should.not.have.property('rateLimit')
+            app.config.should.have.property('rate_limits', false) // rate_limits should be false / not an object with limits etc
+            app.close()
+        })
+        it('Plugin is loaded when config settings are enabled', async function () {
+            const app = await setup({
+                rate_limits: {
+                    enabled: true
+                    // use defaults - see getLimits unit test 'should get correct default values'
+                }
+            })
+            const isPluginLoaded = app.hasDecorator('rateLimit')
+            isPluginLoaded.should.be.true('rateLimit plugin should be loaded')
+            app.should.have.property('rateLimit').and.be.a.Function()
+            app.config.should.have.property('rate_limits').and.be.an.Object()
+            app.config.rate_limits.should.have.property('enabled', true)
+            app.config.rate_limits.should.have.property('global', true) // global should be true by default
+            app.config.rate_limits.should.have.property('timeWindow', '1 minute') // timeWindow should be "1 minute" by default
+            app.config.rate_limits.should.have.property('max', 1000) // max should be 1000 by default
+            app.close()
+        })
+    })
+
+    describe('Rate Limiting Routes', () => {
+        const ROUTES = [
+            // routes that are always rate limited
+            { url: '/account/login', method: 'POST', shouldLimit: true },
+            { url: '/account/register', method: 'POST', shouldLimit: true },
+            { url: '/account/forgot_password', method: 'POST', shouldLimit: true },
+            { url: '/account/reset_password/:token', method: 'POST', shouldLimit: true },
+            // routes that are never rate limited
+            { url: '/api/comms/auth/client', method: 'POST', shouldLimit: false },
+            { url: '/api/comms/auth/acl', method: 'POST', shouldLimit: false },
+            { url: '/account/logout', method: 'POST', shouldLimit: false },
+            { url: '/account/verify/:token', method: 'POST', shouldLimit: false },
+            { url: '/account/verify', method: 'POST', shouldLimit: false },
+            { url: '/account/authorize', method: 'GET', shouldLimit: false }, // used by oauth2, needs license
+            { url: '/account/token', method: 'POST', shouldLimit: false }, // used by oauth2, needs license
+            { url: '/api/v1/devices/:deviceId/editor', method: 'PUT', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor', method: 'GET', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/token', method: 'GET', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/comms/:access_token', method: 'GET', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/proxy/*', method: 'GET', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/proxy/*', method: 'POST', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/proxy/*', method: 'PUT', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/proxy/*', method: 'HEAD', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/proxy/*', method: 'DELETE', shouldLimit: false }, // licensed feature
+            { url: '/api/v1/devices/:deviceId/editor/proxy/*', method: 'OPTIONS', shouldLimit: false }, // licensed feature
+            // a selection of other URLs that should be rate limited when global is true, but not when global is false
+            { url: '/', method: 'GET', shouldLimit: 'global:true' },
+            { url: '/app/main.js', method: 'GET', shouldLimit: 'global:true', route: '/*' },
+            { url: '/admin/overview', method: 'GET', shouldLimit: 'global:true', route: '/*' },
+            { url: '/api/v1/teams/:teamId/members', method: 'GET', shouldLimit: 'global:true' },
+            { url: '/api/v1/applications/:applicationId', method: 'GET', shouldLimit: 'global:true' },
+            { url: '/api/v1/projects/:instanceId/logs', method: 'GET', shouldLimit: 'global:true' }
+        ]
+        ROUTES.forEach((route) => {
+            route.route = route.route || route.url
+        })
+
+        async function createDevice (app, options) {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/devices',
+                body: {
+                    name: options.name,
+                    type: options.type,
+                    team: options.team
+                },
+                cookies: { sid: options.as }
+            })
+            return response.json()
+        }
+
+        async function getSid (app, username, password) {
+            const response = await app.inject({
+                method: 'POST',
+                url: '/account/login',
+                payload: { username, password, remember: false }
+            })
+            response.cookies.should.have.length(1)
+            response.cookies[0].should.have.property('name', 'sid')
+            return response.cookies[0].value
+        }
+
+        describe('All Routes use limits except explicitly excluded (global:true)', () => {
+            // These tests are to ensure that the routes are using the rate limits
+            // this is achieved by stubbing the rateLimits.getLimits function to return a rate limit
+            // and then checking that the keyGenerator function is called
+
+            /** @type { import('forge/forge.js').ForgeApplication} */
+            let app
+            let defaultSid
+            let device1
+
+            before(async function () {
+                // This license has limit of 2 devices
+                const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTk1MjAwLCJleHAiOjc5ODcwNzUxOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjoyLCJkZXYiOnRydWUsImlhdCI6MTY2MjY1MzkyMX0.Tj4fnuDuxi_o5JYltmVi1Xj-BRn0aEjwRPa_fL2MYa9MzSwnvJEd-8bsRM38BQpChjLt-wN-2J21U7oSq2Fp5A'
+                app = await setup({
+                    license, // required to load ee only routes
+                    test: {
+                        // disableSchemaValidation: true,
+                        fastifyRoutes: true
+                    },
+                    rate_limits: {
+                        enabled: true,
+                        global: true,
+                        timeWindow: '60 seconds',
+                        max: 666
+                    },
+                    broker: {
+                        url: ':test:' // so that api/comms/auth/client and api/comms/auth/acl are loaded
+                    }
+                })
+
+                // update ROUTES array with the fastify routes, so that we can check the config
+                // This requires the test config to have `fastifyRoutes: true` which loads @fastify/routes plugin
+                // allowing us to get the fastify routes from the app.
+                ROUTES.forEach((route) => {
+                    const fastifyRoutes = app.routes.get(route.route)
+                    if (fastifyRoutes) {
+                        route.fastifyRoute = fastifyRoutes.find((r) => r.method === route.method || (Array.isArray(r.method) && r.method.includes(route.method)))
+                    }
+                    if (route.fastifyRoute) {
+                        // route specified test config was found in the app routes
+                    } else {
+                        // route not found in test config - was a route deleted or changed?
+                        console.error(`Route ${route.method} ${route.route} was specified in test config but not found in app routes`)
+                        // throw new Error(`Route ${route.method} ${route.route} was specified in test config but not found in app routes`)
+                    }
+                })
+
+                // log in alice and get her sid
+                defaultSid = await getSid(app, 'alice', 'aaPassword')
+
+                device1 = await createDevice(app, { name: 'device1', type: 'device1', team: app.team.hashid, as: defaultSid })
+                device1.should.have.property('id') // verify that the device was created
+            })
+
+            after(async function () {
+                await app.close()
+            })
+
+            // Routes that should always have limits applied whether global is true or false
+            describe('Routes that should always be limited', () => {
+                ROUTES.filter(e => e.shouldLimit === true).forEach((route) => {
+                    it(`Route ${route.method} ${route.url} should be rate limited`, async function () {
+                        const routeConfig = route.fastifyRoute.config
+                        routeConfig.should.have.property('rateLimit').and.be.an.Object()
+                        routeConfig.rateLimit.should.have.property('enabled', true)
+                        routeConfig.rateLimit.should.have.property('global', true)
+                        routeConfig.rateLimit.should.have.property('max', 666)
+                        routeConfig.rateLimit.should.have.property('timeWindow', '60 seconds')
+                        routeConfig.rateLimit.should.have.property('keyGenerator').and.be.a.Function()
+                    })
+                })
+            })
+
+            // Routes that should never have limits applied whether global is true or false
+            describe('Routes that should never be limited', () => {
+                ROUTES.filter(e => e.shouldLimit === false).forEach((route) => {
+                    it(`Route ${route.method} ${route.url} should never be rate limited`, async function () {
+                        const routeConfig = route.fastifyRoute
+                        routeConfig.should.have.property('config').and.be.an.Object()
+                        routeConfig.config.should.have.property('rateLimit').and.be.false()
+                    })
+                })
+            })
+
+            // Routes that should be limited when global is true, but not when global is false
+            describe('Routes that should be limited because the global is true', () => {
+                ROUTES.filter(e => e.shouldLimit === 'global:true').forEach((route) => {
+                    it(`Route ${route.method} ${route.url} should be rate limited`, async function () {
+                        const routeConfig = route.fastifyRoute.config
+                        if (routeConfig && Object.prototype.hasOwnProperty.call(routeConfig, 'rateLimit')) {
+                            // route has a config.rateLimit - it should be an object (not false)
+                            // meaning that the route should be rate limited
+                            routeConfig.should.have.property('rateLimit').and.be.an.Object()
+                            routeConfig.rateLimit.should.have.property('enabled', true)
+                            routeConfig.rateLimit.should.have.property('global', false)
+                            routeConfig.rateLimit.should.have.property('max', 666)
+                            routeConfig.rateLimit.should.have.property('timeWindow', '60 seconds')
+                            routeConfig.rateLimit.should.have.property('keyGenerator').and.be.a.Function()
+                        } else {
+                            // route has no config.rateLimit - it should not be rate limited
+                            // Do nothing - this is a valid test
+                        }
+                    })
+                })
+            })
+        })
+
+        describe('Only specific Routes use limits except (global:false)', () => {
+            // These tests are to ensure that the routes are using the rate limits
+            // this is achieved by stubbing the rateLimits.getLimits function to return a rate limit
+            // and then checking that the keyGenerator function is called
+
+            /** @type { import('forge/forge.js').ForgeApplication} */
+            let app
+            let defaultSid
+            let device1
+
+            before(async function () {
+                // This license has limit of 2 devices
+                const license = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIERldmVsb3BtZW50IiwibmJmIjoxNjYyNTk1MjAwLCJleHAiOjc5ODcwNzUxOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjoyLCJkZXYiOnRydWUsImlhdCI6MTY2MjY1MzkyMX0.Tj4fnuDuxi_o5JYltmVi1Xj-BRn0aEjwRPa_fL2MYa9MzSwnvJEd-8bsRM38BQpChjLt-wN-2J21U7oSq2Fp5A'
+                app = await setup({
+                    license, // required to load ee only routes
+                    test: {
+                        // disableSchemaValidation: true,
+                        fastifyRoutes: true
+                    },
+                    rate_limits: {
+                        enabled: true,
+                        global: false,
+                        timeWindow: '55 seconds',
+                        max: 555
+                    },
+                    broker: {
+                        url: ':test:' // so that api/comms/auth/client and api/comms/auth/acl are loaded
+                    }
+                })
+
+                // update ROUTES array with the fastify routes, so that we can check the config
+                // This requires the test config to have `fastifyRoutes: true` which loads @fastify/routes plugin
+                // allowing us to get the fastify routes from the app.
+                ROUTES.forEach((route) => {
+                    const fastifyRoutes = app.routes.get(route.route)
+                    if (fastifyRoutes) {
+                        route.fastifyRoute = fastifyRoutes.find((r) => r.method === route.method || (Array.isArray(r.method) && r.method.includes(route.method)))
+                    }
+                    if (route.fastifyRoute) {
+                        // route specified test config was found in the app routes
+                    } else {
+                        // route not found in test config - was a route deleted or changed?
+                        console.error(`Route ${route.method} ${route.route} was specified in test config but not found in app routes`)
+                        // throw new Error(`Route ${route.method} ${route.route} was specified in test config but not found in app routes`)
+                    }
+                })
+
+                // log in alice and get her sid
+                defaultSid = await getSid(app, 'alice', 'aaPassword')
+
+                device1 = await createDevice(app, { name: 'device1', type: 'device1', team: app.team.hashid, as: defaultSid })
+                device1.should.have.property('id') // verify that the device was created
+            })
+
+            after(async function () {
+                await app.close()
+            })
+
+            // Routes that should always have limits applied whether global is true or false
+            describe('Routes that should always be limited', () => {
+                ROUTES.filter(e => e.shouldLimit === true).forEach((route) => {
+                    it(`Route ${route.method} ${route.url} should be rate limited`, async function () {
+                        const routeConfig = route.fastifyRoute.config
+                        routeConfig.should.have.property('rateLimit').and.be.an.Object()
+                        routeConfig.rateLimit.should.have.property('enabled', true)
+                        routeConfig.rateLimit.should.have.property('global', false)
+                        routeConfig.rateLimit.should.have.property('max', 555)
+                        routeConfig.rateLimit.should.have.property('timeWindow', '55 seconds')
+                        routeConfig.rateLimit.should.have.property('keyGenerator').and.be.a.Function()
+                    })
+                })
+            })
+
+            // Routes that should never have limits applied whether global is true or false
+            describe('Routes that should never be limited', () => {
+                ROUTES.filter(e => e.shouldLimit === false).forEach((route) => {
+                    it(`Route ${route.method} ${route.url} should never be rate limited`, async function () {
+                        const routeConfig = route.fastifyRoute
+                        routeConfig.should.have.property('config').and.be.an.Object()
+                        routeConfig.config.should.have.property('rateLimit').and.be.false()
+                    })
+                })
+            })
+
+            // Routes that should be limited when global is true, but not when global is false
+            describe('Routes that should not be limited because global is false', () => {
+                ROUTES.filter(e => e.shouldLimit === 'global:true').forEach((route) => {
+                    it(`Route ${route.method} ${route.url} should not be rate limited`, async function () {
+                        const routeConfig = route.fastifyRoute.config
+                        if (routeConfig && Object.prototype.hasOwnProperty.call(routeConfig, 'rateLimit')) {
+                            // route has a config.rateLimit - it should be false
+                            // meaning that the route should not be rate limited
+                            routeConfig.should.have.property('rateLimit', false)
+                        } else {
+                            // route has no config.rateLimit - it should be rate limited because global is false
+                            // Do nothing - this is a valid test
+                        }
+                    })
+                })
+            })
+        })
+    })
+})

--- a/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
+++ b/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js
@@ -324,7 +324,7 @@ describe('Endpoint Rate Limiting', () => {
             })
         })
 
-        describe('Only specific Routes use limits except (global:false)', () => {
+        describe('Only specific Routes use limits (global:false)', () => {
             // These tests are to ensure that the routes are using the rate limits
             // this is achieved by stubbing the rateLimits.getLimits function to return a rate limit
             // and then checking that the keyGenerator function is called


### PR DESCRIPTION
## Description

Implements the rate-limiting part of [sec #18](https://github.com/flowforge/security/issues/18)

### Commits: 
* add rateLimits.js and required plugin
* setup routes for inclusion/exclusion of limiting
* login and account create pages handle 429 errors
* add tests and required fastify-routes plugin
* add default config to ff yaml file
* update docs for rate-limiting
* sync package lock
* add upgrade section with link to new docs

**_This PR is probably best reviewed by commit as they were made in logical order_**


### Implementation detail
1. Adds `/forge/routes/rateLimits.js`
    * This has one function: `getLimits` which returns the rate limit settings. It is directly exported for unit testing.
2. `/config/index.js`
    * Adds `rate_limits` to `config` with default values by calling to `rateLimits.getLimits(...)`
3. `/forge/forge.js`
    * Registers `@fastify/rate-limit` plugin - **but only if `config.rate_limits.enabled` is `true`**
4. Any routes that should be rate limited have `config: { rate_limits: app.config.rate_limits }` added to their route options.
5. Any routes that should not be rate limited have `config: { rate_limits: false }` added to their route options.


### Endpoint Rate Limiting

Rate limiting will be disabled by default.  

To enable rate limiting, set the config setting `rate_limits.enabled` to `true`.

#### When enabled, the following config settings are available:
* `rate_limits.global` - (boolean, default: `true`) - enable/disable rate limiting for all routes
* `rate_limits.timeWindow` - (number, default: `"1 minute"`) - time window in milliseconds for `rate_limits.max` requests
* `rate_limits.max` - (number, default: `1000`) - max number of requests per `rate_limits.timeWindow` for a given route
* `rate_limits.maxAnonymous` - (number, default: _not set_) - max number of requests per `rate_limits.timeWindow` for a given route for anonymous users
* _Additional settings are possible - see [@fastify/rate-limit#options](https://github.com/fastify/fastify-rate-limit#options) for more details._

#### Specific routes
##### The following routes will be rate limited by default:
* POST /account/login
* POST /account/register
* POST /account/forgot_password
* POST /account/reset_password/:token

##### The following routes will never be rate limited:
* POST /api/comms/auth/client
* POST /api/comms/auth/acl
* POST /account/logout
* POST /account/verify/:token
* POST /account/verify
* GET /account/authorize
* POST /account/token
* PUT /api/v1/devices/:deviceId/editor
* GET /api/v1/devices/:deviceId/editor
* GET /api/v1/devices/:deviceId/editor/token
* GET /api/v1/devices/:deviceId/editor/comms/:access_token
* GET /api/v1/devices/:deviceId/editor/proxy/*
* POST /api/v1/devices/:deviceId/editor/proxy/*
* PUT /api/v1/devices/:deviceId/editor/proxy/*
* HEAD /api/v1/devices/:deviceId/editor/proxy/*
* DELETE /api/v1/devices/:deviceId/editor/proxy/*
* OPTIONS /api/v1/devices/:deviceId/editor/proxy/*

##### When config setting `rate_limits.global` is `true`.
* Everything not explicitly excluded will be rate limited.

##### When config setting `rate_limits.global` is `true`.
* Nothing else will be rate limited

### package.json changes
* Adds the following to package.json
    * dependencies
        * @fastify/rate-limit
    * devDependencies
        * @fastify/routes

#### Important notes

* In order to get access the fastify routes, the plugin @fastify/routes added to the dev dependencies.
    * It is only loaded when the setting `options.config.test?.fastifyRoutes` is `true`.
    * NOTE: access to app.routes is very useful - may want to consider loading the routes plugin by default.


### Adds tests in `/test/unit/forge/routes/api/rateLimits/rateLimits_spec.js`

NOTE: There are 3 sections of tests under " Rate Limiting Routes" for `global:true` and `global:false`:
1. routes that are explicitly enabled (and should always have limiting regardless of `global` setting)
2. routes that are explicitly disabled (and should never be limited regardless of `global` setting)
3. a random selection of endpoints that should be enabled by `global:true`, otherwise disabled.

#### Test results (local execution)
```
Endpoint Rate Limiting
    getLimits unit tests
      ✔ should be disabled by default
      ✔ should get correct default values
      ✔ max should be a function when maxAnonymous is set
      ✔ keyGenerator should return sid if logged in, ip if not
      ✔ keyGenerator should return x-real-ip first, then x-forwarded-for, then ip
    Rate Limiting plugin
      ✔ Plugin is not loaded when config settings are not specified (implicitly disabled) (1038ms)
      ✔ Plugin is not loaded when config settings explicitly disables rate limits (693ms)
      ✔ Plugin is loaded when config settings are enabled (724ms)
    Rate Limiting Routes
      All Routes use limits except explicitly excluded (global:true)
        Routes that should always be limited
          ✔ Route POST /account/login should be rate limited
          ✔ Route POST /account/register should be rate limited
          ✔ Route POST /account/forgot_password should be rate limited
          ✔ Route POST /account/reset_password/:token should be rate limited
        Routes that should never be limited
          ✔ Route POST /api/comms/auth/client should never be rate limited
          ✔ Route POST /api/comms/auth/acl should never be rate limited
          ✔ Route POST /account/logout should never be rate limited
          ✔ Route POST /account/verify/:token should never be rate limited
          ✔ Route POST /account/verify should never be rate limited
          ✔ Route GET /account/authorize should never be rate limited
          ✔ Route POST /account/token should never be rate limited
          ✔ Route PUT /api/v1/devices/:deviceId/editor should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor/token should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor/comms/:access_token should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route POST /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route PUT /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route HEAD /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route DELETE /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route OPTIONS /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
        Routes that should be limited because the global is true
          ✔ Route GET / should be rate limited
          ✔ Route GET /app/main.js should be rate limited
          ✔ Route GET /admin/overview should be rate limited
          ✔ Route GET /api/v1/teams/:teamId/members should be rate limited
          ✔ Route GET /api/v1/applications/:applicationId should be rate limited
          ✔ Route GET /api/v1/projects/:instanceId/logs should be rate limited
      Only specific Routes use limits (global:false)
        Routes that should always be limited
          ✔ Route POST /account/login should be rate limited
          ✔ Route POST /account/register should be rate limited
          ✔ Route POST /account/forgot_password should be rate limited
          ✔ Route POST /account/reset_password/:token should be rate limited
        Routes that should never be limited
          ✔ Route POST /api/comms/auth/client should never be rate limited
          ✔ Route POST /api/comms/auth/acl should never be rate limited
          ✔ Route POST /account/logout should never be rate limited
          ✔ Route POST /account/verify/:token should never be rate limited
          ✔ Route POST /account/verify should never be rate limited
          ✔ Route GET /account/authorize should never be rate limited
          ✔ Route POST /account/token should never be rate limited
          ✔ Route PUT /api/v1/devices/:deviceId/editor should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor/token should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor/comms/:access_token should never be rate limited
          ✔ Route GET /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route POST /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route PUT /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route HEAD /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route DELETE /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
          ✔ Route OPTIONS /api/v1/devices/:deviceId/editor/proxy/* should never be rate limited
        Routes that should not be limited because global is false
          ✔ Route GET / should not be rate limited
          ✔ Route GET /app/main.js should not be rate limited
          ✔ Route GET /admin/overview should not be rate limited
          ✔ Route GET /api/v1/teams/:teamId/members should not be rate limited
          ✔ Route GET /api/v1/applications/:applicationId should not be rate limited
          ✔ Route GET /api/v1/projects/:instanceId/logs should not be rate limited
```

## Related Issue(s)

https://github.com/flowforge/security/issues/18

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [x] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

