### PR TITLE
Fix device running or reporting old snapshot id/name

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -83,9 +83,17 @@ class DeviceCommsHandler {
                     // The Project is incorrect
                     sendUpdateCommand = true
                 }
-                if (Object.hasOwn(payload, 'snapshot') && payload.snapshot !== (device.targetSnapshot?.hashid || null)) {
-                    // The Snapshot is incorrect
-                    sendUpdateCommand = true
+                if (Object.hasOwn(payload, 'snapshot')) {
+                    // load the full snapshot (as specified by the device) from the db so we can check the snapshots
+                    // `ProjectId` is "something" (not orphaned) and matches the device's project
+                    const targetSnapshot = (await this.app.db.models.ProjectSnapshot.byId(payload.snapshot))
+                    if (payload.snapshot !== (targetSnapshot?.hashid || null)) {
+                        // The Snapshot is incorrect
+                        sendUpdateCommand = true
+                    } else if (targetSnapshot && payload.project !== (targetSnapshot?.ProjectId || null)) {
+                        // The project the device is reporting it belongs to does not match the target Snapshot parent project
+                        sendUpdateCommand = true
+                    }
                 }
                 if (Object.hasOwn(payload, 'settings') && payload.settings !== (device.settingsHash || null)) {
                     // The Settings are incorrect

--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -101,7 +101,7 @@ class DeviceCommsHandler {
                 }
 
                 if (sendUpdateCommand) {
-                    this.app.db.controllers.Device.sendDeviceUpdateCommand(device)
+                    await this.app.db.controllers.Device.sendDeviceUpdateCommand(device)
                 }
             } catch (err) {
                 // Not a JSON payload - ignore

--- a/forge/routes/api/device.js
+++ b/forge/routes/api/device.js
@@ -405,7 +405,7 @@ module.exports = async function (app) {
 
         const updatedDevice = await app.db.models.Device.byId(device.id)
         if (sendDeviceUpdate) {
-            app.db.controllers.Device.sendDeviceUpdateCommand(updatedDevice)
+            await app.db.controllers.Device.sendDeviceUpdateCommand(updatedDevice)
         }
         reply.send(app.db.views.Device.device(updatedDevice))
     })
@@ -472,7 +472,7 @@ module.exports = async function (app) {
             }
             await request.device.updateSettings(bodySettingsEnvOnly)
         }
-        app.db.controllers.Device.sendDeviceUpdateCommand(request.device)
+        await app.db.controllers.Device.sendDeviceUpdateCommand(request.device)
         reply.send({ status: 'okay' })
     })
 
