### PR TITLE
Update v-slot syntax and remove lint exception

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -536,49 +536,6 @@
                 "frontend/src/pages/team/Settings/index.vue",
                 "frontend/src/pages/team/Settings/Permissions.vue"
             ]
-        },
-        {
-            "rules": {
-                "vue/v-slot-style": "off"
-            },
-            "files": [
-                "frontend/src/components/audit-log/AuditLog.vue",
-                "frontend/src/components/PageHeader.vue",
-                "frontend/src/components/SectionTopMenu.vue",
-                "frontend/src/components/TeamSelection.vue",
-                "frontend/src/pages/account/Create.vue",
-                "frontend/src/pages/account/index.vue",
-                "frontend/src/pages/account/Teams/Invitations.vue",
-                "frontend/src/pages/account/Teams/Teams.vue",
-                "frontend/src/pages/admin/index.vue",
-                "frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue",
-                "frontend/src/pages/admin/InstanceTypes/index.vue",
-                "frontend/src/pages/admin/Settings/SSO/createEditProvider.vue",
-                "frontend/src/pages/admin/Settings/SSO/index.vue",
-                "frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue",
-                "frontend/src/pages/admin/Stacks/index.vue",
-                "frontend/src/pages/admin/Templates/index.vue",
-                "frontend/src/pages/admin/Users/createUser.vue",
-                "frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue",
-                "frontend/src/pages/admin/Users/General.vue",
-                "frontend/src/pages/admin/Users/Invitations.vue",
-                "frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue",
-                "frontend/src/pages/setup/CreateAdminUser.vue",
-                "frontend/src/pages/setup/Options.vue",
-                "frontend/src/pages/team/create.vue",
-                "frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue",
-                "frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue",
-                "frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue",
-                "frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue",
-                "frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue",
-                "frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue",
-                "frontend/src/pages/team/dialogs/InviteMemberDialog.vue",
-                "frontend/src/pages/team/Members/General.vue",
-                "frontend/src/pages/team/Members/Invitations.vue",
-                "frontend/src/pages/team/Overview.vue",
-                "frontend/src/pages/team/Settings/Devices.vue",
-                "frontend/src/pages/team/Settings/Permissions.vue"
-            ]
         }
     ]
 }

--- a/frontend/src/components/PageHeader.vue
+++ b/frontend/src/components/PageHeader.vue
@@ -39,14 +39,14 @@
             <ff-team-selection data-action="team-selection" />
             <!-- Desktop: User Options -->
             <ff-dropdown v-if="user" class="ff-navigation ff-user-options" options-align="right" data-action="user-options" data-cy="user-options">
-                <template v-slot:placeholder>
+                <template #placeholder>
                     <div class="ff-user">
                         <img :src="user.avatar" class="ff-avatar"/>
                         <ff-notification-pill v-if="notifications.total > 0" data-el="notification-pill" class="ml-3" :count="notifications.total"/>
                         <!-- <label>{{ user.name }}</label> -->
                     </div>
                 </template>
-                <template v-slot:default>
+                <template #default>
                     <ff-dropdown-option v-for="option in options" :key="option.label" @click="option.onclick(option.onclickparams)">
                         <nav-item :label="option.label" :icon="option.icon" :notifications="option.notifications" :data-nav="option.tag"></nav-item>
                     </ff-dropdown-option>

--- a/frontend/src/components/SectionTopMenu.vue
+++ b/frontend/src/components/SectionTopMenu.vue
@@ -23,13 +23,13 @@
         </ul>
     </div>
     <ff-dialog v-if="hasInfoDialog" ref="help-dialog" class="ff-dialog-box--info" :header="helpHeader || 'FlowForge Info'">
-        <template v-slot:default>
+        <template #default>
             <div class="flex gap-8">
                 <slot name="pictogram"><img src="../images/pictograms/node_catalog_red.png"/></slot>
                 <div><slot name="helptext"></slot></div>
             </div>
         </template>
-        <template v-slot:actions>
+        <template #actions>
             <ff-button @click="$refs['help-dialog'].close()">Close</ff-button>
         </template>
     </ff-dialog>

--- a/frontend/src/components/TeamSelection.vue
+++ b/frontend/src/components/TeamSelection.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dropdown v-if="team" class="ff-team-selection">
-        <template v-slot:placeholder>
+        <template #placeholder>
             <div class="flex grow items-center">
                 <img :src="team.avatar" class="ff-avatar"/>
                 <div class="ff-team-selection-name">
