### PR TITLE
Add HA feature flag to team

### DIFF
--- a/forge/ee/lib/ha/index.js
+++ b/forge/ee/lib/ha/index.js
@@ -2,7 +2,7 @@ const { KEY_HA } = require('../../../db/models/ProjectSettings')
 
 module.exports.init = function (app) {
     if (app.config.driver.type === 'kubernetes' || app.config.driver.type === 'stub') {
-        // Register ha flag as a private flag - no requirement to expose it in public settings
+        // Register ha feature flag
         app.config.features.register('ha', true)
 
         /**
@@ -16,6 +16,10 @@ module.exports.init = function (app) {
             // For initial beta release, we will support 1-2 replicas.
             // 1 replica is equivalent to no HA
             // In the future this will need to take into account the team type
+            const teamType = await team.getTeamType()
+            if (!teamType.getFeatureProperty('ha', true)) {
+                return false
+            }
             return (haConfig.replicas > 0 && haConfig.replicas < 3)
         }
 

--- a/forge/ee/routes/ha/index.js
+++ b/forge/ee/routes/ha/index.js
@@ -14,6 +14,11 @@ module.exports = async function (app) {
                         reply.code(404).send({ code: 'not_found', error: 'Not Found' })
                         return
                     }
+                    const teamType = await request.project.Team.getTeamType()
+                    if (!teamType.getFeatureProperty('ha', true)) {
+                        reply.code(404).send({ code: 'not_found', error: 'Not Found' })
+                        return // eslint-disable-line no-useless-return
+                    }
                     if (request.session.User) {
                         request.teamMembership = await request.session.User.getTeamMembership(request.project.Team.id)
                         if (!request.teamMembership && !request.session.User.admin) {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -774,13 +774,14 @@ module.exports = async function (app) {
             delete settings.settings.env
         }
 
-        if (app.config.features.enabled('ha')) {
+        const teamType = await request.project.Team.getTeamType()
+
+        if (app.config.features.enabled('ha') && teamType.getFeatureProperty('ha', true)) {
             const ha = await request.project.getHASettings()
             if (ha && ha.replicas > 1) {
                 settings.ha = ha
             }
         }
-        const teamType = await request.project.Team.getTeamType()
         settings.features = {
             'shared-library': app.config.features.enabled('shared-library') && teamType.getFeatureProperty('shared-library', true),
             projectComms: app.config.features.enabled('projectComms') && teamType.getFeatureProperty('projectComms', true)

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -72,8 +72,8 @@
                 <div class="grid gap-3 grid-cols-2">
                     <FormRow v-model="input.properties.features['shared-library']" type="checkbox">Team Library</FormRow>
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
-                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
+                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
                     <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow> -->
                 </div>
@@ -149,6 +149,9 @@ export default {
                     }
                     if (this.input.properties.features.projectComms === undefined) {
                         this.input.properties.features.projectComms = true
+                    }
+                    if (this.input.properties.features.ha === undefined) {
+                        this.input.properties.features.ha = true
                     }
                 } else {
                     this.editDisabled = false

--- a/frontend/src/pages/instance/Settings/HighAvailability.vue
+++ b/frontend/src/pages/instance/Settings/HighAvailability.vue
@@ -1,6 +1,7 @@
 <template>
     <ff-loading v-if="updating" message="Updating Instance..." />
     <template v-else>
+        <FeatureUnavailableToTeam v-if="!haFeatureAvailable" />
         <FormHeading>High Availability</FormHeading>
         <FormRow>
             <template #description>
@@ -29,20 +30,22 @@
             <template #input>&nbsp;</template>
         </FormRow>
         <template v-if="!isHA">
-            <ff-button kind="secondary" data-nav="enable-ha" @click="enableHA()">Enable HA mode</ff-button>
+            <ff-button :disabled="!haFeatureAvailable" kind="secondary" data-nav="enable-ha" @click="enableHA()">Enable HA mode</ff-button>
         </template>
         <template v-else>
-            <ff-button kind="secondary" data-nav="disable-ha" @click="disableHA()">Disable HA mode</ff-button>
+            <ff-button :disabled="!haFeatureAvailable" kind="secondary" data-nav="disable-ha" @click="disableHA()">Disable HA mode</ff-button>
         </template>
     </template>
 </template>
 
 <script>
+import { mapState } from 'vuex'
 
 import InstanceApi from '../../../api/instances.js'
 
 import FormHeading from '../../../components/FormHeading.vue'
 import FormRow from '../../../components/FormRow.vue'
+import FeatureUnavailableToTeam from '../../../components/banners/FeatureUnavailableToTeam.vue'
 import Alerts from '../../../services/alerts.js'
 import Dialog from '../../../services/dialog.js'
 
@@ -50,7 +53,8 @@ export default {
     name: 'InstanceSettingsStages',
     components: {
         FormHeading,
-        FormRow
+        FormRow,
+        FeatureUnavailableToTeam
     },
     inheritAttrs: false,
     props: {
@@ -66,8 +70,13 @@ export default {
         }
     },
     computed: {
+        ...mapState('account', ['team', 'features']),
         isHA () {
             return this.instance?.ha?.replicas !== undefined
+        },
+        haFeatureAvailable () {
+            const flag = this.team.type.properties.features?.ha
+            return flag === undefined || flag
         }
     },
     methods: {

--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -124,7 +124,8 @@ export default {
     computed: {
         ...mapState('account', ['features']),
         featureEnabledForTeam () {
-            return this.team.type.properties.features?.['shared-library']
+            const flag = this.team.type.properties.features?.['shared-library']
+            return flag === undefined || flag
         },
         featureEnabledForPlatform () {
             return this.features['shared-library']


### PR DESCRIPTION
## Description

Part of https://github.com/flowforge/flowforge/issues/2531

This adds a flag to the TeamType to control whether the HA feature is available.

In the UI, if a team does not have access to HA they see this:

<img width="950" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/02ecd605-a9f2-40a8-a251-5f85d621998a">

As with #2599, the link to upgrade your team doesn't yet go anywhere.

Unlike the other feature flags, no changes are needed in the launcher as we can use this the flag to inhibit the existing `ha` config object from being passed down to the launcher.
