### PR TITLE
Show tooltip on hover in device bar, and truncate text when not enough space

### DIFF
--- a/frontend/src/components/charts/DeviceStatusBar.vue
+++ b/frontend/src/components/charts/DeviceStatusBar.vue
@@ -15,13 +15,15 @@
         </div>
         <div v-if="visible" class="ff-chart-device-status">
             <div
-                v-for="(bucket, b) in buckets" :key="b"
+                v-for="(bucket, b) in buckets"
+                :key="b" v-ff-tooltip:top="bucket.label"
+                class="capitalize"
                 :class="'ff-chart-bar ff-chart-bar--' + b + ' ' + (((filter?.property === property) && (filter?.bucket && filter?.bucket !== b)) ? 'ghost' : '')"
                 :style="{width: 100 * (bucket.devices.length/devices.length) + '%'}"
                 @click="selected(b, bucket.devices)"
             >
                 <div>{{ bucket.devices.length }}</div>
-                <label>{{ bucket.label }}</label>
+                <label class="truncate overflow-ellipsis">{{ bucket.label }}</label>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

- Adds tooltip to the bar. 
    - Positioning on `top`, instead of `bottom` as originally planned. This is because it made sense to show tooltip when hovering on the bar _or_ the label, but `bottom` positioning it at the bottom of the label, which left white space. `top` binds it to the bar.
- Truncates the label (and adds ellipsis) when there isn't enough space to render the label.

<img width="587" alt="Screenshot 2023-07-27 at 10 41 03" src="https://github.com/flowforge/flowforge/assets/99246719/70bb0828-cc7d-41d7-9e3e-73ee1e04935e">

## Related Issue(s)

Closes #2380 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