@@ -9,7 +9,7 @@
                 </div>
             </div>
         </template>
-        <template v-slot:default>
+        <template #default>
             <ul class="ff-dropdown-option-list">
                 <ff-dropdown-option>
                     <nav-item v-for="t in teams" :key="t.id" :label="t.name" :avatar="t?.avatar" @click="selectTeam(t)" data-action="switch-team"></nav-item>

--- a/frontend/src/components/audit-log/AuditLog.vue
+++ b/frontend/src/components/audit-log/AuditLog.vue
@@ -4,10 +4,10 @@
         No Activity Found
     </div>
     <ff-accordion v-for="(logEntries, date, $index) in logEntriesByDate" :key="date" :label="date" :set-open="$index < 3" data-el="accordion" :disabled="disableAccordion">
-        <template v-slot:meta>
+        <template #meta>
             <span>{{ logEntries.length }} Event{{ logEntries.length === 1 ? '' : 's' }}</span>
         </template>
-        <template v-slot:content>
+        <template #content>
             <div v-for="entry in logEntries" :key="entry.id">
                 <AuditEntry :entry="entry"></AuditEntry>
             </div>

--- a/frontend/src/pages/account/Create.vue
+++ b/frontend/src/pages/account/Create.vue
@@ -2,7 +2,7 @@
 
 <template>
     <ff-layout-box class="ff-signup">
-        <template v-slot:splash-content v-if="splash">
+        <template #splash-content v-if="splash">
             <div v-html="splash" data-el="splash"></div>
         </template>
         <form v-if="!emailSent && !ssoCreated" class="max-w-md m-auto">

--- a/frontend/src/pages/account/Teams/Invitations.vue
+++ b/frontend/src/pages/account/Teams/Invitations.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="space-y-6">
         <ff-data-table data-el="table" :columns="inviteColumns" :rows="invitations">
-            <template v-slot:context-menu="{row}">
+            <template #context-menu="{row}">
                 <ff-list-item data-action="accept" label="Accept" @click="acceptInvite(row)"/>
                 <ff-list-item data-action="reject" label="Reject" kind="danger" @click="rejectInvite(row)"/>
             </template>

--- a/frontend/src/pages/account/Teams/Teams.vue
+++ b/frontend/src/pages/account/Teams/Teams.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="text-right mb-4" v-if="settings['team:create']"><CreateTeamButton /></div>
     <ff-data-table :columns="columns" :rows="teams">
-        <template v-slot:context-menu="{row}">
+        <template #context-menu="{row}">
             <ff-list-item data-action="member-remove-from-team" label="Leave Team" kind="danger" @click="removeUserDialog(row)" />
         </template>
     </ff-data-table>

--- a/frontend/src/pages/account/index.vue
+++ b/frontend/src/pages/account/index.vue
@@ -1,18 +1,18 @@
 <template>
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
-            <template v-slot:options>
+            <template #options>
                 <li class="ff-navigation-divider">User Settings</li>
                 <router-link v-for="route in navigation" :key="route.label" :to="route.path" :data-nav="route.tag">
                     <nav-item :icon="route.icon" :label="route.name" :notifications="route.notifications"></nav-item>
                 </router-link>
             </template>
-            <template v-slot:back v-if="team">
+            <template #back v-if="team">
                 <router-link :to="{name: 'Team', params: {team_slug: team.slug}}" data-nav="team-overview">
                     <nav-item :icon="icons.chevronLeft" label="Back to Dashboard"></nav-item>
                 </router-link>
             </template>
-            <template v-slot:back v-else>
+            <template #back v-else>
                 <router-link :to="{name: 'CreateTeam'}" data-nav="create-team">
                     <nav-item :icon="icons.chevronLeft" label="Back to Create Team"></nav-item>
                 </router-link>

--- a/frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue
+++ b/frontend/src/pages/admin/InstanceTypes/dialogs/InstanceTypeEditDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" :header="dialogTitle">
-        <template v-slot:default>
+        <template #default>
             <form class="space-y-6 mt-2" @submit.prevent>
                 <FormRow v-model="input.name" :error="errors.name" data-form="name">Name</FormRow>
                 <FormRow v-model="input.active" type="checkbox" data-form="active">Active</FormRow>
@@ -23,7 +23,7 @@
                 </FormRow>
             </form>
         </template>
-        <template v-slot:actions>
+        <template #actions>
             <div class="w-full grow flex justify-between">
                 <div>
                     <ff-button v-if="instanceType" kind="danger" style="margin: 0;" @click="$emit('show-delete-dialog', instanceType); $refs.dialog.close()">Delete Instance Type</ff-button>

