### PR TITLE
Remove ui-components from package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "@fastify/swagger": "^8.6.0",
                 "@fastify/swagger-ui": "^1.9.0",
                 "@fastify/websocket": "^8.1.0",
-                "@flowforge/forge-ui-components": "^0.7.0",
                 "@flowforge/localfs": "^1.10.0",
                 "@headlessui/vue": "1.7.14",
                 "@heroicons/vue": "1.0.6",
@@ -5939,18 +5938,6 @@
             "dependencies": {
                 "fastify-plugin": "^4.0.0",
                 "ws": "^8.0.0"
-            }
-        },
-        "node_modules/@flowforge/forge-ui-components": {
-            "version": "0.7.0",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.x"
-            },
-            "peerDependencies": {
-                "@heroicons/vue": "^1.0.6",
-                "marked": "^4.0.12",
-                "vue": "^3.2.21"
             }
         },
         "node_modules/@flowforge/localfs": {
@@ -27334,10 +27321,6 @@
                 "fastify-plugin": "^4.0.0",
                 "ws": "^8.0.0"
             }
-        },
-        "@flowforge/forge-ui-components": {
-            "version": "0.7.0",
-            "requires": {}
         },
         "@flowforge/localfs": {
             "version": "1.10.0",


### PR DESCRIPTION
## Description

Removes ui-components from package-lock as it is now merged into this repo and not maintained as an external module.