### PR TITLE
Change redirect post application creation to /instance

### DIFF
--- a/frontend/src/pages/team/createApplication.vue
+++ b/frontend/src/pages/team/createApplication.vue
@@ -120,9 +120,11 @@ export default {
             }
 
             try {
-                await this.createProject(projectFields, copyParts)
+                const instance = await this.createProject(projectFields, copyParts)
 
                 await this.$store.dispatch('account/refreshTeam')
+
+                this.$router.push({ name: 'Instance', params: { id: instance.id } })
             } catch (err) {
                 this.projectDetails = projectFields
                 if (err.response?.status === 409) {
@@ -135,10 +137,7 @@ export default {
                 }
 
                 this.loading = false
-                return
             }
-
-            this.$router.push({ name: 'Application', params: { id: this.application.id } })
         },
         createApplication (applicationDetails) {
             const createPayload = { ...applicationDetails, teamId: this.team.id }

--- a/test/e2e/frontend/cypress/tests-ee/trials.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/trials.spec.js
@@ -12,7 +12,7 @@ describe('FlowForge - Trial Users', () => {
         cy.get('[data-el="empty-state"] [data-action="create-application"]').click()
     })
 
-    it('are redirected to their (first) newly created application', () => {
+    it('are redirected to their (first) newly created instance', () => {
         const APPLICATION_NAME = `new-application-${Math.random().toString(36).substring(2, 7)}`
         const INSTANCE_NAME = `new-instance-${Math.random().toString(36).substring(2, 7)}`
 
@@ -37,7 +37,7 @@ describe('FlowForge - Trial Users', () => {
 
         cy.get('[data-action="create-project"]').should('not.be.disabled').click()
 
-        cy.url().should('include', '/instances')
+        cy.url().should('include', '/instance/')
     })
 
     it('cannot create a second instance', () => {

--- a/test/e2e/frontend/cypress/tests/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests/applications.spec.js
@@ -55,6 +55,8 @@ describe('FlowForge - Applications', () => {
 
                 cy.contains(APPLICATION_NAME)
                 cy.contains(INSTANCE_NAME)
+
+                cy.url().should('include', '/instance/')
             })
         })
 


### PR DESCRIPTION
## Description

After creating an Application & Instance, redirect to the Instance, rather than the Application. This removes one step in the onboarding UX.

## Related Issue(s)

Closes #2495 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->