### PR TITLE
Clarify instructions when presented with device.yml

### DIFF
--- a/docs/device-agent/register.md
+++ b/docs/device-agent/register.md
@@ -7,12 +7,12 @@ navOrder: 3
 
 To connect a device to FlowForge, it needs a set of credentials. 
 
-There are two types of credentials to choose from:
+There are two types of configurations to choose from:
 
-* **Device Credentials**: for connecting a single device to the platform
-* **Provisioning Credentials**: for setting up one or more devices to automatically register themselves on the platform
+* **Device Configuration**: for connecting a single device to the platform
+* **Provisioning Configuration**: for setting up one or more devices to automatically register themselves on the platform
 
-### Generating "Device Credentials" 
+### Generating "Device Configuration" 
 _for a single device_
 
 1. Go to your teams's **Devices** page.
@@ -21,7 +21,7 @@ _for a single device_
    The type field can be used to record additional meta information about the device.
 4. Click **Register**
 
-Once the device has been registered, you will be shown the **Device Credentials** 
+Once the device has been registered, you will be shown the **Device Configuration** 
 dialog. This is the only time the platform will show you this information without
 resetting it. Make sure to take a copy or use the **Download** button to save
 the configuration file locally.
@@ -29,7 +29,7 @@ the configuration file locally.
 Repeat these steps for each device you want to connect to the platform.
 
 
-### Generating "Provisioning Credentials" 
+### Generating "Provisioning Configuration" 
 _for automatic registration of one or more devices_
 
 1. Go to your teams's **Settings** page.
@@ -39,27 +39,27 @@ _for automatic registration of one or more devices_
 4. Click **Create**
 
 Once the Provisioning Token has been created, you will be shown the 
-**Device Provisioning Credentials** dialog. This is the only time the 
+**Device Provisioning Configuration** dialog. This is the only time the 
 platform will show you this information. 
 Make sure to take a copy or use the **Download** button to save
 the configuration file locally.
 
 ## Connect the device
 
-### Install the credentials
+### Install the configuration
 
 Before you can connect a device to the platform, the device must have
-a **Device Credentials** file or a **Device Provisioning Credentials** 
+a **Device Configuration** file or a **Device Provisioning Configuration** 
 file present in its working directory. There are two ways to do this:
