### PR TITLE
Cleaner layout for Instance overview

### DIFF
--- a/frontend/src/pages/instance/Overview.vue
+++ b/frontend/src/pages/instance/Overview.vue
@@ -1,82 +1,90 @@
 <template>
     <div class="ff-project-overview space-y-4">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div class="border rounded p-4">
-                <FormHeading><TemplateIcon class="w-6 h-6 mr-2 inline text-gray-400" />Overview</FormHeading>
+            <div>
+                <div class="ff-instance-info">
+                    <FormHeading><TemplateIcon />Info</FormHeading>
 
-                <table class="table-fixed w-full">
-                    <tr class="border-b">
-                        <td class="w-1/4 font-medium">Editor</td>
-                        <td>
-                            <div v-if="editorAvailable">
-                                <div v-if="isVisitingAdmin || instance.settings.disableEditor" class="my-2">
-                                    {{ instance.url }}
+                    <table class="table-fixed w-full border border-separate rounded">
+                        <tr class="border-b">
+                            <td class="w-40 font-medium">Editor</td>
+                            <td>
+                                <div v-if="editorAvailable">
+                                    <div v-if="isVisitingAdmin || instance.settings.disableEditor" class="my-2">
+                                        {{ instance.url }}
+                                    </div>
+                                    <a v-else :href="instance.url" target="_blank" class="ff-link flex" data-el="editor-link">
+                                        <span class="ml-r">{{ instance.url }}</span>
+                                        <ExternalLinkIcon class="w-4 ml-3" />
+                                    </a>
                                 </div>
-                                <a v-else :href="instance.url" target="_blank" class="forge-button-secondary py-1 mb-1" data-el="editor-link">
-                                    <span class="ml-r">{{ instance.url }}</span>
-                                    <ExternalLinkIcon class="w-4 ml-3" />
-                                </a>
-                            </div>
-                            <div v-else class="my-2">
-                                <router-link v-if="isHA" :to="{name: 'InstanceSettingsHA', params: { id: instance.id }}" @click.stop>
-                                    <StatusBadge class="text-gray-400 hover:text-blue-600" status="high-availability" />
-                                </router-link>
-                                <template v-else>
-                                    Unavailable
+                                <div v-else class="my-2">
+                                    <router-link v-if="isHA" :to="{name: 'InstanceSettingsHA', params: { id: instance.id }}" @click.stop>
+                                        <StatusBadge class="text-gray-400 hover:text-blue-600" status="high-availability" />
+                                    </router-link>
+                                    <template v-else>
+                                        Unavailable
+                                    </template>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr class="border-b">
+                            <td class="font-medium">Status</td>
+                            <td class="py-2">
+                                <InstanceStatusBadge :status="instance.meta.state" :pendingStateChange="instance.pendingStateChange" :optimisticStateChange="instance.optimisticStateChange" />
+                            </td>
+                        </tr>
+                        <tr class="border-b">
+                            <td class="font-medium">Last Updated</td>
+                            <td class="py-2">
+                                <template v-if="instance.flowLastUpdatedSince">
+                                    {{ instance.flowLastUpdatedSince }}
                                 </template>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr class="border-b">
-                        <td class="font-medium">Status</td>
-                        <td class="py-2">
-                            <InstanceStatusBadge :status="instance.meta.state" :pendingStateChange="instance.pendingStateChange" :optimisticStateChange="instance.optimisticStateChange" />
-                        </td>
-                    </tr>
-                    <tr class="border-b">
-                        <td class="font-medium">Last Updated</td>
-                        <td class="py-2">
-                            <template v-if="instance.flowLastUpdatedSince">
-                                {{ instance.flowLastUpdatedSince }}
-                            </template>
-                            <span v-else class="text-gray-400 italic">
-                                flows never deployed
-                            </span>
-                        </td>
-                    </tr>
-                    <tr class="border-b">
-                        <td class="font-medium">Type</td>
-                        <td class="flex items-center">
-                            <div class="py-2 flex-grow">{{ instance.projectType?.name || 'none' }} / {{ instance.stack?.label || instance.stack?.name || 'none' }}</div>
-                            <div v-if="instance.stack?.replacedBy">
-                                <ff-button size="small" to="./settings/general">Update</ff-button>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr v-if="instance.template?.name" class="border-b">
-                        <td class="font-medium">Template</td>
-                        <td><div class="py-2">{{ instance.template?.name }}</div></td>
-                    </tr>
-                    <template v-if="instance.meta?.versions">
-                        <tr class="border-b">
-                            <td class="font-medium">Node-RED Version</td>
-                            <td><div class="py-2">{{ instance.meta.versions['node-red'] }}</div></td>
+                                <span v-else class="text-gray-400 italic">
+                                    flows never deployed
+                                </span>
+                            </td>
                         </tr>
