### PR TITLE
Ensure Default InstanceType is enabled for Default TeamType in clean install

### DIFF
--- a/forge/db/controllers/ProjectStack.js
+++ b/forge/db/controllers/ProjectStack.js
@@ -14,8 +14,6 @@ module.exports = {
             },
             defaults: {
                 label,
-                order: 1,
-                description: '',
                 properties
             }
         })

--- a/forge/db/controllers/TeamType.js
+++ b/forge/db/controllers/TeamType.js
@@ -108,5 +108,21 @@ module.exports = {
                 }
             }
         }
+    },
+    /**
+     * Called by the setup wizard, ensures the default InstanceType is enabled
+     * for the default TeamType
+     * @param {InstanceType} instanceType the instanceType to enable
+     */
+    enableInstanceTypeForDefaultType: async function (app, instanceType) {
+        const defaultTeamType = await app.db.models.TeamType.findOne({ where: { id: 1 } })
+        if (defaultTeamType) {
+            const props = defaultTeamType.properties
+            props.instances[instanceType.hashid] = {
+                active: true
+            }
+            defaultTeamType.properties = props
+            await defaultTeamType.save()
+        }
     }
 }

--- a/forge/routes/setup/index.js
+++ b/forge/routes/setup/index.js
@@ -78,12 +78,19 @@ module.exports = async function (app) {
                 }
             })
             const projectType = await app.db.controllers.ProjectType.createDefaultProjectType()
-            app.log.info('[SETUP] Created default ProjectType')
+            app.log.info('[SETUP] Created default InstanceType')
+
+            await app.db.controllers.TeamType.enableInstanceTypeForDefaultType(projectType)
+            app.log.info('[SETUP] Enabled default InstanceType for default TeamType')
+
             await app.db.controllers.ProjectTemplate.createDefaultTemplate(adminUser)
-            app.log.info('[SETUP] Created default ProjectTemplate')
+            app.log.info('[SETUP] Created default Template')
+
             await app.db.controllers.ProjectStack.createDefaultProjectStack(projectType)
-            app.log.info('[SETUP] Created default ProjectStack')
+            app.log.info('[SETUP] Created default Stack')
+
             await app.settings.set('setup:initialised', true)
+
             app.log.info('****************************************************')
             app.log.info('* FlowForge setup is complete. You can login at:   *')
             app.log.info(`*   ${app.config.base_url.padEnd(47, ' ')}*`)

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -45,7 +45,7 @@
                     <FormRow v-model="input.properties.users.limit"># Limit</FormRow>
                 </div>
                 <div v-for="(instanceType, index) in instanceTypes" :key="index">
-                    <FormHeading>Instances: {{ instanceType.name }}</FormHeading>
+                    <FormHeading>Instance Type: {{ instanceType.name }}</FormHeading>
                     <FormRow v-model="input.properties.instances[instanceType.id].active" type="checkbox" class="mb-4">Available</FormRow>
                     <div v-if="input.properties.instances[instanceType.id].active" class="grid gap-3 grid-cols-4 pl-4">
                         <div class="grid gap-3 grid-cols-2">
@@ -54,7 +54,7 @@
                         </div>
                         <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].productId" :type="editDisabled?'uneditable':''">Product Id</FormRow>
                         <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
-                        <FormRow v-model="input.properties.instances[instanceType.id].description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
+                        <FormRow v-if="features.billing" v-model="input.properties.instances[instanceType.id].description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
                     </div>
                 </div>
                 <FormHeading>Devices</FormHeading>
@@ -67,7 +67,8 @@
                     <FormRow v-if="features.billing" v-model="input.properties.devices.priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
                     <FormRow v-if="features.billing" v-model="input.properties.devices.description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
                 </div>
-                <FormHeading>Features</FormHeading>
+
+                <!-- <FormHeading>Features</FormHeading>
                 <div class="grid gap-3 grid-cols-2">
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
                     <FormRow v-model="input.properties.features['shared-library']" type="checkbox">Team Library</FormRow>
@@ -75,7 +76,7 @@
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow>
-                </div>
+                </div> -->
             </form>
         </template>
         <template #actions>

--- a/test/system/001-setup_spec.js
+++ b/test/system/001-setup_spec.js
@@ -378,5 +378,26 @@ describe('First run setup', function () {
             response.statusCode.should.equal(302)
             response.headers.location.should.equal('/')
         })
+
+        it('should have created default objects', async function () {
+            const defaultProjectTypeList = await forge.db.models.ProjectType.findAll()
+            defaultProjectTypeList.should.have.length(1)
+            const defaultProjectType = defaultProjectTypeList[0]
+
+            const defaultTeamTypeList = await forge.db.models.TeamType.findAll()
+            defaultTeamTypeList.should.have.length(1)
+
+            const defaultTeamType = defaultTeamTypeList[0]
+
+            defaultTeamType.properties.should.have.property('instances')
+            defaultTeamType.properties.instances.should.have.property(defaultProjectType.hashid)
+            defaultTeamType.properties.instances[defaultProjectType.hashid].should.have.property('active', true)
+
+            const defaultTemplateList = await forge.db.models.ProjectTemplate.findAll()
+            defaultTemplateList.should.have.length(1)
+
+            const defaultStackList = await forge.db.models.ProjectStack.findAll()
+            defaultStackList.should.have.length(1)
+        })
     })
 })


### PR DESCRIPTION
Fixes #2572

## Description

Ensures the default instanceType is enabled for the default TeamType in a clean install

This will need backporting once merged.

This also tidies up the TeamType edit dialog:
 - removes the 'billing description' field for instances when billing isn't enabled
 - improves the heading shown against the individual instance types
 - hides the whole features table as it is not functional yet.

Finally, noticed a spurious log message from sequelize around creating the default ProjectStack - we were passing in default values for non-existent properties of the Stack object. Now tidied up.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