@@ -568,7 +568,7 @@ module.exports = async function (app) {
         request.device.mode = request.body.mode
         await request.device.save()
         // send update to device for immediate effect
-        app.db.controllers.Device.sendDeviceUpdateCommand(request.device)
+        await app.db.controllers.Device.sendDeviceUpdateCommand(request.device)
         // Audit log the change
         if (request.device.mode === 'developer') {
             await app.auditLog.Team.team.device.developerMode.enabled(request.session.User, null, request.device.Team, request.device)

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -1,13 +1,85 @@
+const sinon = require('sinon')
 const should = require('should') // eslint-disable-line
+const snapshotServices = require('../../../../../forge/services/snapshots.js')
+const TestModelFactory = require('../../../../lib/TestModelFactory.js')
 const setup = require('../setup')
 
 describe('Device controller', function () {
-    // Use standard test data.
     let app
-    before(async function () {
-        app = await setup()
-    })
+    /** @type {TestModelFactory} */ let factory
+    const TestObjects = {}
 
+    async function setupCE () {
+        app = await setup()
+        factory = new TestModelFactory(app)
+        await setupTestObjects()
+    }
+
+    async function login (username, password) {
+        const response = await app.inject({
+            method: 'POST',
+            url: '/account/login',
+            payload: { username, password, remember: false }
+        })
+        response.cookies.should.have.length(1)
+        response.cookies[0].should.have.property('name', 'sid')
+        TestObjects.tokens[username] = response.cookies[0].value
+    }
+
+    async function setupTestObjects () {
+        // alice : admin
+        // ATeam ( alice  (owner) )
+
+        // Alice is created in setup()
+        const userAlice = await app.db.models.User.byUsername('alice')
+        // ATeam is created in setup()
+        const ATeam = await app.db.models.Team.byName('ATeam')
+        // Alice is set as ATeam owner in setup()
+
+        // generate a template
+        const template1 = await factory.createProjectTemplate({
+            name: 'template1',
+            settings: {
+                httpAdminRoot: '',
+                codeEditor: '',
+                palette: {
+                    modules: []
+                }
+            }
+        }, userAlice)
+        const projectType1 = await factory.createProjectType({
+            name: 'projectType1',
+            description: 'default project type',
+            properties: { foo: 'bar' }
+        })
+        const stack1 = await factory.createStack({ name: 'stack1' }, projectType1)
+        const application1 = await factory.createApplication({ name: 'application-1' }, ATeam)
+        const instance1 = await factory.createInstance(
+            { name: 'project1' },
+            application1,
+            stack1,
+            template1,
+            projectType1,
+            { start: false }
+        )
+
+        // Set up TestObjects
+        TestObjects.alice = userAlice
+        TestObjects.team = ATeam
+        TestObjects.stack = stack1
+        TestObjects.template = template1
+        TestObjects.projectType = projectType1
+        TestObjects.application = application1
+        TestObjects.project = instance1
+        TestObjects.projectCredentials = await instance1.refreshAuthTokens()
+
+        TestObjects.tokens = {}
+        await login('alice', 'aaPassword')
+    }
+
+    before(async function () {
+        return setupCE()
+    })
     after(async function () {
         await app.close()
     })
@@ -64,6 +136,95 @@ describe('Device controller', function () {
             const env = app.db.controllers.Device.removePlatformSpecificEnvVars(dummyEnvVars)
             should(env).be.an.Array().and.have.a.lengthOf(1)
             env.should.containEql({ name: 'normal-env-var', value: 'f' })
+        })
+        describe('sendDeviceUpdateCommand', function () {
+            afterEach(async function () {
+                sinon.restore()
+            })
+            it('sends update command to device', async function () {
+                const snapshot = await snapshotServices.createSnapshot(app, TestObjects.project, TestObjects.alice, {
+                    name: 'snapshot 1',
+                    description: 'snapshot 1 description',
+                    setAsTarget: true
+                })
+                await TestObjects.project.reload()
+
+                const device1 = await factory.createDevice({ name: 'device1', type: 'type1' }, TestObjects.team, TestObjects.project)
+
+                // set the snapshot as the target snapshot on the project
+                await device1.setTargetSnapshot(snapshot)
+
+                // stub app.comms.devices.sendCommand so we can see what it was called with
+                /** @type {DeviceCommsHandler} */
+                const commsHandler = app.comms.devices
+                sinon.stub(commsHandler, 'sendCommand').resolves()
+
+                // load the full device model & use it in a call to sendDeviceUpdateCommand
+                const device = await app.db.models.Device.byId(device1.id)
+                await app.db.controllers.Device.sendDeviceUpdateCommand(device)
+
+                // ensure sendCommand was called
+                should(commsHandler.sendCommand.calledOnce).be.true('sendCommand was not called')
+                // get the args used to call sendCommand
+                const args = commsHandler.sendCommand.getCall(0).args
+                // check the args are as expected: Team.hashid, device.hashid, 'update', payload
+                should(args[0]).eql(TestObjects.team.hashid)
+                should(args[1]).eql(device.hashid)
+                should(args[2]).eql('update')
+                should(args[3]).be.an.Object()
+                args[3].should.have.a.property('project', TestObjects.project.id)
+                args[3].should.have.a.property('snapshot', snapshot.hashid)
+                args[3].should.have.a.property('mode', 'autonomous')
+                args[3].should.have.a.property('settings')
+                args[3].should.have.a.property('licensed')
+            })
+            it('does not send orphaned snapshot in update command to device', async function () {
+                // create a new project with snapshot, assign to device, delete project to orphan the snapshot
+                const instance2 = await factory.createInstance(
+                    { name: 'project2' },
+                    TestObjects.application,
+                    TestObjects.stack,
+                    TestObjects.template,
+                    TestObjects.projectType,
+                    { start: false }
+                )
+
+                const snapshot = await snapshotServices.createSnapshot(app, instance2, TestObjects.alice, {
+                    name: 'instance 2 snapshot 1',
+                    description: 'snapshot 1 on instance 2',
+                    setAsTarget: true
+                })
+                await instance2.reload()
+
+                const device1 = await factory.createDevice({ name: 'device1', type: 'type1' }, TestObjects.team, instance2)
+
+                // set the snapshot as the target snapshot on the project
+                await device1.setTargetSnapshot(snapshot)
+
+                // delete the project to orphan the snapshot
+                await instance2.destroy()
+
+                // stub app.comms.devices.sendCommand so we can see what it was called with
+                /** @type {DeviceCommsHandler} */
+                const commsHandler = app.comms.devices
+                sinon.stub(commsHandler, 'sendCommand').resolves()
+
+                // load the full device model & use it in a call to sendDeviceUpdateCommand
+                const device = await app.db.models.Device.byId(device1.id)
+                await app.db.controllers.Device.sendDeviceUpdateCommand(device)
+
+                // ensure sendCommand was called
+                should(commsHandler.sendCommand.calledOnce).be.true('sendCommand was not called')
+                // get the args used to call sendCommand
+                const args = commsHandler.sendCommand.getCall(0).args
+                // check the args are as expected: Team.hashid, device.hashid, 'update', payload
+                should(args[0]).eql(TestObjects.team.hashid)
+                should(args[1]).eql(device.hashid)
+                should(args[2]).eql('update')
+                should(args[3]).be.an.Object()
+                args[3].should.have.a.property('project', null)
+                args[3].should.have.a.property('snapshot', null)
+            })
         })
     })
 })