--- a/frontend/src/pages/admin/InstanceTypes/index.vue
+++ b/frontend/src/pages/admin/InstanceTypes/index.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="space-y-6">
         <SectionTopMenu hero="Instance Types">
-            <template v-slot:tools>
+            <template #tools>
                 <ff-button @click="showCreateInstanceTypeDialog" data-action="create-type">
-                    <template v-slot:icon-right>
+                    <template #icon-right>
                         <PlusSmIcon />
                     </template>
                     Create instance type
@@ -25,7 +25,7 @@
         </div>
         <SectionTopMenu hero="Inactive Types"></SectionTopMenu>
         <ff-data-table :columns="columns" :rows="inactiveInstanceTypes" data-el="inactive-types">
-            <template v-slot:context-menu="{row}">
+            <template #context-menu="{row}">
                 <ff-list-item label="Edit Instance Type" @click="instanceTypeAction('edit', row.id)"/>
                 <ff-list-item label="Delete Instance Type" kind="danger" @click="instanceTypeAction('delete', row.id)"/>
             </template>

--- a/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
+++ b/frontend/src/pages/admin/Settings/SSO/createEditProvider.vue
@@ -1,7 +1,7 @@
 <template>
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
-            <template v-slot:back>
+            <template #back>
                 <router-link :to="{name: 'AdminSettingsSSO'}">
                     <nav-item :icon="icons.chevronLeft" label="Back to SSO"></nav-item>
                 </router-link>
@@ -19,7 +19,7 @@
                 </FormRow>
                 <FormRow v-model="input.domainFilter" :error="errors.domainFilter" placeholder="@example.com">
                     Email Domain
-                    <template v-slot:description>The email domain this provider should be used for.</template>
+                    <template #description>The email domain this provider should be used for.</template>
                 </FormRow>
                 <ff-button v-if="isCreate" :disabled="!formValid" @click="createProvider()">
                     Create configuration
@@ -29,15 +29,15 @@
                     <FormRow v-model="provider.entityID" type="uneditable">Entity ID / Issuer</FormRow>
                     <FormRow v-model="input.options.entryPoint">
                         Identity Provider Single Sign-On URL
-                        <template v-slot:description>Supplied by your Identity Provider</template>
+                        <template #description>Supplied by your Identity Provider</template>
                     </FormRow>
                     <FormRow v-model="input.options.idpIssuer">
                         Identity Provider Issuer ID / URL
-                        <template v-slot:description>Supplied by your Identity Provider</template>
+                        <template #description>Supplied by your Identity Provider</template>
                     </FormRow>
                     <FormRow v-model="input.options.cert">
                         X.509 Certificate Public Key
-                        <template v-slot:description>Supplied by your Identity Provider</template>
+                        <template #description>Supplied by your Identity Provider</template>
                         <template #input><textarea class="font-mono w-full" placeholder="---BEGIN CERTIFICATE---&#10;loremipsumdolorsitamet&#10;consecteturadipiscinge&#10;---END CERTIFICATE---&#10;" rows="6" v-model="input.options.cert"></textarea></template>
                     </FormRow>
                     <FormRow v-model="input.active" type="checkbox">Active</FormRow>

--- a/frontend/src/pages/admin/Settings/SSO/index.vue
+++ b/frontend/src/pages/admin/Settings/SSO/index.vue
@@ -8,15 +8,15 @@
         @row-selected="providerSelected"
         :show-search="true"
     >
-        <template v-slot:actions>
+        <template #actions>
             <ff-button :to="{ name: 'AdminSettingsSSOEdit', params: { id: 'create' } }">
-                <template v-slot:icon-right>
+                <template #icon-right>
                     <PlusSmIcon />
                 </template>
                 Create SSO SAML Configuration
             </ff-button>
         </template>
-        <template v-slot:context-menu="{row}">
+        <template #context-menu="{row}">
             <ff-list-item label="Edit Properties" @click.stop="providerSelected(row)"/>
             <ff-list-item label="Delete SAML Configuration" kind="danger" @click.stop="deleteProvider(row)"/>
         </template>

--- a/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
+++ b/frontend/src/pages/admin/Stacks/dialogs/AdminStackEditDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" :header="dialogTitle" :confirm-label="stack ? 'Save' : 'Create'" @confirm="confirm()" :disable-primary="!formValid || loading">
-        <template v-slot:default>
+        <template #default>
             <ff-loading v-if="loading" message="Creating Stack..."/>
             <form v-else class="space-y-6" @submit.prevent>
                 <div v-if="input.replaces">
