### PR TITLE
Auto-create Application/Instance when first joining FlowForge

### DIFF
--- a/forge/auditLog/user.js
+++ b/forge/auditLog/user.js
@@ -24,6 +24,12 @@ module.exports = {
                 async autoCreateTeam (actionedBy, error, team) {
                     await log('account.verify.auto-create-team', actionedBy, generateBody({ error, team }))
                 },
+                async autoCreateApplication (actionedBy, error, application) {
+                    await log('account.verify.auto-create-application', actionedBy, generateBody({ error, application }))
+                },
+                async autoCreateInstance (actionedBy, error, instance) {
+                    await log('account.verify.auto-create-instance', actionedBy, generateBody({ error, instance }))
+                },
                 async requestToken (actionedBy, error) {
                     await log('account.verify.request-token', actionedBy, generateBody({ error }))
                 },

--- a/forge/db/controllers/Project.js
+++ b/forge/db/controllers/Project.js
@@ -11,6 +11,27 @@ const inflightProjectState = { }
 
 const inflightDeploys = new Set()
 
+class ControllerError extends Error {
+    /**
+     * ControllerError
+     * @param {string} code
+     * @param {string} message
+     * @param {number} statusCode
+     */
+    constructor (code, message, statusCode = null, options = null) {
+        super(message, options)
+
+        this.name = 'ControllerError'
+
+        this.code = code
+        this.error = message
+
+        if (statusCode) {
+            this.statusCode = statusCode
+        }
+    }
+}
+
 module.exports = {
     /**
      * Get the in-flight state of a project
@@ -270,6 +291,221 @@ module.exports = {
     },
 
     /**
+     *
+     * @param {*} app
+     * @param {Team} team
+     * @param {Application} application
+     * @param {User} user
+     * @param {ProjectType} type
+     * @param {ProjectStack} stack
+     * @param {ProjectTemplate} template
+     * @param {{name: string, ha: {}, sourceProject: Project, sourceProjectOptions: {}}} properties Props of the project to create
+     * @returns
+     */
+    create: async function (
+        app,
+        team,
+        application,
+        user,
+        type,
+        stack,
+        template,
+        {
+            name = '',
+            ha = null,
+            sourceProject = null,
+            sourceProjectOptions = {}
+        } = {}
+    ) {
+        if (!user) {
+            throw new ControllerError('invalid_user', 'Invalid user')
+        }
+
+        if (!team) {
+            throw new ControllerError('invalid_team', 'Invalid team')
+        }
+
+        if (!application) {
+            throw new ControllerError('invalid_application', 'Invalid application')
+        }
+
+        if (!type) {
+            throw new ControllerError('invalid_project_type', 'Invalid project type')
+        }
+
+        // This will perform all checks needed to ensure this instance type can be created for this team.
+        // Throws an exception if not allowed
+        await team.checkInstanceTypeCreateAllowed(type)
+
+        if (sourceProject) {
+            if (sourceProject.Team.id !== team.id) {
+                throw new ControllerError('invalid_source_project', 'Source Project Not in Same Team', 403)
+            } else if (sourceProject && sourceProject.Application.id !== application.id) {
+                throw new ControllerError('invalid_source_project', 'Source Project Not in Same Application', 403)
+            }
+        }
+
+        if (!stack || stack.ProjectTypeId !== type.id) {
+            throw new ControllerError('invalid_stack', 'Invalid stack')
+        }
+
+        if (!template) {
+            throw new ControllerError('invalid_template', 'Invalid template')
+        }
+
+        name = name.trim()
+        const safeName = name?.toLowerCase()
+        if (app.db.models.Project.BANNED_NAME_LIST.includes(safeName)) {
+            throw new ControllerError('invalid_project_name', 'name not allowed', 409)
+        }
+
+        if (/^[a-zA-Z][a-zA-Z0-9-]*$/.test(safeName) === false) {
+            throw new ControllerError('invalid_project_name', 'name not allowed', 409)
+        }
+
+        if (await app.db.models.Project.isNameUsed(safeName)) {
+            throw new ControllerError('invalid_project_name', 'name in use', 409)
+        }
+
+        if (app.license.active() && app.ha) {
+            if (ha && !await app.ha.isHAAllowed(team, type, ha)) {
+                throw new ControllerError('invalid_ha', 'Invalid HA configuration')
+            }
+        }
+
+        let instance
+        try {
+            instance = await app.db.models.Project.create({
+                name,
+                ApplicationId: application.id,
+                type: '',
+                url: ''
+            })
+        } catch (err) {
+            throw new ControllerError('unexpected_error', err.message, null, { cause: err })
+        }
+
+        await team.addProject(instance)
+        await instance.setProjectStack(stack)
+        await instance.setProjectTemplate(template)
+        await instance.setProjectType(type)
+
+        if (app.license.active() && app.ha && ha) {
+            await instance.updateHASettings(ha)
+        }
+
+        await instance.reload({
+            include: [
+                { model: app.db.models.Team },
+                { model: app.db.models.ProjectType },
+                { model: app.db.models.ProjectStack },
+                { model: app.db.models.ProjectTemplate },
+                { model: app.db.models.ProjectSettings }
+            ]
+        })
+
+        if (sourceProject) {
+            await app.db.controllers.Project.importFromInstance(instance, sourceProject, sourceProjectOptions)
+        } else {
+            const newProjectSettings = { header: { title: instance.name } }
+            // Copy the palette modules from the template (if any)
+            // This is an instance creation time only operation to avoid the complexities of
+            // merging the palette modules from the template with the instance palette modules.
+            if (template.settings.palette?.modules?.length > 0) {
+                newProjectSettings.palette = { modules: [...template.settings.palette.modules] }
+            }
+            await instance.updateSetting(KEY_SETTINGS, newProjectSettings)
+            await instance.updateSetting('credentialSecret', app.db.models.Project.generateCredentialSecret())
+        }
+
+        await app.containers.start(instance)
+        await app.auditLog.Project.project.created(user, null, team, instance)
+
+        if (sourceProject) {
+            await app.auditLog.Team.project.duplicated(user, null, team, sourceProject, instance)
+        } else {
+            await app.auditLog.Team.project.created(user, null, team, instance)
+        }
+
+        return instance
+    },
+
+    /**
+     * This method imports from an existing instance, whereas importProject imports from a representation of an instance
+     * Long term, these two method should be combined.
+     *
+     * @param {*} app
+     * @param {Project} targetInstance
+     * @param {Project} sourceInstance
+     * @param {{flows: boolean, credentials: boolean, envVars: boolean}} options
+     */
+    importFromInstance: async function (app, targetInstance, sourceInstance, options = {}) {
+        // need to copy values over
+        const settingsString = (await app.db.models.StorageSettings.byProject(sourceInstance.id))?.settings ?? '{}'
+        const newSettings = {
+            users: {}
+        }
+        const sourceSettings = JSON.parse(settingsString)
+        if (settingsString) {
+            newSettings.nodes = sourceSettings.nodes
+        }
+        const newCredentialSecret = app.db.models.Project.generateCredentialSecret()
+        if (options.flows) {
+            const sourceFlows = await app.db.models.StorageFlow.byProject(sourceInstance.id)
+            if (sourceFlows) {
+                const newFlow = await app.db.models.StorageFlow.create({
+                    flow: sourceFlows.flow,
+                    ProjectId: targetInstance.id
+                })
+                await newFlow.save()
+            }
+
+            if (options.credentials) {
+                // To copy over the credentials, we have to:
+                //  - get the existing credentials + credentialSecret
+                //  - generate a new credentialSecret for the new project
+                //    (this is normally left to NR to do itself)
+                //  - re-encrypt the credentials using the new key
+                const origCredentialsModel = await app.db.models.StorageCredentials.byProject(sourceInstance.id)
+                if (origCredentialsModel) {
+                    const origCredentials = JSON.parse(origCredentialsModel.credentials) // .credentials is stored as text in the DB
+                    const origCredentialSecret = await sourceInstance.getSetting('credentialSecret') || sourceSettings._credentialSecret // Legacy
+                    const newCredentials = await app.db.controllers.Project.reEncryptCredentials(origCredentials, origCredentialSecret, newCredentialSecret)
+                    await app.db.models.StorageCredentials.create({
+                        credentials: JSON.stringify(newCredentials),
+                        ProjectId: targetInstance.id
+                    })
+                }
+            }
+        }
+        await targetInstance.updateSetting('credentialSecret', newCredentialSecret)
+        const settings = await app.db.models.StorageSettings.create({
+            settings: JSON.stringify(newSettings),
+            ProjectId: targetInstance.id
+        })
+        await settings.save()
+
+        const sourceProjectSettings = await sourceInstance.getSetting(KEY_SETTINGS) || { env: [] }
+        const sourceProjectEnvVars = sourceProjectSettings.env || []
+        const newProjectSettings = { ...sourceProjectSettings }
+        newProjectSettings.env = []
+
+        if (options.envVars) {
+            sourceProjectEnvVars.forEach(envVar => {
+                newProjectSettings.env.push({
+                    name: envVar.name,
+                    value: options.envVars === 'keys' ? '' : envVar.value
+                })
+            })
+        }
+        newProjectSettings.header = { title: targetInstance.name }
+        await targetInstance.updateSetting(KEY_SETTINGS, newProjectSettings)
+
+        return targetInstance
+    },
+
+    /**
+     * Imports settings, flows and credentials from a project export object
      *
      * @param {*} app
      * @param {*} project

--- a/forge/db/models/Application.js
+++ b/forge/db/models/Application.js
@@ -34,7 +34,7 @@ module.exports = {
                         ]
                     })
                 },
-                byTeam: async (teamIdOrHash, { includeInstances = false }) => {
+                byTeam: async (teamIdOrHash, { includeInstances = false } = {}) => {
                     let id = teamIdOrHash
                     if (typeof teamIdOrHash === 'string') {
                         id = M.Team.decodeHashid(teamIdOrHash)

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -19,6 +19,21 @@ const Controllers = require('../controllers')
 
 const { KEY_HOSTNAME, KEY_SETTINGS, KEY_HA } = require('./ProjectSettings')
 
+const BANNED_NAME_LIST = [
+    'www',
+    'node-red',
+    'nodered',
+    'forge',
+    'support',
+    'help',
+    'accounts',
+    'account',
+    'status',
+    'billing',
+    'mqtt',
+    'broker'
+]
+
 /** @type {FFModel} */
 module.exports = {
     name: 'Project',
@@ -276,6 +291,7 @@ module.exports = {
                 }
             },
             static: {
+                BANNED_NAME_LIST,
                 isNameUsed: async (name) => {
                     const safeName = name?.toLowerCase()
                     const count = await this.count({

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -303,27 +303,13 @@ module.exports = {
                     return this.findAll({
                         include: {
                             model: M.Team,
+                            attributes: ['hashid', 'id', 'name', 'slug', 'links', 'TeamTypeId'],
                             include: [
-                                {
-                                    model: M.Application,
-                                    attributes: ['hashid', 'id', 'name', 'links', 'TeamTypeId']
-                                },
                                 {
                                     model: M.TeamMember,
                                     where: {
                                         UserId: user.id
                                     }
-                                },
-                                {
-                                    model: M.ProjectType,
-                                    attributes: ['hashid', 'id', 'name']
-                                },
-                                {
-                                    model: M.ProjectStack
-                                },
-                                {
-                                    model: M.ProjectTemplate,
-                                    attributes: ['hashid', 'id', 'name', 'links']
                                 }
                             ],
                             required: true

--- a/forge/db/models/TeamType.js
+++ b/forge/db/models/TeamType.js
@@ -128,7 +128,7 @@ module.exports = {
                             if (parts.length > 0) {
                                 props = props[k]
                             } else {
-                                return props[k]
+                                return props[k] ?? defaultValue
                             }
                         } else {
                             return defaultValue

--- a/forge/routes/api/settings.js
+++ b/forge/routes/api/settings.js
@@ -50,6 +50,7 @@ module.exports = async function (app) {
                 response['user:reset-password'] = app.settings.get('user:reset-password')
                 response['user:team:auto-create'] = app.settings.get('user:team:auto-create')
                 response['user:team:auto-create:teamType'] = app.settings.get('user:team:auto-create:teamType')
+                response['user:team:auto-create:instanceType'] = app.settings.get('user:team:auto-create:instanceType')
                 response.email = app.postoffice.exportSettings(true)
                 response['version:forge'] = app.settings.get('version:forge')
                 response['version:node'] = app.settings.get('version:node')

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -553,7 +553,6 @@ async function init (app, opts, done) {
 
             reply.send({ status: 'okay' })
         } catch (err) {
-            console.log(err)
             app.log.error(`/account/verify/token error - ${err.toString()}`)
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.User.account.verify.verifyToken(request.session?.User, resp)

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -539,8 +539,8 @@ async function init (app, opts, done) {
                     await app.auditLog.User.account.verify.autoCreateTeam(request.session?.User || verifiedUser, null, application)
                 }
 
-                const safeTeamName = userTeam.name.replace(/[\W_]/g, '')
-                const safeUserName = verifiedUser.username.replace(/[\W_]/g, '-')
+                const safeTeamName = userTeam.name.toLowerCase().replace(/[\W_]/g, '-')
+                const safeUserName = verifiedUser.username.toLowerCase().replace(/[\W_]/g, '-')
 
                 const instanceProperties = {
                     name: `${safeTeamName}-${safeUserName}-${crypto.randomBytes(4).toString('hex')}`

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -531,8 +531,10 @@ async function init (app, opts, done) {
                 if (applications.length > 0) {
                     application = applications[0]
                 } else {
+                    const applicationName = `${verifiedUser.name}'s Application`
+
                     application = await app.db.models.Application.create({
-                        name: 'Default Application',
+                        name: applicationName.charAt(0).toUpperCase() + applicationName.slice(1),
                         TeamId: userTeam.id
                     })
 

--- a/forge/routes/auth/index.js
+++ b/forge/routes/auth/index.js
@@ -15,6 +15,8 @@
  * @namespace session
  * @memberof forge.routes
  */
+const crypto = require('crypto')
+
 const fp = require('fastify-plugin')
 
 // This defines how long the session cookie is valid for. This should match
@@ -500,8 +502,58 @@ async function init (app, opts, done) {
                 // await invite.save()
             }
             await app.auditLog.User.account.verify.verifyToken(request.session?.User || verifiedUser, null)
+
+            // only create a starting instance if the flag is set and this user and their teams have no instances
+            if (app.settings.get('user:team:auto-create:instanceType') &&
+             !((await app.db.models.Project.byUser(verifiedUser)).length)) {
+                const instanceTypeId = app.settings.get('user:team:auto-create:instanceType')
+
+                const instanceType = await app.db.models.ProjectType.byId(instanceTypeId)
+                const instanceStack = await instanceType?.getDefaultStack() || (await instanceType.getProjectStacks())?.[0]
+                const instanceTemplate = await app.db.models.ProjectTemplate.findOne({ where: { active: true } })
+
+                const userTeamMemberships = await app.db.models.Team.forUser(verifiedUser)
+                if (userTeamMemberships.length <= 0) {
+                    console.warn("Flag to auto-create instance is set ('user:team:auto-create:instanceType'), but user has no team, consider setting 'user:team:auto-create'")
+                    return reply.send({ status: 'okay' })
+                } else if (!instanceType) {
+                    throw new Error(`Instance type with id ${instanceTypeId} from 'user:team:auto-create:instanceType' not found`)
+                } else if (!instanceStack) {
+                    throw new Error(`Unable to find a stack for use with instance type ${instanceTypeId} to auto-create user instance`)
+                } else if (!instanceTemplate) {
+                    throw new Error('Unable to find the default instance template from which to auto-create user instance')
+                }
+
+                const userTeam = userTeamMemberships[0].Team
+
+                const applications = await app.db.models.Application.byTeam(userTeam.id)
+                let application
+                if (applications.length > 0) {
+                    application = applications[0]
+                } else {
+                    application = await app.db.models.Application.create({
+                        name: 'Default Application',
+                        TeamId: userTeam.id
+                    })
+
+                    await app.auditLog.User.account.verify.autoCreateTeam(request.session?.User || verifiedUser, null, application)
+                }
+
+                const safeTeamName = userTeam.name.replace(/[\W_]/g, '')
+                const safeUserName = verifiedUser.username.replace(/[\W_]/g, '-')
+
+                const instanceProperties = {
+                    name: `${safeTeamName}-${safeUserName}-${crypto.randomBytes(4).toString('hex')}`
+                }
+
+                const instance = await app.db.controllers.Project.create(userTeam, application, verifiedUser, instanceType, instanceStack, instanceTemplate, instanceProperties)
+
+                await app.auditLog.User.account.verify.autoCreateInstance(request.session?.User || verifiedUser, null, instance)
+            }
+
             reply.send({ status: 'okay' })
         } catch (err) {
+            console.log(err)
             app.log.error(`/account/verify/token error - ${err.toString()}`)
             const resp = { code: 'unexpected_error', error: err.toString() }
             await app.auditLog.User.account.verify.verifyToken(request.session?.User, resp)

--- a/forge/settings/defaults.js
+++ b/forge/settings/defaults.js
@@ -39,6 +39,8 @@ module.exports = {
     'user:team:auto-create': false,
     // The type of team to create - if null, will default to the 'first' in the list
     'user:team:auto-create:teamType': null,
+    // The type of instance to auto-create when an account signs up, defaults to none.
+    'user:team:auto-create:instanceType': null,
 
     // Can external users be invited to join teams
     'team:user:invite:external': false,

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -157,17 +157,18 @@ export default {
                         }
                     }
                 }
-                if (this.features.billing) {
-                    // Need to ensure we have input.properties.instances entries
-                    // for all known instance types
-                    this.instanceTypes.forEach(instanceType => {
-                        if (!this.input.properties.instances[instanceType.id]) {
-                            this.input.properties.instances[instanceType.id] = {
-                                active: false
-                            }
+
+                // Need to ensure we have input.properties.instances entries
+                // for all known instance types
+                this.instanceTypes.forEach(instanceType => {
+                    if (!this.input.properties.instances[instanceType.id]) {
+                        this.input.properties.instances[instanceType.id] = {
+                            active: false
                         }
-                    })
-                }
+                    }
+                })
+
+                debugger
 
                 this.errors = {}
                 this.$refs.dialog.show()

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -168,8 +168,6 @@ export default {
                     }
                 })
 
-                debugger
-
                 this.errors = {}
                 this.$refs.dialog.show()
             }

--- a/test/unit/forge/db/models/TeamType_spec.js
+++ b/test/unit/forge/db/models/TeamType_spec.js
@@ -1,0 +1,79 @@
+const should = require('should') // eslint-disable-line
+const setup = require('../setup')
+
+describe('TeamType model', function () {
+    let app
+
+    before(async function () {
+        app = await setup()
+    })
+    after(async function () {
+        await app.close()
+    })
+
+    describe('getInstanceTypeProperty', async function () {
+        it('Should read the (nested) property from an instances config when passed a hashid', async function () {
+            const teamType = await app.db.models.TeamType.create({
+                name: 'Test Team Type',
+                properties: {
+                    instances: {
+                        one: {
+                            active: true
+                        }
+                    }
+                }
+            })
+
+            teamType.getInstanceTypeProperty('one', 'active').should.equal(true)
+        })
+
+        it('Should read the (nested) property from an instances config when passed an whole model', async function () {
+            const instanceType = await app.db.models.ProjectType.create({
+                name: 'Test Instance Type'
+            })
+
+            const properties = {
+                instances: {}
+            }
+            properties.instances[instanceType.hashid] = {
+                active: true
+            }
+
+            const teamType = await app.db.models.TeamType.create({
+                name: 'Test Team Type',
+                properties
+            })
+
+            teamType.getInstanceTypeProperty(instanceType, 'active').should.equal(true)
+        })
+
+        it('Should return the default value if property is not found', async function () {
+            const teamType = await app.db.models.TeamType.create({
+                name: 'Test Team Type',
+                properties: {
+                    instances: {
+                        one: {
+                        }
+                    }
+                }
+            })
+
+            teamType.getInstanceTypeProperty('one', 'active', 'defaultValue').should.equal('defaultValue')
+        })
+
+        it('Should also return the default value if property is null', async function () {
+            const teamType = await app.db.models.TeamType.create({
+                name: 'Test Team Type',
+                properties: {
+                    instances: {
+                        one: {
+                            active: null
+                        }
+                    }
+                }
+            })
+
+            teamType.getInstanceTypeProperty('one', 'active', 'defaultValue').should.equal('defaultValue')
+        })
+    })
+})

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -293,7 +293,7 @@ describe('Accounts API', async function () {
                 const response = await registerUser({
                     username: 'user4',
                     password: '12345678',
-                    name: 'user',
+                    name: 'dave',
                     email: 'user4@example.com'
                 })
                 response.statusCode.should.equal(200)
@@ -316,10 +316,10 @@ describe('Accounts API', async function () {
                 applications.length.should.equal(1)
 
                 const application = applications[0]
-                application.name.should.match('Default Application')
+                application.name.should.match('Dave\'s Application')
 
                 application.Instances.length.should.equal(1)
-                application.Instances[0].safeName.should.match(/team-user-user4-(\w)+/)
+                application.Instances[0].safeName.should.match(/team-dave-user4-(\w)+/)
             })
 
             it('handles a custom team type being set, still creating an application & instance if the flag is set', async function () {
@@ -343,7 +343,7 @@ describe('Accounts API', async function () {
                 const response = await registerUser({
                     username: 'user5',
                     password: '12345678',
-                    name: 'user',
+                    name: 'Pez Cuckow',
                     email: 'user5@example.com'
                 })
                 response.statusCode.should.equal(200)
@@ -366,10 +366,10 @@ describe('Accounts API', async function () {
                 applications.length.should.equal(1)
 
                 const application = applications[0]
-                application.name.should.match('Default Application')
+                application.name.should.match('Pez Cuckow\'s Application')
 
                 application.Instances.length.should.equal(1)
-                application.Instances[0].safeName.should.match(/team-user-user5-(\w)+/)
+                application.Instances[0].safeName.should.match(/team-pez-cuckow-user5-(\w)+/)
 
                 // cleanup else this becomes the new default and breaks other tests
                 newTeamType.active = false

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -282,7 +282,7 @@ describe('Accounts API', async function () {
                 instances.length.should.equal(1)
 
                 const instance = instances[0]
-                instance.safeName.should.match(/teamuser-user3-(\w)+/)
+                instance.safeName.should.match(/team-user-user3-(\w)+/)
             })
 
             it('auto-creates an application & instance if instanceType option is set and there is no application yet', async function () {
@@ -320,7 +320,6 @@ describe('Accounts API', async function () {
 
                 // Validate via application
                 application.Instances.length.should.equal(1)
-                application.Instances[0].safeName.should.match(/teamuser-user4-(\w)+/)
 
                 // Validate directly via user
                 const instances = await app.db.models.Project.byUser(user)
@@ -330,6 +329,7 @@ describe('Accounts API', async function () {
                 instance.safeName.should.match(/teamuser-user4-(\w)+/)
 
                 application.Instances[0].should.equal(instance) // they are the same
+                application.Instances[0].safeName.should.match(/team-user-user4-(\w)+/)
             })
 
             it('handles a custom team type being set, still creating an application & instance if the flag is set', async function () {
@@ -354,7 +354,7 @@ describe('Accounts API', async function () {
                     username: 'user5',
                     password: '12345678',
                     name: 'user',
-                    email: 'user4@example.com'
+                    email: 'user5@example.com'
                 })
                 response.statusCode.should.equal(200)
 
@@ -380,7 +380,6 @@ describe('Accounts API', async function () {
 
                 // Validate via application
                 application.Instances.length.should.equal(1)
-                application.Instances[0].safeName.should.match(/teamuser-user5-(\w)+/)
 
                 // Validate directly via user
                 const instances = await app.db.models.Project.byUser(user)
@@ -390,6 +389,7 @@ describe('Accounts API', async function () {
                 instance.safeName.should.match(/teamuser-user5-(\w)+/)
 
                 application.Instances[0].should.equal(instance)
+                application.Instances[0].safeName.should.match(/team-user-user5-(\w)+/)
 
                 // cleanup else this becomes the new default and breaks other tests
                 newTeamType.active = false

--- a/test/unit/forge/routes/auth/index_spec.js
+++ b/test/unit/forge/routes/auth/index_spec.js
@@ -318,17 +318,7 @@ describe('Accounts API', async function () {
                 const application = applications[0]
                 application.name.should.match('Default Application')
 
-                // Validate via application
                 application.Instances.length.should.equal(1)
-
-                // Validate directly via user
-                const instances = await app.db.models.Project.byUser(user)
-                instances.length.should.equal(1)
-
-                const instance = instances[0]
-                instance.safeName.should.match(/teamuser-user4-(\w)+/)
-
-                application.Instances[0].should.equal(instance) // they are the same
                 application.Instances[0].safeName.should.match(/team-user-user4-(\w)+/)
             })
 
@@ -378,17 +368,7 @@ describe('Accounts API', async function () {
                 const application = applications[0]
                 application.name.should.match('Default Application')
 
-                // Validate via application
                 application.Instances.length.should.equal(1)
-
-                // Validate directly via user
-                const instances = await app.db.models.Project.byUser(user)
-                instances.length.should.equal(1)
-
-                const instance = instances[0]
-                instance.safeName.should.match(/teamuser-user5-(\w)+/)
-
-                application.Instances[0].should.equal(instance)
                 application.Instances[0].safeName.should.match(/team-user-user5-(\w)+/)
 
                 // cleanup else this becomes the new default and breaks other tests


### PR DESCRIPTION
## Description

Adds a new admin config option `user:team:auto-create:instanceType` to the admins setting screen, nested under auto-creation of team types.

If this option is set, when a user verifies their email, if they have a team (which they should always do thanks to the `team:auto-create` setting); the user is also given an application named `Default Application` and an instance, which is based on the team, and username, with a random hash, like so: `team-name-username-3425aed6`

![Screenshot 2023-08-02 at 11 44 02](https://github.com/flowforge/flowforge/assets/507155/43cedb52-76be-4175-8386-5a2f948d8cf7)
![Screenshot 2023-08-02 at 11 43 57](https://github.com/flowforge/flowforge/assets/507155/67387487-3155-4761-834b-c96a0c3302f2)


https://github.com/flowforge/flowforge/assets/507155/f564218d-9b2f-4b21-8dab-693844432521



## Related Issue(s)


Fixes #2475 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