--- a/test/unit/forge/db/controllers/Device_spec.js
+++ b/test/unit/forge/db/controllers/Device_spec.js
@@ -4,7 +4,7 @@ const snapshotServices = require('../../../../../forge/services/snapshots.js')
 const TestModelFactory = require('../../../../lib/TestModelFactory.js')
 const setup = require('../setup')
 
-describe.only('Device controller', function () {
+describe('Device controller', function () {
     let app
     /** @type {TestModelFactory} */ let factory
     const TestObjects = {}


### PR DESCRIPTION
## Description

This PR addresses several issues found while debugging the reported problem.

NOTE: None of the work here involved messing with the device files. The state of the device and its files were all a result of actions taken in the forge application.  I feel this is important to point out because as it stands, it is possible to get the device to crash and into odd states.

The issues encountered...

### problem 1 - device running snapshot of deleted instance
Device active/target snapshot get populated in checkin code
device reports it is on old snapshot & that matches 
checkin code did not check that the activeSnapshots project matched the device current project

### problem 2 - snapshot table is not cleaned - holds snapshots from deleted instances
When device checks in, its reported snapshot is found and the device objects active/target snapshot are populated meaning the device passes its checkin & does not instruct an update.

NOTE: No work was done to delete the old snapshots, only to mitigate the problem. A separate issue will be raised detailing thoughts and care points around this.  

### problem 3
Even if we force a DeviceUpdate, it just passes the exact same settings due to the snapshot table having old entries

### problem 4
Once we do get the device to clean up, switching between dev/autonomous mode caused a crash due to missing files
```
[AGENT] 09/08/2023 09:47:27 [info] Cleaning instance directory
[AGENT] 09/08/2023 09:47:50 [info] Enabling developer mode
[AGENT] 09/08/2023 09:47:51 [info] Enabling remote editor access
[AGENT] 09/08/2023 09:47:51 [info] No running Node-RED instance, not starting editor
[AGENT] 09/08/2023 09:47:56 [info] Enabling remote editor access
[AGENT] 09/08/2023 09:47:56 [info] No running Node-RED instance, not starting editor
[Error: ENOENT: no such file or directory, open 'C:\opt\flowforge-device\project\flows.json'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\opt\\flowforge-device\\project\\flows.json'
}
```

### problem 5
when the agent determines a new snapshot is available, we dont instruct it to grab new settings.
Since some env vars are computed by the platform (e.g. FF_SNAPSHOT_ID/NAME) we must also instruct
the agent to refresh its settings.

### The work in this PR

#### 1: [ensure device is not using orphaned snapshot](https://github.com/flowforge/flowforge/commit/c516bd3f8b044f2b57e3aa348d55c95ca67fd56f)

When checking the status of the device, grab the full row from ProjectSnapshots and verify the associated project is both present and matches the device. If not, the snapshot is considered to be an orphan or mismatched and a device update is requested.

#### 2: [ensure platform doesnt send ophaned snapshot > dev](https://github.com/flowforge/flowforge/commit/8b2427c535cab08f4baaeff2ca2e7d86a1c6ea3a)

When sending an update command to device, check the targetSnapshot has a project AND it matches the projectId that owns the device. If this fails, set the snapshot id in the payload update to null. This will signal the device to clear its current snapshot.

This can occur when an instance (with a member device and target snapshot) is deleted. The ProjectId field is cleared but the snapshot remains in the database. 


### ~TODO~ Unit Tests
Adds tests to `test/unit/forge/db/controllers/Device_spec.js`
- Device controller
    -  sendDeviceUpdateCommand
        - sends update command to device
        - does not send orphaned snapshot in update command to device

### Manual Tests

1. delete instance - expect device to clear its config

* On next poll, agent reports correct change  👍 
```
[AGENT] 09/08/2023 15:17:39 [info] Stopping Node-RED
[AGENT] 09/08/2023 15:17:39 [info] Stopped Node-RED
[AGENT] 09/08/2023 15:17:39 [info] Cleaning instance directory
```
* Device status on forge app shows Application and Instace _Unassigned_ 👍 
* Last Known Status shows `stopped` 👍 

2. delete active snapshot - expect device to clear its config

* On next poll, agent reports correct change  👍 
```
[AGENT] 09/08/2023 15:13:52 [info] Stopping Node-RED
[AGENT] 09/08/2023 15:13:52 [info] Stopped Node-RED
[AGENT] 09/08/2023 15:13:52 [info] Cleaning instance directory
```

## Related Issue(s)

https://github.com/flowforge/flowforge-device-agent/issues/132

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