@@ -10,17 +10,17 @@
                 </div>
                 <FormRow v-model="input.name" :error="errors.name" :disabled="editDisabled">
                     Name
-                    <template v-slot:description>An internal name for the stack. This must be unique and can only contain a-z 0-9 - _ / @ .</template>
+                    <template #description>An internal name for the stack. This must be unique and can only contain a-z 0-9 - _ / @ .</template>
                 </FormRow>
                 <FormRow v-model="input.label" :error="errors.label">
                     Label
-                    <template v-slot:description>This is how the stack is shown to users.</template>
+                    <template #description>This is how the stack is shown to users.</template>
                 </FormRow>
                 <FormRow v-model="input.active" type="checkbox">Active</FormRow>
                 <template v-if="!editDisabled">
                     <FormRow :options="instanceTypes" :disabled="editTypeDisabled" :error="errors.projectType" v-model="input.projectType" id="projectType">
                         Instance Type
-                        <template v-slot:description>
+                        <template #description>
                             <div v-if="editTypeDisabled">Stacks cannot be moved to a different instance type</div>
                             <div v-else-if="stack && !stack.projectType">You can assign this stack to an instance type as a one-time action. Once assigned you cannot move it.</div>
                         </template>

--- a/frontend/src/pages/admin/Stacks/index.vue
+++ b/frontend/src/pages/admin/Stacks/index.vue
@@ -11,15 +11,15 @@
             search-placeholder="Search by Stack Name..."
             no-data-message="No Active Stacks Found"
         >
-            <template v-slot:actions>
+            <template #actions>
                 <ff-button @click="showCreateStackDialog">
-                    <template v-slot:icon-right>
+                    <template #icon-right>
                         <PlusSmIcon />
                     </template>
                     Create stack
                 </ff-button>
             </template>
-            <template v-slot:context-menu="{row}">
+            <template #context-menu="{row}">
                 <ff-list-item label="Create New Version" @click="stackAction('createNewVersion', row.id)"/>
                 <ff-list-item label="Edit Properties" @click="stackAction('editProperties', row.id)"/>
                 <ff-list-item label="Delete Stack" kind="danger" @click="stackAction('delete', row.id)"/>
@@ -39,7 +39,7 @@
             search-placeholder="Search by Stack Name..."
             no-data-message="No Inactive Stacks Found"
         >
-            <template v-slot:context-menu="{row}">
+            <template #context-menu="{row}">
                 <ff-list-item label="Create New Version" @click="stackAction('createNewVersion', row.id)"/>
                 <ff-list-item label="Edit Properties" @click="stackAction('editProperties', row.id)"/>
                 <ff-list-item label="Delete Stack" kind="danger" @click="stackAction('delete', row.id)"/>

--- a/frontend/src/pages/admin/Templates/index.vue
+++ b/frontend/src/pages/admin/Templates/index.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="space-y-6">
         <SectionTopMenu hero="Templates">
-            <template v-slot:tools>
+            <template #tools>
                 <ff-button :to="{ name: 'Admin Template', params: { id: 'create' } }">
-                    <template v-slot:icon-right>
+                    <template #icon-right>
                         <PlusSmIcon />
                     </template>
                     Create template
@@ -22,7 +22,7 @@
             :rows-selectable="true"
             @row-selected="editTemplate"
         >
-            <template v-slot:context-menu="{row}">
+            <template #context-menu="{row}">
                 <ff-list-item label="Edit Template" @click.stop="editTemplate(row)"/>
                 <ff-list-item label="Delete Template" kind="danger" @click.stop="showDeleteDialog(row)"/>
             </template>

--- a/frontend/src/pages/admin/Users/General.vue
+++ b/frontend/src/pages/admin/Users/General.vue
@@ -13,15 +13,15 @@
             no-data-message="No Users Found"
             :rows-selectable="true" @row-selected="showUser"
         >
-            <template v-slot:actions>
+            <template #actions>
                 <ff-button to="./create">
-                    <template v-slot:icon-left>
+                    <template #icon-left>
                         <UserAddIcon />
                     </template>
                     Create New User
                 </ff-button>
             </template>
-            <template v-slot:context-menu="{row}">
+            <template #context-menu="{row}">
                 <ff-list-item label="Edit User" @click.stop="showEditUserDialog(row)"></ff-list-item>
             </template>
         </ff-data-table>