-1. Copy the credentials file into the device's 
+1. Copy the configuration file into the device's 
 [Working Directory](./install.md#working-directory).
-2. Download the credentials file to the device using its built in Web UI.
+2. Download the configuration file to the device using its built in Web UI.
 NOTE: The Device Agent must be running and the command line flag for the Web UI must be enabled.
 See [Command Line Options](./running.md#device-agent-command-line-options) for more information.
 
 ### Copy method
 
-Place the **Device Credentials** or **Device Provisioning Credentials** file on the device
+Place the **Device Configuration** or **Device Provisioning Configuration** file on the device
 in the [Working Directory](./install.md#working-directory)
 
 The agent can then be started with the command: [^global-install]
@@ -74,17 +74,17 @@ to the platform to check what it should be running.
 ### Download method
 
 If the Device Agent is running with the Web UI enabled, you can download the
-credentials file to the device using the Web UI. This is useful if you don't
-have direct access to the device's file system. Once the credentials file is
-downloaded, the device agent will automatically restart and load the credentials.
+configuration file to the device using the Web UI. This is useful if you don't
+have direct access to the device's file system. Once the configuration file is
+downloaded, the device agent will automatically restart and load the configuration.
 
 #### Additional Information
 
-If you copy or download a **Device Provisioning Credentials** file to the device,
+If you copy or download a **Device Provisioning Configuration** file to the device,
 you will see the device start and perform a 'call-home' where it connects back
 to the platform to auto register itself in the team devices.  If successful,
-the real **Device Credentials** are generated and downloaded to the device. 
-The original **Provisioning Credentials** will be overwritten meaning subsequent 
+the real **Device Configuration** is generated and downloaded to the device. 
+The original **Provisioning Configuration** will be overwritten meaning subsequent 
 runs will not need to perform the auto registration again.
 
 ## Assign the device to a Node-RED instance
@@ -108,20 +108,20 @@ To remove the device from a Node-RED instance:
 The device will stop running the current Node-RED flows. It will then wait
 until it is assigned to another instance.
 
-## Regenerating credentials
+## Regenerating Configurations
 
-To regenerate device credentials:
+To regenerate device configurations:
 
 1. Go to your team's or instance's **Devices** page.
 2. Open the dropdown menu to the right of the device and select the
-   **Regenerate credentials** option.
-3. You will need to confirm this action as the existing credentials will be
-   immediately revoked. If the device tries to use the old credentials it will
+   **Regenerate Configuration** option.
+3. You will need to confirm this action as the existing configuration will be
+   immediately revoked. If the device tries to use the old configuration it will
    fail to connect and will delete its local copy of the snapshot it was
-   running. Click **Regenerate credentials** to continue.
+   running. Click **Regenerate Configuration** to continue.
 
-You will then be shown the **Device Credentials** dialog again with a new set of
-credentials to copy or download.
+You will then be shown the **Device Configuration** dialog again with a new
+configuration to copy or download.
 
 ## Deleting a device
 

--- a/docs/device-agent/register.md
+++ b/docs/device-agent/register.md
@@ -62,6 +62,8 @@ See [Command Line Options](./running.md#device-agent-command-line-options) for m
 Place the **Device Configuration** or **Device Provisioning Configuration** file on the device
 in the [Working Directory](./install.md#working-directory)
 
+By default, the device agent expects the configuration file to be named `device.yml`, if not, you will need to start the device agent with the `-c` [Command Line Option](./running.md#device-agent-command-line-options) and specify the path of the configuration file.
+
 The agent can then be started with the command: [^global-install]
 
 ```bash

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -77,7 +77,7 @@
                     />
                     <ff-list-item
                         kind="danger"
-                        label="Regenerate Credentials"
+                        label="Regenerate Configuration"
                         @click="deviceAction('updateCredentials', row.id)"
                     />
                     <ff-list-item

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -14,7 +14,7 @@
                 <template v-if="hasCredentials">
                     <p>
                         To connect your device to the platform, use the following
-                        configuration. This <code>device.yml</code> file will need to be moved to your device.
+                        configuration. This will need to be placed on your device.
                     </p>
                     <p class="mt-3 mb-3">
                         See the

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -24,7 +24,7 @@
                         >Connect Your Device</a> documentation for more information.
                     </p>
                     <p class="font-bold mt-3 mb-6">
-                        Make a note of this configuration, as this is the only time you will see them.
+                        Make a note of this configuration, as this is the only time you will see it.
                     </p>
                     <pre class="overflow-auto text-sm p-4 mt-6 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
                 </template>

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -14,11 +14,17 @@
                 <template v-if="hasCredentials">
                     <p>
                         To connect your device to the platform, use the following
-                        credentials.
+                        credentials. This <code>device.yml</code> file will need to be moved to your device.
+                    </p>
+                    <p class="mt-3 mb-3">
+                        See the
+                        <a
+                            href="https://flowforge.com/docs/device-agent/register/#connect-the-device" target="_blank"
+                            rel="noreferrer"
+                        >Connect Your Device</a> documentation for more information.
                     </p>
                     <p class="font-bold mt-3 mb-6">
-                        Make a note of them as this is the only
-                        time you will see them.
+                        Make a note of these credentials, as this is the only time you will see them.
                     </p>
                     <pre class="overflow-auto text-sm p-4 mt-6 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
                 </template>

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -1,20 +1,20 @@
 <template>
-    <ff-dialog ref="dialog" header="Device Credentials">
+    <ff-dialog ref="dialog" header="Device Configuration">
         <template v-slot:default>
             <form class="text-gray-800">
                 <template v-if="!hasCredentials">
                     <p>
-                        Are you sure you want to regenerate credentials for this device?
+                        Are you sure you want to regenerate configuration for this device?
                     </p>
                     <p class="mt-3 mb-6">
-                        The existing credentials will be reset and the device will not
-                        be able to reconnect until it has been given its new credentials.
+                        The existing configuration will be reset and the device will not
+                        be able to reconnect until it has been given its new configuration.
                     </p>
                 </template>
                 <template v-if="hasCredentials">
                     <p>
                         To connect your device to the platform, use the following
-                        credentials. This <code>device.yml</code> file will need to be moved to your device.
+                        configuration. This <code>device.yml</code> file will need to be moved to your device.
                     </p>
                     <p class="mt-3 mb-3">
                         See the
@@ -24,7 +24,7 @@
                         >Connect Your Device</a> documentation for more information.
                     </p>
                     <p class="font-bold mt-3 mb-6">
-                        Make a note of these credentials, as this is the only time you will see them.
+                        Make a note of this configuration, as this is the only time you will see them.
                     </p>
                     <pre class="overflow-auto text-sm p-4 mt-6 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
                 </template>
@@ -33,7 +33,7 @@
         <template v-slot:actions>
             <template v-if="!hasCredentials">
                 <ff-button kind="secondary" @click="close()">Cancel</ff-button>
-                <ff-button kind="danger" class="ml-4" @click="regenerateCredentials()">Regenerate credentials</ff-button>
+                <ff-button kind="danger" class="ml-4" @click="regenerateCredentials()">Regenerate configuration</ff-button>
             </template>
             <template v-else>
                 <ff-button v-if="clipboardSupported" kind="secondary" @click="copy()">Copy to Clipboard</ff-button>

--- a/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
@@ -1,13 +1,13 @@
 <template>
-    <ff-dialog ref="dialog" header="Device Provisioning Credentials">
+    <ff-dialog ref="dialog" header="Device Provisioning Configuration">
         <template v-slot:default>
             <form class="space-y-6 mt-2">
                 <p class="text-sm text-gray-500">
                     To auto provision your devices on the platform, use the following
-                    credentials. Make a note of them as this is the only
+                    configuration. Make a note of them as this is the only
                     time you will see them.
                 </p>
-                <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ credentials }}</pre>
+                <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ configuration }}</pre>
             </form>
         </template>
         <template v-slot:actions>

--- a/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
@@ -4,7 +4,7 @@
             <form class="space-y-6 mt-2">
                 <p class="text-sm text-gray-500">
                     To auto provision your devices on the platform, use the following
-                    configuration. Make a note of them as this is the only
+                    configuration. Make a note of it as this is the only
                     time you will see it.
                 </p>
                 <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ configuration }}</pre>

--- a/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
@@ -5,7 +5,7 @@
                 <p class="text-sm text-gray-500">
                     To auto provision your devices on the platform, use the following
                     configuration. Make a note of them as this is the only
-                    time you will see them.
+                    time you will see it.
                 </p>
                 <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ configuration }}</pre>
             </form>

--- a/test/e2e/frontend/cypress/tests/devices.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices.spec.js
@@ -40,9 +40,9 @@ describe('FlowForge - Devices', () => {
 
             cy.wait('@registerDevice')
 
-            // show user the device credentials
+            // show user the device config
             cy.get('.ff-dialog-box').should('be.visible')
-            cy.get('.ff-dialog-header').contains('Device Credentials')
+            cy.get('.ff-dialog-header').contains('Device Configuration')
 
             cy.get('[data-el="devices-browser"] tbody').find('tr').should('have.length', 1)
             cy.get('[data-el="devices-browser"] tbody').find('tr').contains('device1')


### PR DESCRIPTION
## Description

Adds clarity, and links to documentation when a user is presented with the `device.yml`

<img width="589" alt="Screenshot 2023-07-27 at 10 31 31" src="https://github.com/flowforge/flowforge/assets/99246719/1626fa3f-d403-4639-8f1a-986b0c7c5cfd">

## Related Issue(s)

Closes #2430 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Documentation has been updated