+                    </table>
+                </div>
+                <div class="ff-instance-info">
+                    <FormHeading><ServerIcon />Specs</FormHeading>
+
+                    <table class="table-fixed w-full">
                         <tr class="border-b">
-                            <td class="font-medium">Launcher Version</td>
-                            <td><div class="py-2">{{ instance.meta.versions.launcher }}</div></td>
+                            <td class="w-48 font-medium">Type</td>
+                            <td class="flex items-center">
+                                <div class="py-2 flex-grow">{{ instance.projectType?.name || 'none' }} / {{ instance.stack?.label || instance.stack?.name || 'none' }}</div>
+                                <div v-if="instance.stack?.replacedBy">
+                                    <ff-button size="small" to="./settings/general">Update</ff-button>
+                                </div>
+                            </td>
                         </tr>
-                        <tr class="border-b">
-                            <td class="font-medium">Node.js Version</td>
-                            <td><div class="py-2">{{ instance.meta.versions.node }}</div></td>
+                        <tr v-if="instance.template?.name" class="border-b">
+                            <td class="font-medium">Template</td>
+                            <td><div class="py-2">{{ instance.template?.name }}</div></td>
                         </tr>
-                    </template>
-                </table>
+                        <template v-if="instance.meta?.versions">
+                            <tr class="border-b">
+                                <td class="font-medium">Node-RED Version</td>
+                                <td><div class="py-2">{{ instance.meta.versions['node-red'] }}</div></td>
+                            </tr>
+                            <tr class="border-b">
+                                <td class="font-medium">Launcher Version</td>
+                                <td><div class="py-2">{{ instance.meta.versions.launcher }}</div></td>
+                            </tr>
+                            <tr class="border-b">
+                                <td class="font-medium">Node.js Version</td>
+                                <td><div class="py-2">{{ instance.meta.versions.node }}</div></td>
+                            </tr>
+                        </template>
+                    </table>
+                </div>
             </div>
-            <div class="border rounded p-4">
-                <FormHeading><TrendingUpIcon class="w-6 h-6 mr-2 inline text-gray-400" />Recent Activity</FormHeading>
+            <div class="ff-instance-info">
+                <FormHeading><TrendingUpIcon />Recent Activity</FormHeading>
                 <AuditLog :entries="auditLog" :showLoadMore="false" :disableAccordion="true" />
-                <div class="pb-4">
+                <div class="pb-4 text-center">
                     <router-link to="./audit-log" class="forge-button-inline">More...</router-link>
                 </div>
             </div>
@@ -85,7 +93,7 @@
 </template>
 
 <script>
-import { ExternalLinkIcon, TemplateIcon, TrendingUpIcon } from '@heroicons/vue/outline'
+import { ExternalLinkIcon, ServerIcon, TemplateIcon, TrendingUpIcon } from '@heroicons/vue/outline'
 
 import { mapState } from 'vuex'
 
@@ -104,6 +112,7 @@ export default {
         ExternalLinkIcon,
         FormHeading,
         InstanceStatusBadge,
+        ServerIcon,
         StatusBadge,
         TemplateIcon,
         TrendingUpIcon

--- a/frontend/src/stylesheets/pages/project.scss
+++ b/frontend/src/stylesheets/pages/project.scss
@@ -1,5 +1,43 @@
+@import '~@flowforge/forge-ui-components/dist/scss/forge-colors.scss';
+
 .ff-project-overview {
     .ff-accordion--content {
         transition: none;
+    }
+}
+
+.ff-instance-info {
+    margin-bottom: 12px;
+    h1 {
+        > div {
+            display: flex;
+            gap: 6px;
+        }
+        border-bottom: 0;
+        svg {
+            width: 20px;
+        }
+    }
+    table {
+        padding: 9px 12px;
+        background-color: white;
+        border-radius: 0.25rem;
+        border-collapse: separate;
+        border-width: 1px;
+        border-color: $ff-grey-300;
+        td {
+            height: 36px;
+        }
+        tr:not(:last-child) {
+            td {
+                border-bottom: 1px solid $ff-grey-100;
+            }
+        }
+    }
+    .ff-accordion {
+        margin-bottom: 0;
+    }
+    .ff-accordion--content {
+        background-color: white;
     }
 }


### PR DESCRIPTION
## Description

First step in #2487 - this makes the overview screen cleaner to look at and separates the "info" from the "specs" of the instance.

**After:**
<img width="1728" alt="Screenshot 2023-08-01 at 10 50 42" src="https://github.com/flowforge/flowforge/assets/99246719/30500732-ec68-4a71-be51-9aa52c1f9d35">

**Before**:
<img width="1728" alt="Screenshot 2023-08-01 at 10 51 06" src="https://github.com/flowforge/flowforge/assets/99246719/377a3be7-de76-4440-b4d1-7b00e33493c5">

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
     - Structural & styling changes only 