--- a/frontend/src/pages/admin/Users/Invitations.vue
+++ b/frontend/src/pages/admin/Users/Invitations.vue
@@ -3,7 +3,7 @@
         <div class="space-y-6">
             <div class="text-right"></div>
             <ff-data-table :columns="inviteColumns" :rows="invitations" :show-search="true" search-placeholder="Search Invites...">
-                <template v-slot:context-menu="{row}">
+                <template #context-menu="{row}">
                     <ff-list-item label="Remove Invite" kind="danger" @click="removeInvite(row)"/>
                 </template>
             </ff-data-table>

--- a/frontend/src/pages/admin/Users/createUser.vue
+++ b/frontend/src/pages/admin/Users/createUser.vue
@@ -1,7 +1,7 @@
 <template>
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
-            <template v-slot:back>
+            <template #back>
                 <router-link :to="{name: 'AdminUsersGeneral'}">
                     <nav-item :icon="icons.chevronLeft" label="Back to Users"></nav-item>
                 </router-link>
@@ -21,7 +21,7 @@
                 <FormHeading>Team options</FormHeading>
                 <FormRow id="createDefaultTeam" v-model="input.createDefaultTeam" type="checkbox">
                     Create personal team
-                    <template v-slot:description>A user needs to be in a team to create projects</template>
+                    <template #description>A user needs to be in a team to create projects</template>
                 </FormRow>
                 <!-- <FormRow v-model="input.addToTeam">Add to existing team</FormRow> -->
                 <ff-button :disabled="!formValid" @click="createUser()">

--- a/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
+++ b/frontend/src/pages/admin/Users/dialogs/AdminUserEditDialog.vue
@@ -1,21 +1,21 @@
 <template>
     <ff-dialog ref="dialog" header="Edit User" confirm-label="Save" @confirm="confirm()" :closeOnConfirm="false" :disable-primary="disableSave">
-        <template v-slot:default>
+        <template #default>
             <form class="space-y-6" @submit.prevent>
                 <FormRow v-model="input.username" :error="errors.username">Username</FormRow>
                 <FormRow v-model="input.name" :placeholder="input.username">Name</FormRow>
                 <FormRow v-model="input.email" :error="errors.email">
                     Email
-                    <template v-slot:description v-if="user.sso_enabled">
+                    <template #description v-if="user.sso_enabled">
                         <div>SSO is enabled for this user.</div>
                     </template>
                 </FormRow>
                 <FormRow id="email_verified" wrapperClass="flex justify-between items-center" :disabled="email_verifiedLocked" v-model="input.email_verified" type="checkbox">
                     Verified
-                    <template v-slot:append>
+                    <template #append>
                         <ff-button v-if="email_verifiedLocked" kind="danger" size="small" @click="unlockEmailVerify()">
                             Unlock
-                            <template v-slot:icon>
+                            <template #icon>
                                 <LockClosedIcon />
                             </template>
                         </ff-button>
@@ -23,10 +23,10 @@
                 </FormRow>
                 <FormRow id="admin" :error="errors.admin" wrapperClass="flex justify-between items-center" :disabled="adminLocked" v-model="input.admin" type="checkbox">
                     Administrator
-                    <template v-slot:append>
+                    <template #append>
                         <ff-button v-if="adminLocked" kind="danger" size="small" @click="unlockAdmin()">
                             Unlock
-                            <template v-slot:icon>
+                            <template #icon>
                                 <LockClosedIcon />
                             </template>
                         </ff-button>
@@ -34,10 +34,10 @@
                 </FormRow>
                 <FormRow id="user_suspended" wrapperClass="flex justify-between items-center" :disabled="user_suspendedLocked" v-model="input.user_suspended" type="checkbox">
                     Suspended
-                    <template v-slot:append>
+                    <template #append>
                         <ff-button v-if="user_suspendedLocked" kind="danger" size="small" @click="unlockSuspended()">
                             Unlock
-                            <template v-slot:icon>
+                            <template #icon>
                                 <LockClosedIcon />
                             </template>
                         </ff-button>
@@ -50,7 +50,7 @@
                             <ff-button :disabled="expirePassLocked" :kind="expirePassLocked?'secondary':'danger'" @click="expirePassword">Expire password</ff-button>
                             <ff-button v-if="expirePassLocked" kind="danger" size="small" @click="unlockExpirePassword()">
                                 Unlock
-                                <template v-slot:icon>
+                                <template #icon>
                                     <LockClosedIcon />
                                 </template>
                             </ff-button>
