### PR TITLE
Removes triggering of emails to trial users

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -338,16 +338,6 @@ module.exports.init = async function (app) {
                     )
                     if (teamTrialInstanceTypeId) {
                         const trialProjectType = await app.db.models.ProjectType.byId(teamTrialInstanceTypeId)
-                        await app.postoffice.send(
-                            user,
-                            'TrialTeamCreated',
-                            {
-                                username: user.name,
-                                teamName: team.name,
-                                trialDuration: teamTrialDuration,
-                                trialProjectTypeName: trialProjectType.name
-                            }
-                        )
                     }
                 }
             }


### PR DESCRIPTION
## Description

I have removed the code which triggers emails to trial teams. The plan is to replace these with emails sent from Hubspot using the existing database integration from FF Cloud to Hubspot.

## Related Issue(s)

[<!-- What issue does this PR relate to? -->](https://github.com/flowforge/CloudProject/issues/175)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

