### PR TITLE
Add team-type feature flag on ff-auth for http endpoints

### DIFF
--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -395,6 +395,14 @@ module.exports = async function (app) {
                 }
             }
             const newSettings = app.db.controllers.ProjectTemplate.validateSettings(bodySettings, request.project.ProjectTemplate)
+            if (newSettings.httpNodeAuth?.type === 'flowforge-user') {
+                const teamType = await request.project.Team.getTeamType()
+                if (teamType.properties.features?.teamHttpSecurity === false) {
+                    reply.code(400).send({ code: 'invalid_request', error: 'FlowForge User Authentication not available for this team type' })
+                    return
+                }
+            }
+
             // Merge the settings into the existing values
             const currentProjectSettings = await request.project.getSetting(KEY_SETTINGS) || {}
             const updatedSettings = app.db.controllers.ProjectTemplate.mergeSettings(currentProjectSettings, newSettings)

--- a/frontend/src/components/banners/FeatureUnavailableToTeam.vue
+++ b/frontend/src/components/banners/FeatureUnavailableToTeam.vue
@@ -5,7 +5,7 @@
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />
         <div>
-            This feature is not available for your current Team. Please <a class="ff-link" href="#" target="_blank" rel="noopener noreferrer">upgrade</a> your Team in order to use it.
+            {{ featureName }} is not available for your current Team. Please <a class="ff-link" href="#" target="_blank" rel="noopener noreferrer">upgrade</a> your Team in order to use it.
         </div>
         <SparklesIcon class="ff-icon ml-2" style="stroke-width: 1px;" />
     </div>
@@ -18,6 +18,12 @@ export default {
     name: 'FeatureUnavailableToTeam',
     components: {
         SparklesIcon
+    },
+    props: {
+        featureName: {
+            type: String,
+            default: 'This feature'
+        }
     }
 }
 </script>

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -73,8 +73,8 @@
                     <FormRow v-model="input.properties.features['shared-library']" type="checkbox">Team Library</FormRow>
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
-                    <!--<FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
-                    <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
+                    <FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
+                    <!--<FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
                     <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow> -->
                 </div>
             </form>

--- a/frontend/src/pages/admin/Template/sections/Security.vue
+++ b/frontend/src/pages/admin/Template/sections/Security.vue
@@ -29,7 +29,7 @@
             </div>
             <LockSetting class="flex justify-end flex-col" :editTemplate="editTemplate" v-model="editable.policy.httpNodeAuth_pass" :changed="editable.changed.policy.httpNodeAuth_pass"></LockSetting>
         </div>
-
+        <FeatureUnavailableToTeam v-if="!ffAuthFeatureAvailable" featureName="FlowForge User Authentication" />
         <ff-radio-group v-model="editable.settings.httpNodeAuth_type" orientation="vertical" :options="authOptions2"></ff-radio-group>
     </form>
 </template>
@@ -37,11 +37,13 @@
 <script>
 import FormHeading from '../../../../components/FormHeading.vue'
 import FormRow from '../../../../components/FormRow.vue'
+import FeatureUnavailableToTeam from '../../../../components/banners/FeatureUnavailableToTeam.vue'
 import ChangeIndicator from '../components/ChangeIndicator.vue'
 import LockSetting from '../components/LockSetting.vue'
+
 export default {
     name: 'TemplateSettingsSecurity',
-    props: ['editTemplate', 'modelValue'],
+    props: ['editTemplate', 'modelValue', 'team'],
     computed: {
         editable: {
             get () {
@@ -50,6 +52,14 @@ export default {
             set (localValue) {
                 this.$emit('update:modelValue', localValue)
             }
+        },
+        ffAuthFeatureAvailable () {
+            if (!this.team) {
+                // If on the Admin Template view, then this option is available
+                return true
+            }
+            const flag = this.team.type.properties.features?.teamHttpSecurity
+            return flag === undefined || flag
         },
         authOptions1 () {
             return [
@@ -72,7 +82,7 @@ export default {
                 {
                     label: 'FlowForge User Authentication',
                     value: 'flowforge-user',
-                    disabled: !this.editTemplate && !this.editable.policy.httpNodeAuth_type,
+                    disabled: !this.ffAuthFeatureAvailable || (!this.editTemplate && !this.editable.policy.httpNodeAuth_type),
                     description: 'Only members of the application instance\'s team will be able to access the routes'
                 }
             ]
@@ -82,7 +92,8 @@ export default {
         FormRow,
         FormHeading,
         LockSetting,
-        ChangeIndicator
+        ChangeIndicator,
+        FeatureUnavailableToTeam
     }
 }
 </script>

--- a/frontend/src/pages/instance/Settings/Security.vue
+++ b/frontend/src/pages/instance/Settings/Security.vue
@@ -1,6 +1,6 @@
 <template>
     <form class="space-y-6">
-        <TemplateSettingsSecurity v-model="editable" :editTemplate="false" />
+        <TemplateSettingsSecurity v-model="editable" :editTemplate="false" :team="team" />
         <div class="space-x-4 whitespace-nowrap">
             <ff-button size="small" :disabled="!unsavedChanges" @click="saveSettings()">Save settings</ff-button>
         </div>

--- a/frontend/src/ui-components/components/form/RadioGroup.vue
+++ b/frontend/src/ui-components/components/form/RadioGroup.vue
@@ -46,6 +46,9 @@ export default {
         }
     },
     watch: {
+        options: function () {
+            this.checkOptions()
+        },
         modelValue: function () {
             this.checkOptions()
         },


### PR DESCRIPTION
## Description

Part of https://github.com/flowforge/flowforge/issues/2531

This adds a flag to the TeamType to control whether the FF Team auth option is available.

In the UI, if a team does not have access to the option they see this:

<img width="1144" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/1f0bb87f-713b-470f-879b-9031dca36e9f">

Notes:

 - Includes a fix ff-radio-group to address https://github.com/flowforge/forge-ui-components/issues/117 that is required for this feature
 - The banner has been updated so we can include the feature name in the text of the banner. Helpful when it applies to one option on the page, rather than the whole page. Not 100% on using the banner like this, but it will do for now.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