@@ -63,7 +63,7 @@
                             <ff-button :disabled="deleteLocked" :kind="deleteLocked?'secondary':'danger'" @click="deleteUser">Delete user</ff-button>
                             <ff-button v-if="deleteLocked" kind="danger" size="small" @click="unlockDelete()">
                                 Unlock
-                                <template v-slot:icon>
+                                <template #icon>
                                     <LockClosedIcon />
                                 </template>
                             </ff-button>

--- a/frontend/src/pages/admin/index.vue
+++ b/frontend/src/pages/admin/index.vue
@@ -1,18 +1,18 @@
 <template>
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation>
-            <template v-slot:options>
+            <template #options>
                 <li class="ff-navigation-divider">Admin Settings</li>
                 <router-link v-for="route in navigation" :key="route.label" :to="route.path">
                     <nav-item :icon="route.icon" :label="route.name" :data-nav="route.tag"></nav-item>
                 </router-link>
             </template>
-            <template v-slot:back v-if="team">
+            <template #back v-if="team">
                 <router-link :to="{name: 'Team', params: {team_slug: team.slug}}">
                     <nav-item :icon="icons.chevronLeft" label="Back to Dashboard" data-nav="team-overview"></nav-item>
                 </router-link>
             </template>
-            <template v-slot:back v-else>
+            <template #back v-else>
                 <router-link :to="{name: 'CreateTeam'}">
                     <nav-item :icon="icons.chevronLeft" label="Back to Create Team" data-nav="create-team"></nav-item>
                 </router-link>

--- a/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
+++ b/frontend/src/pages/device/Settings/dialogs/ConfirmDeviceDeleteDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" header="Delete Device" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
-        <template v-slot:default>
+        <template #default>
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
                     <p>

--- a/frontend/src/pages/setup/CreateAdminUser.vue
+++ b/frontend/src/pages/setup/CreateAdminUser.vue
@@ -4,20 +4,20 @@
         <template v-if="!state.adminUser">
             <FormRow v-model="input.username" :error="errors.username">
                 Username
-                <template v-slot:description>Unique, short, no spaces. Cannot be 'admin' or 'root'</template>
+                <template #description>Unique, short, no spaces. Cannot be 'admin' or 'root'</template>
             </FormRow>
             <FormRow v-model="input.name" :placeholder="input.username">
                 Full Name
             </FormRow>
             <FormRow v-model="input.email" :error="errors.email">
                 Email
-                <template v-if="!state.email" v-slot:description>
+                <template v-if="!state.email" #description>
                     <div class="text-red-400">Email has not be configured. This will limit available features, such as inviting users to the platform. Check the documentation for how to configure email before running this setup.</div>
                 </template>
             </FormRow>
             <FormRow type="password" :error="errors.password" v-model="input.password" id="password" :onBlur="checkPassword" >
                 Password
-                <template v-slot:description>At least 8 characters</template>
+                <template #description>At least 8 characters</template>
             </FormRow>
             <FormRow type="password" :error="errors.password_confirm" v-model="input.password_confirm" id="password_confirm">Confirm Password</FormRow>
             <ff-button :disabled="!formValid" @click="createUser()" class="mt-6">

--- a/frontend/src/pages/setup/Options.vue
+++ b/frontend/src/pages/setup/Options.vue
@@ -3,7 +3,7 @@
         <FormHeading>3. Options</FormHeading>
         <FormRow v-model="input.telemetry" type="checkbox">
             Enable collection of anonymous statistics
-            <template v-slot:description>
+            <template #description>
                 <p>
                     We collect anonymous statistics about how FlowForge is used.
                     This allows us to improve how it works and make a better product.

--- a/frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/CreateProvisioningTokenDialog.vue
@@ -6,7 +6,7 @@
         @confirm="confirm()"
         :disable-primary="!formValid"
     >
-        <template v-slot:default>
+        <template #default>
             <p>This will generate a <code>device.yml</code> to move to your device, that will auto register with this team.</p>
             <form class="space-y-6 mt-2 mb-2">
                 <FormRow data-form="token-name" v-model="input.name" :error="errors.name" :disabled="editMode">Token Name</FormRow>

--- a/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/DeviceCredentialsDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" header="Device Configuration">
-        <template v-slot:default>
+        <template #default>
             <form class="text-gray-800">
                 <template v-if="!hasCredentials">
                     <p>
@@ -30,14 +30,14 @@
                 </template>
             </form>
         </template>
