### PR TITLE
Add basic Team Type docs

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -46,6 +46,9 @@ following settings are available:
     create the Team (if that option is enabled), or be invited to an existing
     Team.
 
+    When enabled, a choice of what type of team should be created for the user
+    is shown.
+
  - **Allow users to reset their password on the login screen** (default: `false)
 
    With this option enabled, a 'forgot your password' link is shown on the login
@@ -93,6 +96,13 @@ With the 0.1.0 release, the Teams page just lists the teams on the platform.
 
 Further team management options will come in later releases.
 
+### Managing Team Types
+
+The Team Types page can be used to manage the Team Types on the platform.
+
+They determine what features of the platform are available to teams of a given type,
+including what Instance Types are available and any limits that should be applied.
+
 ### Managing Instance Types
 
 The Instance Types page can be used to manage the Instance Types on the platform.
@@ -104,6 +114,10 @@ associated with it.
 The Instance Types page shows what types are current active, how many stacks
 each type has assigned to it, and how many instances have been created of that
 type.
+
+Whenever a new Instance Type is created, it will need to be manually enabled for
+the individual [Team Types](#managing-team-types) before they will be available
+for teams to use.
 
 ### Managing Stacks
 

--- a/docs/upgrade/README.md
+++ b/docs/upgrade/README.md
@@ -19,6 +19,12 @@ has been performed.
 Endpoint Rate Limiting is now available to FlowForge. This is disabled by default, but can be enabled by setting the `rate_limits.enabled` config setting to `true`.
 The documentation for this is available [here](../install/configuration.md#rate-limiting-configuration).
 
+The [TeamType concept](../user/concepts.md#team-type) was expanded in this release.
+It is used to control what Instance Types are available for different teams, as
+well as any additional limits that should be applied. When creating new Instance
+Types, they must now be [manually enabled](../admin/README.md#managing-instance-types)
+for the Team Types on the platform.
+
 
 ### Upgrading to 1.5
 

--- a/docs/user/concepts.md
+++ b/docs/user/concepts.md
@@ -28,6 +28,13 @@ The users in a team can have different roles that determine what they are
 
 In FlowForge Cloud, each team has its own billing plan, managed via Stripe.
 
+#### Team Type
+
+The platform can be configured to provide different types of team. These can be used
+to apply limits on what teams of a given type can do. For example, a particular
+team type may be restricted to certain types of [Node-RED Instance](#instance),
+or how many members the team can have.
+
 ### Application
 
 **Introduced in FlowForge 1.5**


### PR DESCRIPTION
## Description

This adds very basic TeamType docs - mostly only relevant for self-hosted users. The key information being the need to enable which InstanceTypes are available to a given TeamType.

