### PR TITLE
Adds differentiation in messaging between debit/credit amounts

### DIFF
--- a/frontend/src/pages/instance/components/InstanceChargesTable.vue
+++ b/frontend/src/pages/instance/components/InstanceChargesTable.vue
@@ -34,8 +34,11 @@
                 <div v-else />
             </template>
             <template v-if="subscription?.customer?.balance">
-                <div data-el="credit-balance-row">
+                <div v-if="subscription.customer.balance < 0" data-el="credit-balance-row">
                     Credit Balance
+                </div>
+                <div v-else data-el="credit-balance-row">
+                    Debit Balance
                 </div>
                 <div
                     data-el="credit-balance-amount"
@@ -43,7 +46,6 @@
                 >
                     {{ formatCurrency(subscription?.customer?.balance) }}
                 </div>
-                <div />
             </template>
         </div>
     </div>

--- a/frontend/src/pages/instance/components/InstanceCreditBanner.vue
+++ b/frontend/src/pages/instance/components/InstanceCreditBanner.vue
@@ -1,10 +1,19 @@
 <template>
     <div
-        v-if="subscription?.customer?.balance"
+        v-if="subscription?.customer?.balance && subscription?.customer?.balance < 0"
         class="w-full text-sm text-blue-600 italic"
         data-el="credit-balance-banner"
     >
-        You have a credit balance of {{ formatCurrency(Math.abs(subscription.customer.balance)) }} that will be applied to this instance
+        <!-- Stripe gives credit as a -ve number -->
+        You have a credit balance of {{ formatCurrency(-1 * subscription.customer.balance) }} that will be applied to this instance
+    </div>
+    <div
+        v-else
+        class="w-full text-sm text-blue-600 italic"
+        data-el="credit-balance-banner"
+    >
+        <!-- Stripe gives credit as a -ve number -->
+        You owe {{ formatCurrency(subscription.customer.balance) }} that will be applied to this instance
     </div>
 </template>
 

--- a/test/e2e/frontend/cypress/tests-ee/applications/applications.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/applications.spec.js
@@ -58,6 +58,7 @@ describe('FlowForge - Applications - With Billing', () => {
 
             cy.get('[data-el="charges-table"]').should('exist')
 
+            cy.get('[data-el="credit-balance-banner"]').should('exist').contains('credit')
             cy.get('[data-el="credit-balance-banner"]').should('exist').contains('$10.01')
 
             cy.get('[data-el="selected-instance-type-name"]').contains('type1')
@@ -68,6 +69,43 @@ describe('FlowForge - Applications - With Billing', () => {
             cy.get('[data-el="credit-balance-amount"]').contains('$10.01')
 
             cy.get('[data-el="payable-now-summary"]').contains('$4.99')
+
+            cy.get('[data-action="create-project"]').should('not.be.disabled').click()
+        })
+    })
+
+    it('considers any debit balance the team may have when creating a project', () => {
+        cy.applyBillingCreditToTeam(-1001)
+        cy.login('alice', 'aaPassword')
+        cy.home()
+
+        cy.request('GET', 'api/v1/teams').then((response) => {
+            const team = response.body.teams[0]
+
+            cy.visit(`/team/${team.slug}/applications/create`)
+
+            cy.wait('@getTeamBySlug')
+            cy.wait('@getTeamBilling')
+
+            cy.get('[data-el="charges-table"]').should('not.exist')
+
+            cy.get('[data-form="application-name"] input').clear()
+            cy.get('[data-form="application-name"] input').type(`new-application-${Math.random().toString(36).substring(2, 7)}`)
+            cy.contains('type1').click()
+
+            cy.get('[data-el="charges-table"]').should('exist')
+
+            cy.get('[data-el="credit-balance-banner"]').should('exist').contains('owe')
+            cy.get('[data-el="credit-balance-banner"]').should('exist').contains('$10.01')
+
+            cy.get('[data-el="selected-instance-type-name"]').contains('type1')
+            cy.get('[data-el="selected-instance-type-cost"]').contains('$15.00')
+            cy.get('[data-el="selected-instance-type-interval"]').contains('/mo')
+
+            cy.get('[data-el="credit-balance-row"]').should('exist')
+            cy.get('[data-el="credit-balance-amount"]').contains('$10.01')
+
+            cy.get('[data-el="payable-now-summary"]').contains('$25.01')
 
             cy.get('[data-action="create-project"]').should('not.be.disabled').click()
         })


### PR DESCRIPTION
## Description

Update messaging to be a function of whether Stripe credit is +ve/-ve.

When in credit:

<img width="647" alt="Screenshot 2023-07-27 at 13 55 34" src="https://github.com/flowforge/flowforge/assets/99246719/ba809940-4144-4a78-814b-d79873b66c76">

When in debit:

<img width="692" alt="Screenshot 2023-07-27 at 13 55 02" src="https://github.com/flowforge/flowforge/assets/99246719/c6dcd879-8c8e-4edd-9aed-8b62d0a9fd9c">

## Related Issue(s)

Closes #2416 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->