-        <template v-slot:actions>
+        <template #actions>
             <template v-if="!hasCredentials">
                 <ff-button kind="secondary" @click="close()">Cancel</ff-button>
                 <ff-button kind="danger" class="ml-4" @click="regenerateCredentials()">Regenerate configuration</ff-button>
             </template>
             <template v-else>
                 <ff-button v-if="clipboardSupported" kind="secondary" @click="copy()">Copy to Clipboard</ff-button>
-                <ff-button kind="secondary" @click="downloadCredentials()"><template v-slot:icon-left><DocumentDownloadIcon /></template>Download device-{{ device.id }}.yml</ff-button>
+                <ff-button kind="secondary" @click="downloadCredentials()"><template #icon-left><DocumentDownloadIcon /></template>Download device-{{ device.id }}.yml</ff-button>
                 <ff-button class="ml-4" @click="close()">Done</ff-button>
             </template>
         </template>

--- a/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
+++ b/frontend/src/pages/team/Devices/dialogs/ProvisioningCredentialsDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" header="Device Provisioning Configuration">
-        <template v-slot:default>
+        <template #default>
             <form class="space-y-6 mt-2">
                 <p class="text-sm text-gray-500">
                     To auto provision your devices on the platform, use the following
@@ -10,9 +10,9 @@
                 <pre class="overflow-auto text-sm p-4 border rounded bg-gray-800 text-gray-200">{{ configuration }}</pre>
             </form>
         </template>
-        <template v-slot:actions>
+        <template #actions>
             <ff-button v-if="!!clipboardSupported" kind="secondary" @click="copy()">Copy to Clipboard</ff-button>
-            <ff-button kind="secondary" @click="downloadCredentials()"><template v-slot:icon-left><DocumentDownloadIcon /></template>Download device.yml</ff-button>
+            <ff-button kind="secondary" @click="downloadCredentials()"><template #icon-left><DocumentDownloadIcon /></template>Download device.yml</ff-button>
             <ff-button class="ml-4" @click="close()">Done</ff-button>
         </template>
     </ff-dialog>

--- a/frontend/src/pages/team/Members/General.vue
+++ b/frontend/src/pages/team/Members/General.vue
@@ -3,13 +3,13 @@
     <form v-else class="mb-8">
         <div class="text-right"></div>
         <ff-data-table data-el="members-table" :columns="userColumns" :rows="users" :show-search="true" search-placeholder="Search Team Members..." :search-fields="['name', 'username', 'role']">
-            <template v-if="hasPermission('team:user:invite')" v-slot:actions>
+            <template v-if="hasPermission('team:user:invite')" #actions>
                 <ff-button data-action="member-invite-button" kind="primary" @click="inviteMember">
-                    <template v-slot:icon-left><PlusSmIcon class="w-4" /></template>
+                    <template #icon-left><PlusSmIcon class="w-4" /></template>
                     Invite Member
                 </ff-button>
             </template>
-            <template v-if="canEditUser" v-slot:context-menu="{row}">
+            <template v-if="canEditUser" #context-menu="{row}">
                 <ff-list-item v-if="hasPermission('team:user:change-role')" data-action="member-change-role" label="Change Role" @click="changeRoleDialog(row)" />
                 <ff-list-item v-if="hasPermission('team:user:remove')" data-action="member-remove-from-team" label="Remove From Team" kind="danger" @click="removeUserDialog(row)" />
             </template>

--- a/frontend/src/pages/team/Members/Invitations.vue
+++ b/frontend/src/pages/team/Members/Invitations.vue
@@ -4,7 +4,7 @@
         <form v-else class="space-y-6">
             <div class="text-right"></div>
             <ff-data-table data-el="invites-table" :columns="inviteColumns" :rows="invitations">
-                <template v-slot:context-menu="{row}">
+                <template #context-menu="{row}">
                     <ff-list-item data-action="remove-invite" label="Remove Invite" kind="danger" @click="removeInvite(row)" />
                 </template>
             </ff-data-table>

--- a/frontend/src/pages/team/Settings/Devices.vue
+++ b/frontend/src/pages/team/Settings/Devices.vue
@@ -1,6 +1,6 @@
 <template>
     <SectionTopMenu hero="Device Provisioning" help-header="Device Provisioning Tokens" info="A list of device provisioning tokens that can be used to auto register devices to a team.">
-        <template v-slot:helptext>
+        <template #helptext>
             <p>FlowForge can be used to manage instances of Node-RED running on remote devices.</p>
             <p>Each device must run the <a href="https://flowforge.com/docs/user/devices/" target="_blank">FlowForge Device Agent</a>, which connects back to the platform to receive updates.</p>
             <p>Provisioning tokens can be created to allow devices to automatically connect to a team, application and instance without having to register them first.</p>
