### PR TITLE
Run tests if package-lock changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - 'test/e2e/frontend/**'
       - 'test/unit/frontend/**'
       - 'package.json'
+      - 'package-lock.json'
       - '.eslintrc'
   pull_request:
     paths:

--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -14,6 +14,7 @@ on:
       - 'test/unit/**'
       - 'test/system/**'
       - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/test-postgresql.yml'
 
 jobs:

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -11,6 +11,7 @@ on:
       - 'test/e2e/frontend/**'
       - 'test/unit/frontend/**'
       - 'package.json'
+      - 'package-lock.json'
       - '.eslintrc'
   pull_request:
     paths:
@@ -21,6 +22,7 @@ on:
       - 'test/e2e/frontend/**'
       - 'test/unit/frontend/**'
       - 'package.json'
+      - 'package-lock.json'
       - '.eslintrc'
 
 jobs:


### PR DESCRIPTION
## Description

I noted https://github.com/flowforge/flowforge/pull/2603/files ran no tests.

Tests should run if the package-lock is changed.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

