### PR TITLE
Add projectComms feature flag to instance settings

### DIFF
--- a/forge/ee/lib/ha/index.js
+++ b/forge/ee/lib/ha/index.js
@@ -2,7 +2,7 @@ const { KEY_HA } = require('../../../db/models/ProjectSettings')
 
 module.exports.init = function (app) {
     if (app.config.driver.type === 'kubernetes' || app.config.driver.type === 'stub') {
-        // Register ha flag as a private flag - no requirement to expose it in public settings
+        // Register ha feature flag
         app.config.features.register('ha', true)
 
         /**
@@ -16,6 +16,10 @@ module.exports.init = function (app) {
             // For initial beta release, we will support 1-2 replicas.
             // 1 replica is equivalent to no HA
             // In the future this will need to take into account the team type
+            const teamType = await team.getTeamType()
+            if (!teamType.getFeatureProperty('ha', true)) {
+                return false
+            }
             return (haConfig.replicas > 0 && haConfig.replicas < 3)
         }
 

--- a/forge/ee/routes/ha/index.js
+++ b/forge/ee/routes/ha/index.js
@@ -14,6 +14,11 @@ module.exports = async function (app) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
+                    const teamType = await request.project.Team.getTeamType()
+                    if (!teamType.getFeatureProperty('ha', true)) {
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                        return // eslint-disable-line no-useless-return
+                    }
                     if (request.session.User) {
                         request.teamMembership = await request.session.User.getTeamMembership(request.project.Team.id)
                         if (!request.teamMembership && !request.session.User.admin) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -395,6 +395,14 @@ module.exports = async function (app) {
                 }
             }
             const newSettings = app.db.controllers.ProjectTemplate.validateSettings(bodySettings, request.project.ProjectTemplate)
+            if (newSettings.httpNodeAuth?.type === 'flowforge-user') {
+                const teamType = await request.project.Team.getTeamType()
+                if (teamType.properties.features?.teamHttpSecurity === false) {
+                    reply.code(400).send({ code: 'invalid_request', error: 'FlowForge User Authentication not available for this team type' })
+                    return
+                }
+            }
+
             // Merge the settings into the existing values
             const currentProjectSettings = await request.project.getSetting(KEY_SETTINGS) || {}
             const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -782,7 +782,8 @@ module.exports = async function (app) {
         }
         const teamType = await request.project.Team.getTeamType()
         settings.features = {
-            'shared-library': app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true)
+            'shared-library': app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true),
+            projectComms: app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true)
         }
         reply.send(settings)
     })

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -774,13 +774,14 @@ module.exports = async function (app) {
             delete settings.settings.env
         }
 
-        if (app.config.features.enabled('ha')) {
+        const teamType = await request.project.Team.getTeamType()
+
+        if (app.config.features.enabled('ha') && teamType.getFeatureProperty('ha', true)) {
             const ha = await request.project.getHASettings()
             if (ha && ha.replicas > 1) {
                 settings.ha = ha
             }
         }
-        const teamType = await request.project.Team.getTeamType()
         settings.features = {
             'shared-library': app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true),
             projectComms: app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true)

--- a/frontend/src/components/banners/FeatureUnavailableToTeam.vue
+++ b/frontend/src/components/banners/FeatureUnavailableToTeam.vue
@@ -5,7 +5,7 @@
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />
         <div>
-            This feature is not available for your current Team. Please <a class="ff-link" href="#" target="_blank" rel="noopener noreferrer">upgrade</a> your Team in order to use it.
+            {{ featureName }} is not available for your current Team. Please <a class="ff-link" href="#" target="_blank" rel="noopener noreferrer">upgrade</a> your Team in order to use it.
         </div>
         <SparklesIcon class="ff-icon ml-2" style="stroke-width: 1px;" />
     </div>
@@ -18,6 +18,12 @@ export default {
     name: 'FeatureUnavailableToTeam',
     components: {
         SparklesIcon
+    },
+    props: {
+        featureName: {
+            type: String,
+            default: 'This feature'
+        }
     }
 }
 </script>

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -73,8 +73,8 @@
                     <FormRow v-model="input.properties.features['shared-library']" type="checkbox">Team Library</FormRow>
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
-                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
-                    <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
+                    <FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
+                    <!--<FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow> -->
                 </div>
             </form>

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -72,8 +72,8 @@
                 <div class="grid gap-3 grid-cols-2">
                     <FormRow v-model="input.properties.features['shared-library']" type="checkbox">Team Library</FormRow>
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
-                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
+                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow> -->
                 </div>
@@ -149,6 +149,9 @@ export default {
                     }
                     if (this.input.properties.features.projectComms === undefined) {
                         this.input.properties.features.projectComms = true
+                    }
+                    if (this.input.properties.features.ha === undefined) {
+                        this.input.properties.features.ha = true
                     }
                 } else {
                     this.editDisabled = false

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -71,8 +71,8 @@
                 <FormHeading>Features</FormHeading>
                 <div class="grid gap-3 grid-cols-2">
                     <FormRow v-model="input.properties.features['shared-library']" type="checkbox">Team Library</FormRow>
-                    <!-- <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
-                    <FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
+                    <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
+                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow> -->
@@ -142,6 +142,14 @@ export default {
                         this.input.properties.trial.instanceType = '_'
                     }
                     this.input.order = '' + (teamType.order || 0)
+
+                    // Apply default feature values if undefined
+                    if (this.input.properties.features['shared-library'] === undefined) {
+                        this.input.properties.features['shared-library'] = true
+                    }
+                    if (this.input.properties.features.projectComms === undefined) {
+                        this.input.properties.features.projectComms = true
+                    }
                 } else {
                     this.editDisabled = false
                     this.input = {

--- a/frontend/src/pages/admin/Template/sections/Security.vue
+++ b/frontend/src/pages/admin/Template/sections/Security.vue
@@ -29,7 +29,7 @@
             </div>
             <LockSetting class="flex justify-end flex-col" :editTemplate="editTemplate" v-model="editable.policy.httpNodeAuth_pass" :changed="editable.changed.policy.httpNodeAuth_pass"></LockSetting>
         </div>
-
+        <FeatureUnavailableToTeam v-if="!ffAuthFeatureAvailable" featureName="FlowForge User Authentication" />
         <ff-radio-group v-model="editable.settings.httpNodeAuth_type" orientation="vertical" :options="authOptions2"></ff-radio-group>
     </form>
 </template>
@@ -37,11 +37,13 @@
 <script>
 import FormHeading from '../../../../components/FormHeading.vue'
 import FormRow from '../../../../components/FormRow.vue'
+import FeatureUnavailableToTeam from '../../../../components/banners/FeatureUnavailableToTeam.vue'
 import ChangeIndicator from '../components/ChangeIndicator.vue'
 import LockSetting from '../components/LockSetting.vue'
+
 export default {
     name: 'TemplateSettingsSecurity',
-    props: ['editTemplate', 'modelValue'],
+    props: ['editTemplate', 'modelValue', 'team'],
     computed: {
         editable: {
             get () {
@@ -50,6 +52,14 @@ export default {
             set (localValue) {
                 this.$emit('update:modelValue', localValue)
             }
+        },
+        ffAuthFeatureAvailable () {
+            if (!this.team) {
+                // If on the Admin Template view, then this option is available
+                return true
+            }
+            const flag = this.team.type.properties.features?.teamHttpSecurity
+            return flag === undefined || flag
         },
         authOptions1 () {
             return [
@@ -72,7 +82,7 @@ export default {
                 {
                     label: 'FlowForge User Authentication',
                     value: 'flowforge-user',
-                    disabled: !this.editTemplate && !this.editable.policy.httpNodeAuth_type,
+                    disabled: !this.ffAuthFeatureAvailable || (!this.editTemplate && !this.editable.policy.httpNodeAuth_type),
                     description: 'Only members of the application instance\'s team will be able to access the routes'
                 }
             ]
@@ -82,7 +92,8 @@ export default {
         FormRow,
         FormHeading,
         LockSetting,
-        ChangeIndicator
+        ChangeIndicator,
+        FeatureUnavailableToTeam
     }
 }
 </script>

--- a/frontend/src/pages/instance/Settings/HighAvailability.vue
+++ b/frontend/src/pages/instance/Settings/HighAvailability.vue
@@ -1,6 +1,7 @@
 <template>
     <ff-loading v-if="updating" message="Updating Instance..." />
     <template v-else>
+        <FeatureUnavailableToTeam v-if="!haFeatureAvailable" />
         <FormHeading>High Availability</FormHeading>
         <FormRow>
             <template #description>
@@ -29,20 +30,22 @@
             <template #input>&nbsp;</template>
         </FormRow>
         <template v-if="!isHA">
-            <ff-button kind="secondary" data-nav="enable-ha" @click="enableHA()">Enable HA mode</ff-button>
+            <ff-button :disabled="!haFeatureAvailable" kind="secondary" data-nav="enable-ha" @click="enableHA()">Enable HA mode</ff-button>
         </template>
         <template v-else>
-            <ff-button kind="secondary" data-nav="disable-ha" @click="disableHA()">Disable HA mode</ff-button>
+            <ff-button :disabled="!haFeatureAvailable" kind="secondary" data-nav="disable-ha" @click="disableHA()">Disable HA mode</ff-button>
         </template>
     </template>
 </template>
 
 <script>
+import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
+import FeatureUnavailableToTeam from '../../../components/banners/FeatureUnavailableToTeam.vue'
 import Alerts from '../../../services/alerts.js'
 import Dialog from '../../../services/dialog.js'
 
@@ -50,7 +53,8 @@ export default {
     name: 'InstanceSettingsStages',
     components: {
         FormHeading,
-        FormRow
+        FormRow,
+        FeatureUnavailableToTeam
     },
     inheritAttrs: false,
     props: {
@@ -66,8 +70,13 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team', 'features']),
         isHA () {
             return this.instance?.ha?.replicas !== undefined
+        },
+        haFeatureAvailable () {
+            const flag = this.team.type.properties.features?.ha
+            return flag === undefined || flag
         }
     },
     methods: {

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -1,6 +1,6 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsSecurity v-model="editable" :editTemplate="false" />
+        <TemplateSettingsSecurity v-model="editable" :editTemplate="false" :team="team" />
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save settings</ff-button>
         </div>

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -124,7 +124,8 @@ export default {
     computed: {
         ...mapState('account', ['features']),
         featureEnabledForTeam () {
-            return this.team.type.properties.features?.['shared-library']
+            const flag = this.team.type.properties.features?.['shared-library']
+            return flag === undefined || flag
         },
         featureEnabledForPlatform () {
             return this.features['shared-library']

--- a/frontend/src/ui-components/components/form/RadioGroup.vue
+++ b/frontend/src/ui-components/components/form/RadioGroup.vue
@@ -46,6 +46,9 @@ export default {
         }
     },
     watch: {
+        options: function () {
+            this.checkOptions()
+        },
         modelValue: function () {
             this.checkOptions()
         },


### PR DESCRIPTION
## Description

Part of https://github.com/flowforge/flowforge/issues/2531

This adds a flag to the TeamType to control whether the Project Nodes feature is available.

This feature isn't exposed in the frontend at all - so the only frontend change is the admin ui for enabling the feature flag for the team type.