@@ -35,7 +35,7 @@
                         Add Token
                     </ff-button>
                 </template>
-                <template v-if="editEnabled || deleteEnabled" v-slot:context-menu="{row}">
+                <template v-if="editEnabled || deleteEnabled" #context-menu="{row}">
                     <ff-list-item :disabled="!editEnabled" label="Edit Details" @click="menuAction('edit', row.id)"/>
                     <ff-list-item :disabled="!deleteEnabled" kind="danger" label="Delete Token" @click="menuAction('delete', row.id)" />
                 </template>

--- a/frontend/src/pages/team/Settings/Permissions.vue
+++ b/frontend/src/pages/team/Settings/Permissions.vue
@@ -3,7 +3,7 @@
         <FormHeading>Application Creation</FormHeading>
         <FormRow v-model="input.teamName" id="teamName" type="checkbox">
             Limit application creation
-            <template v-slot:description>
+            <template #description>
             </template>
         </FormRow>
     </form>

--- a/frontend/src/pages/team/create.vue
+++ b/frontend/src/pages/team/create.vue
@@ -1,7 +1,7 @@
 <template>
     <Teleport v-if="mounted" to="#platform-sidenav">
         <SideNavigation v-if="team">
-            <template v-slot:back>
+            <template #back>
                 <router-link :to="{name: 'Home'}">
                     <nav-item :icon="icons.chevronLeft" label="Back to Dashboard"></nav-item>
                 </router-link>
@@ -29,14 +29,14 @@
                 </div>
                 <FormRow v-model="input.name" id="team" :error="errors.name">
                     Team Name
-                    <template v-slot:description>
+                    <template #description>
                         eg. 'Development'
                     </template>
                 </FormRow>
 
                 <FormRow v-model="input.slug" id="team" :error="input.slugError" :placeholder="input.defaultSlug">
                     URL Slug
-                    <template v-slot:description>
+                    <template #description>
                         Use the default slug based on the team name or set your own.<br/>
                         <pre>/team/&lt;slug&gt;</pre>
                     </template>
@@ -47,7 +47,7 @@
                         <p>To create the team we need to setup payment details via Stripe, our secure payment provider.</p>
                     </div>
                     <ff-button :disabled="!formValid" @click="createTeam()">
-                        <template v-slot:icon-right><ExternalLinkIcon /></template>
+                        <template #icon-right><ExternalLinkIcon /></template>
                         Create team and setup payment details
                     </ff-button>
                 </template>

--- a/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
+++ b/frontend/src/pages/team/dialogs/ChangeTeamRoleDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" header="Change Role" confirm-label="Change" @confirm="confirm()" :disable-primary="ownerCount < 2 && isOwner">
-        <template v-slot:default v-if="user">
+        <template #default v-if="user">
             <form class="space-y-6" @submit.prevent>
                 <div class="space-y-2">
                     <template v-if="ownerCount < 2 && isOwner">

--- a/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamDeleteDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" data-el="delete-team-dialog" header="Delete Team" kind="danger" confirm-label="Delete" @confirm="confirm()" :disable-primary="!formValid">
-        <template v-slot:default>
+        <template #default>
             <form class="space-y-6" v-if="team" @submit.prevent>
                 <div class="space-y-6">
                     <p>

--- a/frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue
+++ b/frontend/src/pages/team/dialogs/ConfirmTeamUserRemoveDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" header="Remove User" kind="danger" confirm-label="Remove" @confirm="confirm()" :disable-primary="disableConfirm">
-        <template v-slot:default v-if="user">
+        <template #default v-if="user">
             <form class="space-y-6" @submit.prevent>
                 <div class="mt-2 space-y-2">
                     <template v-if="ownerCount < 2 && user.role === 'owner'">

--- a/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
+++ b/frontend/src/pages/team/dialogs/InviteMemberDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <ff-dialog ref="dialog" header="Invite Team Member" confirm-label="Invite" @confirm="confirm()" :disable-primary="disableConfirm">
-        <template v-slot:default>
+        <template #default>
             <form class="space-y-2" @submit.prevent>
                 <template v-if="!responseErrors">
                     <p v-if="!exceedsUserLimit">Invite a user to join the team by username<span v-if="externalEnabled"> or email</span>.</p>


### PR DESCRIPTION
## Description

Removes the v-slot-style linting exception. All instances of `v-slot:foo` replaced with `#foo`.

Changes made by search/replace and then eyeballed to make sure all looks okay. 