### PR TITLE
Allow admin to change sso_enabled users email

### DIFF
--- a/forge/routes/api/shared/users.js
+++ b/forge/routes/api/shared/users.js
@@ -71,8 +71,8 @@ module.exports = {
             }
             if (request.body.email && user.email !== request.body.email) {
                 // SSO cannot change email address
-                if (user.sso_enabled) {
-                    const err = new Error('Cannot change password for sso-enabled user')
+                if (user.sso_enabled && !isAdmin) {
+                    const err = new Error('Cannot change email for sso-enabled user')
                     err.code = 'invalid_request'
                     throw err
                 }
@@ -94,6 +94,11 @@ module.exports = {
                     pendingEmailChange = true
                 } else {
                     user.email = request.body.email
+                    if (user.sso_enabled && isAdmin) {
+                        // Clear the sso flag on the user as they might not be sso_enabled
+                        // for this new email
+                        user.sso_enabled = false
+                    }
                 }
             }
             if (request.body.username) {

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -26,6 +26,7 @@ describe('Users API', async function () {
         // elvis <-- this user doesn't have email_verified
 
         // fred <-- this user only gets created in the 'delete' tests. Do not add elsewhere
+        // harry sso_enabled <-- added in the sso test - do not add elsewhere
 
         // ATeam ( alice  (owner), bob (owner), chris)
         // BTeam ( bob (owner), chris, dave)
@@ -330,6 +331,25 @@ describe('Users API', async function () {
                 response.statusCode.should.equal(401)
                 const result = response.json()
                 result.should.have.property('error')
+            })
+            it.only('admin can modify sso_enabled user email', async function () {
+                const harry = await app.db.models.User.create({ username: 'harry', name: 'Harry Palpatine', email: 'harry@example.com', email_verified: true, password: 'hhPassword', sso_enabled: true })
+                const response = await app.inject({
+                    method: 'PUT',
+                    url: `/api/v1/users/${harry.hashid}`,
+                    payload: {
+                        email: 'harry2@example.com'
+                    },
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+                response.statusCode.should.equal(200)
+                const result = response.json()
+                result.should.have.property('email', 'harry2@example.com')
+
+                await harry.reload()
+                harry.sso_enabled.should.be.false()
+
+                await harry.destroy()
             })
         })
     })

--- a/test/unit/forge/routes/api/users_spec.js
+++ b/test/unit/forge/routes/api/users_spec.js
@@ -332,7 +332,7 @@ describe('Users API', async function () {
                 const result = response.json()
                 result.should.have.property('error')
             })
-            it.only('admin can modify sso_enabled user email', async function () {
+            it('admin can modify sso_enabled user email', async function () {
                 const harry = await app.db.models.User.create({ username: 'harry', name: 'Harry Palpatine', email: 'harry@example.com', email_verified: true, password: 'hhPassword', sso_enabled: true })
                 const response = await app.inject({
                     method: 'PUT',


### PR DESCRIPTION
## Description

This allows an admin user to modify the email of an sso_enabled user.

As part of doing this, it will clear the sso_enabled flag on the user - as their new email may no longer be covered by an existing sso configuration. The flag will get re-set the next time they log in via sso with the new email.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
