### PR TITLE
Move Delete Snapshot to proper part of api docs

### DIFF
--- a/forge/routes/api/projectSnapshots.js
+++ b/forge/routes/api/projectSnapshots.js
@@ -101,7 +101,7 @@ module.exports = async function (app) {
         preHandler: app.needsPermission('project:snapshot:delete'),
         schema: {
             summary: 'Delete a snapshot',
-            tags: ['Teams'],
+            tags: ['Snapshots'],
             params: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
## Description

Notice the Delete Snapshot API route was listed in the Team section of the swagger doc.

This moves it under the Snapshot section where it belongs.


Purely a docs/swagger change. Not functional changes.