### PR TITLE
Copy InstanceType billing into default starter team type configuration

### DIFF
--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   runner-job:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     services:
       postgres:
         image: postgres:14

--- a/forge/db/controllers/TeamType.js
+++ b/forge/db/controllers/TeamType.js
@@ -18,6 +18,18 @@ module.exports = {
                     properties.instances[instanceType.hashid] = {
                         active: true
                     }
+                    if (app.billing) {
+                        // Copy over any instance type billing info
+                        if (instanceType.properties?.billingDescription) {
+                            properties.instances[instanceType.hashid].description = instanceType.properties?.billingDescription
+                        }
+                        if (instanceType.properties?.billingPriceId) {
+                            properties.instances[instanceType.hashid].priceId = instanceType.properties?.billingPriceId
+                        }
+                        if (instanceType.properties?.billingProductId) {
+                            properties.instances[instanceType.hashid].productId = instanceType.properties?.billingProductId
+                        }
+                    }
                 })
 
                 if (app.settings.get('user:team:trial-mode')) {

--- a/forge/db/controllers/TeamType.js
+++ b/forge/db/controllers/TeamType.js
@@ -64,7 +64,7 @@ module.exports = {
                     // additional configuration before going live.
                     const starterProperties = {
                         users: { limit: 2 },
-                        devices: { limit: 2 },
+                        devices: { limit: 2, free: 2 },
                         features: { },
                         instances: { }
                     }

--- a/frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue
+++ b/frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue
@@ -14,18 +14,7 @@
                 </FormRow>
                 <template v-if="features.billing">
                     <FormHeading>Billing</FormHeading>
-                    <FormRow v-model="input.properties.billingProductId" :type="editDisabled?'uneditable':''">
-                        Stripe Product Id
-                    </FormRow>
-                    <FormRow v-model="input.properties.billingPriceId" :type="editDisabled?'uneditable':''">
-                        Stripe Price Id
-                    </FormRow>
-                    <FormRow v-model="input.properties.billingDescription" :type="editDisabled?'uneditable':''">
-                        Pricing description
-                        <template #description>
-                            How should the pricing be displayed to the user? eg '$10/month'
-                        </template>
-                    </FormRow>
+                    <p>Billing configuration for the Instance Types must be set within the Team Type configuration</p>
                 </template>
                 <FormRow v-model="input.order">Order
                     <template #description>Set the sort order when listing the types</template>


### PR DESCRIPTION
## Description

When creating the default starter team type, we need to ensure any existing instance type billing information is copied across. This ensures the billing information is correctly displayed.

This also hides the UI for setting the instance type billing information against the individual instance types - that has to be done at the team type level now.