### PR TITLE
Support for changing team type

### DIFF
--- a/forge/auditLog/team.js
+++ b/forge/auditLog/team.js
@@ -39,6 +39,11 @@ module.exports = {
                     await log('team.user.role-changed', actionedBy, team?.id, generateBody({ error, user, updates }))
                 }
             },
+            type: {
+                async changed (actionedBy, error, team, info) {
+                    await log('team.type.changed', actionedBy, team.id, generateBody({ error, team, info }))
+                }
+            },
             settings: {
                 async updated (actionedBy, error, team, updates) {
                     await log('team.settings.updated', actionedBy, team?.id, generateBody({ error, team, updates }))

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -354,6 +354,81 @@ module.exports = {
                  */
                 checkInstanceStartAllowed: async function (instance) {
                     return true
+                },
+
+                /**
+                 * Checks whether the team type can be modified to the requested type.
+                 * The team must be within any limits of the target type.
+                 */
+                checkTeamTypeUpdateAllowed: async function (teamType) {
+                    // console.log(teamType.properties)
+                    await this.ensureTeamTypeExists()
+
+                    // Check the following limits:
+                    // - User count
+                    // - Device count
+                    // - Instance Type counts
+                    const errors = []
+
+                    const currentMemberCount = this.get('memberCount')
+                    const targetMemberLimit = teamType.getProperty('users.limit', -1)
+                    if (targetMemberLimit !== -1 && targetMemberLimit < currentMemberCount) {
+                        errors.push({
+                            code: 'member_limit_reached',
+                            error: 'Member limit reached',
+                            limit: targetMemberLimit,
+                            count: currentMemberCount
+                        })
+                    }
+
+                    const currentDeviceCount = await this.deviceCount()
+                    const targetDeviceLimit = teamType.getProperty('devices.limit', -1)
+                    if (targetDeviceLimit !== -1 && targetDeviceLimit < currentDeviceCount) {
+                        errors.push({
+                            code: 'device_limit_reached',
+                            error: 'Device limit reached',
+                            limit: targetDeviceLimit,
+                            count: currentDeviceCount
+                        })
+                    }
+
+                    const currentInstanceCountsByType = await this.instanceCountByType()
+                    // console.log(currentInstanceCountsByType)
+                    const targetInstanceLimits = {}
+                    for (const instanceType of Object.keys(currentInstanceCountsByType)) {
+                        // console.log('checking', instanceType, teamType.properties.instances[instanceType])
+                        if (!teamType.getInstanceTypeProperty(instanceType, 'active', false)) {
+                            targetInstanceLimits[instanceType] = 0
+                        } else {
+                            targetInstanceLimits[instanceType] = teamType.getInstanceTypeProperty(instanceType, 'limit', -1)
+                        }
+                        if (targetInstanceLimits[instanceType] !== -1 && targetInstanceLimits[instanceType] < currentInstanceCountsByType[instanceType]) {
+                            errors.push({
+                                code: 'instance_limit_reached',
+                                error: `Instance type ${instanceType} limit reached`,
+                                type: instanceType,
+                                limit: targetInstanceLimits[instanceType],
+                                count: currentInstanceCountsByType[instanceType]
+                            })
+                        }
+                    }
+                    if (errors.length > 0) {
+                        const message = errors.map(err => `${err.error} (current: ${err.count}, limit: ${err.limit})`).join(', ')
+                        const err = new Error(`Unable to change team type: ${message}`)
+                        err.code = 'invalid_request'
+                        err.errors = errors
+                        throw err
+                    }
+                    // console.log(`members: ${currentMemberCount} / ${targetMemberLimit}`)
+                    // console.log(`devices: ${currentDeviceCount} / ${targetDeviceLimit}`)
+                    // for (const instanceType of Object.keys(currentInstanceCountsByType)) {
+                    //     console.log(`instance[${instanceType}] ${currentInstanceCountsByType[instanceType]} / ${targetInstanceLimits[instanceType]}`)
+                    // }
+                },
+                updateTeamType: async function (teamType) {
+                    await this.setTeamType(teamType)
+                    await this.save()
+                    await this.reload({ include: [{ model: M.TeamType }] })
                 }
             }
         }

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -370,7 +370,7 @@ module.exports = {
                     // - Instance Type counts
                     const errors = []
 
-                    const currentMemberCount = this.get('memberCount')
+                    const currentMemberCount = await this.memberCount()
                     const targetMemberLimit = teamType.getProperty('users.limit', -1)
                     if (targetMemberLimit !== -1 && targetMemberLimit < currentMemberCount) {
                         errors.push({

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -361,7 +361,6 @@ module.exports = {
                  * The team must be within any limits of the target type.
                  */
                 checkTeamTypeUpdateAllowed: async function (teamType) {
-                    // console.log(teamType.properties)
                     await this.ensureTeamTypeExists()
 
                     // Check the following limits:
@@ -393,10 +392,8 @@ module.exports = {
                     }
 
                     const currentInstanceCountsByType = await this.instanceCountByType()
-                    // console.log(currentInstanceCountsByType)
                     const targetInstanceLimits = {}
                     for (const instanceType of Object.keys(currentInstanceCountsByType)) {
-                        // console.log('checking', instanceType, teamType.properties.instances[instanceType])
                         if (!teamType.getInstanceTypeProperty(instanceType, 'active', false)) {
                             targetInstanceLimits[instanceType] = 0
                         } else {
@@ -419,11 +416,6 @@ module.exports = {
                         err.errors = errors
                         throw err
                     }
-                    // console.log(`members: ${currentMemberCount} / ${targetMemberLimit}`)
-                    // console.log(`devices: ${currentDeviceCount} / ${targetDeviceLimit}`)
-                    // for (const instanceType of Object.keys(currentInstanceCountsByType)) {
-                    //     console.log(`instance[${instanceType}] ${currentInstanceCountsByType[instanceType]} / ${targetInstanceLimits[instanceType]}`)
-                    // }
                 },
                 /**
                  * Update the team type.

--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -425,6 +425,12 @@ module.exports = {
                     //     console.log(`instance[${instanceType}] ${currentInstanceCountsByType[instanceType]} / ${targetInstanceLimits[instanceType]}`)
                     // }
                 },
+                /**
+                 * Update the team type.
+                 *
+                 * When running with EE, this function is replaced via ee/lib/billing/Team.js
+                 * to add additional checks related to billing
+                 */
                 updateTeamType: async function (teamType) {
                     await this.setTeamType(teamType)
                     await this.save()

--- a/forge/ee/lib/billing/Team.js
+++ b/forge/ee/lib/billing/Team.js
@@ -168,10 +168,16 @@ module.exports = function (app) {
     }
 
     app.db.models.Team.prototype._updateTeamType = app.db.models.Team.prototype.updateTeamType
+    /**
+     * Updates the team type, taking billing into account.
+     */
     app.db.models.Team.prototype.updateTeamType = async function (teamType) {
+        // Update the subscription on stripe
         await app.billing.updateTeamType(this, teamType)
+        // Update the team type on the model using the CE version of this function
         await this._updateTeamType(teamType)
-        // Resync the device count
+        // Update the device/instance count items on stripe with the new billing
+        // details
         await app.billing.updateTeamDeviceCount(this)
         await app.billing.updateTeamInstanceCount(this)
     }

--- a/forge/ee/lib/billing/TeamType.js
+++ b/forge/ee/lib/billing/TeamType.js
@@ -1,0 +1,92 @@
+/**
+ * Augments the TeamType model will billing-specific instance functions
+ * @param {*} app
+ */
+module.exports = function (app) {
+    /**
+     * Get the Stripe product/price ids for the team type.
+     *
+     * These are either:
+     *  - Provided via flowforge.yml.
+     *    - billing.stripe.team_* provide the default values.
+     *    - billing.stripe.teams.<type-name>.* provide type-specific values
+     *  - Provided by team.TeamType.properties.billing.*
+     *
+     * Each of these potential sources is checked, the latter taking precedence
+     * over the former.
+     *
+     * Example flowforge.yml config:
+     *   billing:
+     *     stripe:
+     *       ...
+     *       team_price: <default team price>
+     *       team_product: <default team product>
+     *       device_price: <default device price>
+     *       device_product: <default device product>
+     *       ...
+     *       teams:
+     *         starter:
+     *           price: <starter team price>
+     *           product: <starter team product>
+     * @returns object
+     */
+    app.db.models.TeamType.prototype.getTeamBillingIds = async function () {
+        // Billing ids can come from the following sources, in order of precedence
+        //  - TeamType properties
+        //  - flowforge.yml - teamType specific config
+        //  - flowforge.yml - default config
+        const defaults = {
+            price: app.config.billing?.stripe?.teams?.[this.name]?.price || app.config.billing?.stripe?.team_price,
+            product: app.config.billing?.stripe?.teams?.[this.name]?.product || app.config.billing?.stripe?.team_product
+        }
+        const result = {
+            price: this.getProperty('billing.priceId', defaults.price),
+            product: this.getProperty('billing.productId', defaults.product)
+        }
+        const trialProduct = this.getProperty('trial.productId')
+        const trialPrice = this.getProperty('trial.priceId')
+        if (trialProduct && trialPrice) {
+            result.trialProduct = trialProduct
+            result.trialPrice = trialPrice
+        }
+        return result
+    }
+
+    /**
+     * Get billing details for devices in the team type
+     * @returns object
+     */
+    app.db.models.TeamType.prototype.getDeviceBillingIds = async function () {
+        // Billing ids can come from the following sources, in order of precedence
+        //  - TeamType properties
+        //  - flowforge.yml - default config
+        const defaults = {
+            price: app.config.billing?.stripe?.device_price,
+            product: app.config.billing?.stripe?.device_product
+        }
+        return {
+            price: this.getProperty('devices.priceId', defaults.price),
+            product: this.getProperty('devices.productId', defaults.product)
+        }
+    }
+
+    /**
+     * Get billing details for a particular instanceType in this team type
+     * @param {ProjectType} instanceType
+     * @returns object
+     */
+    app.db.models.TeamType.prototype.getInstanceBillingIds = async function (instanceType) {
+        // Billing ids can come from the following sources, in order of precedence
+        //  - TeamType properties
+        //  - InstanceType properties
+        //  - flowforge.yml - default config
+        const defaults = {
+            price: instanceType.properties.billingPriceId || app.config.billing?.stripe?.project_price,
+            product: instanceType.properties.billingProductId || app.config.billing?.stripe?.project_product
+        }
+        return {
+            price: this.getInstanceTypeProperty(instanceType, 'priceId', defaults.price),
+            product: this.getInstanceTypeProperty(instanceType, 'productId', defaults.product)
+        }
+    }
+}

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -22,6 +22,7 @@ module.exports.init = async function (app) {
 
     // Augment the Team model with billing functions
     require('./Team')(app)
+    require('./TeamType')(app)
 
     /**
      * Convert a user-friendly promo code to its api id, if valid.

--- a/forge/routes/api-docs.js
+++ b/forge/routes/api-docs.js
@@ -125,7 +125,8 @@ module.exports = fp(async function (app, opts, done) {
         type: 'object',
         properties: {
             code: { type: 'string' },
-            error: { type: 'string' }
+            error: { type: 'string' },
+            errors: { type: 'array', items: { type: 'object', additionalProperties: true } }
         }
     })
     app.addSchema({

--- a/forge/routes/api/team.js
+++ b/forge/routes/api/team.js
@@ -578,7 +578,12 @@ module.exports = async function (app) {
                 code: err.code || 'unexpected_error',
                 error: err.toString()
             }
-            if (err.errors) {
+            if (/SequelizeUniqueConstraintError/.test(response.error)) {
+                if (err.errors) {
+                    // This is an error from sequelize - reformat the message to be more helpful
+                    response.error = err.errors.map(e => e.message).join(', ')
+                }
+            } else if (err.errors) {
                 response.errors = err.errors
             }
             reply.code(400).send(response)

--- a/frontend/src/components/audit-log/AuditEntryIcon.vue
+++ b/frontend/src/components/audit-log/AuditEntryIcon.vue
@@ -108,7 +108,8 @@ const iconMap = {
         'platform.settings.updated',
         'platform.settings.update',
         'team.settings.updated',
-        'project.settings.updated'
+        'project.settings.updated',
+        'team.type.changed'
     ],
     'user-profile': [
         'account.register',

--- a/frontend/src/components/audit-log/AuditEntryVerbose.vue
+++ b/frontend/src/components/audit-log/AuditEntryVerbose.vue
@@ -59,6 +59,14 @@
         <span v-else-if="!error">Updates not found in audit entry.</span>
     </template>
 
+    <!-- Team Type Events -->
+    <template v-else-if="entry.event === 'team.type.changed'">
+        <label>{{ AuditEvents[entry.event] }}</label>
+        <!-- <span v-if="!error && entry.body?.updates">The team type changed from '{{ entry.body.updates.typeName?.old || entry.body.updates.type.old }}' to '{{ entry.body.updates.typeName?.new || entry.body.updates.type.new }}'.</span> -->
+        <span v-if="!error && entry.body?.info">The team type changed from '{{ entry.body.info.old.name }}' to '{{ entry.body.info.new.name }}'.</span>
+        <span v-else-if="!error">Details not found in audit entry.</span>
+    </template>
+
     <!-- Team Device Developer Mode -->
     <template v-else-if="entry.event === 'team.device.developer-mode.enabled'">
         <label>{{ AuditEvents[entry.event] }}</label>

--- a/frontend/src/components/banners/FeatureUnavailableToTeam.vue
+++ b/frontend/src/components/banners/FeatureUnavailableToTeam.vue
@@ -5,7 +5,7 @@
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />
         <div>
-            {{ featureName }} is not available for your current Team. Please <a class="ff-link" href="#" target="_blank" rel="noopener noreferrer">upgrade</a> your Team in order to use it.
+            {{ featureName }} is not available for your current Team. Please <a class="ff-link" href="#" @click="navigateToUpgrade">upgrade</a> your Team in order to use it.
         </div>
         <SparklesIcon class="ff-icon ml-2" style="stroke-width: 1px;" />
     </div>
@@ -13,6 +13,8 @@
 
 <script>
 import { SparklesIcon } from '@heroicons/vue/outline'
+
+import { mapState } from 'vuex'
 
 export default {
     name: 'FeatureUnavailableToTeam',
@@ -23,6 +25,17 @@ export default {
         featureName: {
             type: String,
             default: 'This feature'
+        }
+    },
+    computed: {
+        ...mapState('account', ['team']),
+        upgradePath () {
+            return '/team/' + this.team.slug + '/settings/change-type'
+        }
+    },
+    methods: {
+        navigateToUpgrade () {
+            this.$router.push(this.upgradePath)
         }
     }
 }

--- a/frontend/src/data/audit-events.json
+++ b/frontend/src/data/audit-events.json
@@ -10,6 +10,7 @@
         "team.user.invite.rejected": "User Invite Rejected",
         "team.user.role-changed": "User Role Modified",
         "team.settings.updated": "Team Settings Updated",
+        "team.type.changed": "Team Type Changed",
         "team.device.created": "New Device Created",
         "team.device.deleted": "Device Deleted",
         "team.device.updated": "Device Updated",

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -1,9 +1,22 @@
 <template>
     <div class="space-y-6">
+        <template v-if="teamTypes.length > 1">
+            <FormHeading>Change Team Type</FormHeading>
+            <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+                <div class="flex-grow">
+                    <div class="max-w-sm pr-2">{{ deleteDescription }}</div>
+                </div>
+                <div class="min-w-fit flex-shrink-0">
+                    <ff-button data-action="change-team-type" :to="{name: 'TeamChangeType'}">Change Team Type</ff-button>
+                </div>
+            </div>
+        </template>
         <FormHeading class="text-red-700">Delete Team</FormHeading>
-        <div>
-            <div class="max-w-sm pr-2">{{deleteDescription}}</div>
-            <div class="mt-2">
+        <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
+            <div class="flex-grow">
+                <div class="max-w-sm pr-2">{{ deleteDescription }}</div>
+            </div>
+            <div class="min-w-fit flex-shrink-0">
                 <ff-button kind="danger" data-action="delete-team" :disabled="!deleteActive" @click="showConfirmDeleteDialog()">Delete Team</ff-button>
                 <ConfirmTeamDeleteDialog @delete-team="deleteTeam" ref="confirmTeamDeleteDialog"/>
             </div>
@@ -13,8 +26,10 @@
 
 <script>
 import teamApi from '../../../api/team.js'
+import teamTypesApi from '../../../api/teamTypes.js'
 
 import FormHeading from '../../../components/FormHeading.vue'
+
 import ConfirmTeamDeleteDialog from '../dialogs/ConfirmTeamDeleteDialog.vue'
 
 export default {
@@ -22,7 +37,8 @@ export default {
     props: ['team'],
     data () {
         return {
-            applicationCount: -1
+            applicationCount: -1,
+            teamTypes: []
         }
     },
     computed: {
@@ -39,6 +55,11 @@ export default {
     },
     watch: {
         team: 'fetchData'
+    },
+    async created () {
+        const teamTypesPromise = await teamTypesApi.getTeamTypes()
+
+        this.teamTypes = (await teamTypesPromise).types
     },
     mounted () {
         this.fetchData()

--- a/frontend/src/pages/team/Settings/Danger.vue
+++ b/frontend/src/pages/team/Settings/Danger.vue
@@ -4,7 +4,7 @@
             <FormHeading>Change Team Type</FormHeading>
             <div class="flex flex-col space-y-4 max-w-2xl lg:flex-row lg:items-center lg:space-y-0">
                 <div class="flex-grow">
-                    <div class="max-w-sm pr-2">{{ deleteDescription }}</div>
+                    <div class="max-w-sm pr-2">Change to a different team type</div>
                 </div>
                 <div class="min-w-fit flex-shrink-0">
                     <ff-button data-action="change-team-type" :to="{name: 'TeamChangeType'}">Change Team Type</ff-button>

--- a/frontend/src/pages/team/Settings/General.vue
+++ b/frontend/src/pages/team/Settings/General.vue
@@ -15,7 +15,6 @@
                 <template v-if="editing">
                     Click <router-link :to="{name: 'TeamChangeType'}">here</router-link> to change the team type
                 </template>
-                <!-- <ff-button v-if="editing" size="small" :to="{name: 'TeamChangeType'}">Change</ff-button> -->
             </template>
         </FormRow>
         <FormRow v-model="input.slug" :type="editing ? 'text' : 'uneditable'" :error="errors.slug" id="teamSlug">

--- a/frontend/src/pages/team/Settings/General.vue
+++ b/frontend/src/pages/team/Settings/General.vue
@@ -12,7 +12,10 @@
         <FormRow v-model="input.teamType" type="uneditable">
             <template #default>Type</template>
             <template #description>
-                <div v-if="editing">You cannot currently change the type of team</div>
+                <template v-if="editing">
+                    Click <router-link :to="{name: 'TeamChangeType'}">here</router-link> to change the team type
+                </template>
+                <!-- <ff-button v-if="editing" size="small" :to="{name: 'TeamChangeType'}">Change</ff-button> -->
             </template>
         </FormRow>
         <FormRow v-model="input.slug" :type="editing ? 'text' : 'uneditable'" :error="errors.slug" id="teamSlug">

--- a/frontend/src/pages/team/changeType.vue
+++ b/frontend/src/pages/team/changeType.vue
@@ -1,0 +1,129 @@
+<template>
+    <Teleport v-if="mounted" to="#platform-sidenav">
+        <SideNavigation>
+            <template #options>
+                <a @click="$router.back()">
+                    <nav-item
+                        :icon="icons.chevronLeft"
+                        label="Back"
+                    />
+                </a>
+            </template>
+        </SideNavigation>
+    </Teleport>
+    <ff-page>
+        <ff-loading v-if="loading" message="Updating Team..." />
+        <div v-else class="max-w-2xl m-auto">
+            <form class="space-y-6">
+                <FormHeading>Change your team type</FormHeading>
+                <!-- TeamType Type -->
+                <div class="flex flex-wrap gap-1 items-stretch">
+                    <ff-tile-selection v-model="input.teamTypeId">
+                        <ff-tile-selection-option
+                            v-for="(teamType, index) in teamTypes" :key="index"
+                            :label="teamType.name" :description="teamType.description"
+                            :price="billingEnabled ? teamType.billingPrice : ''"
+                            :price-interval="billingEnabled ? teamType.billingInterval : ''"
+                            :value="teamType.id"
+                        />
+                    </ff-tile-selection>
+                </div>
+                <template v-if="billingEnabled">
+                    <div class="mb-8 text-sm text-gray-500 space-y-2">
+                        <p>Changing the team type will modify your subscription</p>
+                    </div>
+                </template>
+                <ff-button :disabled="!formValid" @click="updateTeam()">
+                    Change team type
+                </ff-button>
+            </form>
+        </div>
+    </ff-page>
+</template>
+
+<script>
+import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { mapState } from 'vuex'
+
+import teamApi from '../../api/team.js'
+import teamTypesApi from '../../api/teamTypes.js'
+import FormHeading from '../../components/FormHeading.vue'
+
+import NavItem from '../../components/NavItem.vue'
+import SideNavigation from '../../components/SideNavigation.vue'
+import Alerts from '../../services/alerts.js'
+
+export default {
+    name: 'ChangeTeamType',
+    components: {
+        FormHeading,
+        SideNavigation,
+        NavItem
+    },
+    data () {
+        return {
+            mounted: false,
+            loading: false,
+            redirecting: false,
+            teamTypes: [],
+            icons: {
+                chevronLeft: ChevronLeftIcon
+            },
+            input: {
+                teamTypeId: '',
+                teamType: null
+            }
+        }
+    },
+    computed: {
+        ...mapState('account', ['user', 'team', 'features']),
+        formValid () {
+            return this.input.teamTypeId && this.input.teamTypeId !== this.team.type.id
+        },
+        billingEnabled () {
+            return this.features.billing
+        }
+    },
+    watch: {
+        'input.teamTypeId': function (v) {
+            if (v) {
+                this.input.teamType = this.teamTypes.find(tt => tt.id === v)
+            } else {
+                this.input.teamType = null
+            }
+        }
+    },
+    async created () {
+        const teamTypesPromise = await teamTypesApi.getTeamTypes()
+
+        this.teamTypes = (await teamTypesPromise).types.map(teamType => {
+            if (teamType.id === this.team.type.id) {
+                teamType.name = `${teamType.name} (current)`
+            }
+            return teamType
+        })
+        this.input.teamTypeId = this.team.type.id
+    },
+    mounted () {
+        this.mounted = true
+    },
+    methods: {
+        updateTeam () {
+            this.loading = true
+
+            const opts = {
+                type: this.input.teamTypeId
+            }
+            teamApi.updateTeam(this.team.id, opts).then(async result => {
+                await this.$store.dispatch('account/refreshTeams')
+                await this.$store.dispatch('account/refreshTeam')
+                this.$router.push({ name: 'Team', params: { team_slug: result.slug } })
+            }).catch(err => {
+                Alerts.emit('Unable to change team type: ' + err.response.data.error, 'warning', 15000)
+            }).finally(() => {
+                this.loading = false
+            })
+        }
+    }
+}
+</script>

--- a/frontend/src/pages/team/routes.js
+++ b/frontend/src/pages/team/routes.js
@@ -14,11 +14,11 @@ import TeamSettingsDevices from './Settings/Devices.vue'
 import TeamSettingsGeneral from './Settings/General.vue'
 import TeamSettings from './Settings/index.vue'
 // import TeamSettingsPermissions from './Settings/Permissions.vue'
+import ChangeTeamType from './changeType.vue'
 import CreateTeam from './create.vue'
 import CreateApplication from './createApplication.vue'
 import CreateInstance from './createInstance.vue'
 
-// EE Only
 import Team from './index.vue'
 
 export default [
@@ -93,6 +93,14 @@ export default [
                 component: TeamAuditLog,
                 meta: {
                     title: 'Team - Audit Log'
+                }
+            },
+            {
+                name: 'TeamChangeType',
+                path: 'settings/change-type',
+                component: ChangeTeamType,
+                meta: {
+                    title: 'Team - Change Type'
                 }
             },
             {

--- a/test/unit/forge/routes/api/team_spec.js
+++ b/test/unit/forge/routes/api/team_spec.js
@@ -22,7 +22,7 @@ describe('Team API', function () {
         TestObjects.chris = await app.db.models.User.create({ username: 'chris', name: 'Chris Kenobi', email: 'chris@example.com', email_verified: true, password: 'ccPassword' })
 
         TestObjects.ATeam = await app.db.models.Team.byName('ATeam')
-        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', TeamTypeId: app.defaultTeamType.id })
+        TestObjects.BTeam = await app.db.models.Team.create({ name: 'BTeam', slug: 'bteam', TeamTypeId: app.defaultTeamType.id })
         TestObjects.CTeam = await app.db.models.Team.create({ name: 'CTeam abc', TeamTypeId: app.defaultTeamType.id })
         TestObjects.DTeam = await app.db.models.Team.create({ name: 'DTeAbCam', TeamTypeId: app.defaultTeamType.id })
 
@@ -67,348 +67,521 @@ describe('Team API', function () {
         }
     })
 
-    describe('Team API', function async () {
-        describe('Get team details', async function () {
-            it('admin can access any team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                response.statusCode.should.equal(200)
-                const result = response.json()
-                result.should.have.property('id', TestObjects.BTeam.hashid)
-                result.should.have.property('type')
-                result.type.should.have.property('id', app.defaultTeamType.hashid)
+    describe('Get team details', async function () {
+        it('admin can access any team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
             })
-            it('member can access team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-                response.statusCode.should.equal(200)
-                const result = response.json()
-                result.should.have.property('id', TestObjects.BTeam.hashid)
-            })
-            it('non-member cannot access team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
-                    cookies: { sid: TestObjects.tokens.chris }
-                })
-                response.statusCode.should.equal(404)
-            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id', TestObjects.BTeam.hashid)
+            result.should.have.property('type')
+            result.type.should.have.property('id', app.defaultTeamType.hashid)
         })
-
-        describe('Get team details by slug', async function () {
-            it('admin can access any team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                response.statusCode.should.equal(200)
-                const result = response.json()
-                result.should.have.property('id', TestObjects.BTeam.hashid)
+        it('member can access team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob }
             })
-            it('member can access team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-                response.statusCode.should.equal(200)
-                const result = response.json()
-                result.should.have.property('id', TestObjects.BTeam.hashid)
-            })
-            it('non-member cannot access team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
-                    cookies: { sid: TestObjects.tokens.chris }
-                })
-                response.statusCode.should.equal(404)
-            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id', TestObjects.BTeam.hashid)
         })
-
-        describe('Get list of teams', async function () {
-            // GET /api/v1/teams/:teamId
-
-            const getTeams = async (limit, cursor, search) => {
-                const query = {}
-                // app.inject will inject undefined values as the string 'undefined' rather
-                // than ignore them. So need to build-up the query object the long way
-                if (limit !== undefined) {
-                    query.limit = limit
-                }
-                if (cursor !== undefined) {
-                    query.cursor = cursor
-                }
-                if (search !== undefined) {
-                    query.query = search
-                }
-                const response = await app.inject({
-                    method: 'GET',
-                    url: '/api/v1/teams',
-                    query,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-                return response.json()
-            }
-
-            it('returns a list of all teams', async function () {
-                const result = await getTeams()
-                result.teams.should.have.length(4)
+        it('non-member cannot access team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
+                cookies: { sid: TestObjects.tokens.chris }
             })
-
-            it('can page through list', async function () {
-                const firstPage = await getTeams(2)
-                firstPage.should.have.property('meta')
-                firstPage.meta.should.have.property('next_cursor', TestObjects.BTeam.hashid)
-                firstPage.teams.should.have.length(2)
-                firstPage.teams[0].should.have.property('name', 'ATeam')
-                firstPage.teams[1].should.have.property('name', 'BTeam')
-
-                const secondPage = await getTeams(2, firstPage.meta.next_cursor)
-                secondPage.meta.should.have.property('next_cursor', TestObjects.DTeam.hashid)
-                secondPage.teams.should.have.length(2)
-                secondPage.teams[0].should.have.property('name', 'CTeam abc')
-                secondPage.teams[1].should.have.property('name', 'DTeAbCam')
-
-                const thirdPage = await getTeams(2, secondPage.meta.next_cursor)
-                thirdPage.meta.should.not.have.property('next_cursor')
-                thirdPage.teams.should.have.length(0)
-            })
-            it('can search for teams - name', async function () {
-                const firstPage = await getTeams(undefined, undefined, 'aBC')
-                firstPage.meta.should.not.have.property('next_cursor')
-                firstPage.teams.should.have.length(2)
-                firstPage.teams[0].should.have.property('name', 'CTeam abc')
-                firstPage.teams[1].should.have.property('name', 'DTeAbCam')
-            })
-        })
-
-        describe('Get list of a teams applications and their instances', async function () {
-            beforeEach(async function () {
-                TestObjects.TeamAApp = await app.db.models.Application.create({ name: 'team-a-application', TeamId: TestObjects.ATeam.id })
-                TestObjects.TeamAApp2 = await app.db.models.Application.create({ name: 'team-a-application-2', TeamId: TestObjects.ATeam.id })
-                TestObjects.TeamBApp = await app.db.models.Application.create({ name: 'team-b-application', TeamId: TestObjects.BTeam.id })
-            })
-
-            it('for an admin lists all the applications in a team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}/applications`,
-                    cookies: { sid: TestObjects.tokens.alice }
-                })
-
-                response.statusCode.should.equal(200)
-
-                // TODO Enhance test
-                const result = response.json()
-                result.should.have.property('count', 1)
-                result.should.have.property('applications').and.have.a.lengthOf(1)
-                result.applications[0].should.have.property('id', TestObjects.TeamBApp.hashid)
-                result.applications[0].should.have.property('name', 'team-b-application')
-            })
-
-            it('for an owner lists all the applications in a team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}/applications`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-
-                response.statusCode.should.equal(200)
-
-                const result = response.json()
-                result.should.have.property('count', 1)
-                result.should.have.property('applications').and.have.a.lengthOf(1)
-                should(result.applications.some((application) => application.name === 'team-b-application')).equal(true)
-            })
-
-            it('for an member lists all the applications in a team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-
-                response.statusCode.should.equal(200)
-
-                const result = response.json()
-                result.should.have.property('count', 3)
-                result.should.have.property('applications').and.have.a.lengthOf(3)
-                should(result.applications.some((application) => application.name === 'team-a-application')).equal(true)
-                should(result.applications.some((application) => application.name === 'team-a-application-2')).equal(true)
-            })
-
-            it('lists all instances within each application', async function () {
-                const secondInstance = await app.factory.createInstance({ name: 'second-instance' }, app.application, app.stack, app.template, app.projectType)
-
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-
-                response.statusCode.should.equal(200)
-
-                const result = response.json()
-                const application = result.applications.find((application) => application.name === app.application.name)
-
-                application.should.have.property('instances').and.have.a.lengthOf(2)
-
-                should(application.instances.some((instance) => instance.name === app.project.name)).equal(true)
-                should(application.instances.some((instance) => instance.name === secondInstance.name)).equal(true)
-            })
-
-            it('includes the instance URL for each accounting for httpAdminRoot', async function () {
-                const instance = await app.factory.createInstance({ name: 'another-instance' }, app.application, app.stack, app.template, app.projectType, { start: true })
-                await instance.updateSetting(KEY_SETTINGS, { httpAdminRoot: '/editor' })
-
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-
-                response.statusCode.should.equal(200)
-
-                const result = response.json()
-                const application = result.applications.find((application) => application.name === app.application.name)
-
-                application.should.have.property('instances').and.have.a.lengthOf(2)
-
-                const instanceDetails = application.instances.find((instance) => instance.name === 'another-instance')
-
-                instanceDetails.should.have.property('id', instance.id)
-                instanceDetails.should.have.property('url', 'http://another-instance.example.com/editor') // from stub driver
-            })
-
-            it('fails if a user is not member of the team', async function () {
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
-                    cookies: { sid: TestObjects.tokens.chris }
-                })
-
-                response.statusCode.should.equal(404)
-
-                const result = response.json()
-                result.should.have.property('code', 'not_found')
-                result.should.have.property('error')
-            })
-        })
-
-        describe('Get list of a teams applications, their instances and their statuses', async function () {
-            it('lists all instances within each application', async function () {
-                const secondInstance = await app.factory.createInstance({ name: 'second-instance' }, app.application, app.stack, app.template, app.projectType, { start: false })
-                const thirdInstance = await app.factory.createInstance({ name: 'third-instance' }, app.application, app.stack, app.template, app.projectType, { start: false })
-
-                // Running
-                const startResult = await app.containers.start(secondInstance)
-                await startResult.started
-
-                // Starting
-                await app.containers.start(thirdInstance)
-
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications/status`,
-                    cookies: { sid: TestObjects.tokens.bob }
-                })
-
-                response.statusCode.should.equal(200)
-
-                const result = response.json()
-                const application = result.applications.find((application) => application.id === app.application.hashid)
-
-                application.should.have.property('instances').and.have.a.lengthOf(3)
-
-                const firstInstanceStatus = application.instances.find((instance) => instance.id === app.project.id)
-                firstInstanceStatus.meta.should.have.property('state', 'unknown')
-
-                const secondInstanceStatus = application.instances.find((instance) => instance.id === secondInstance.id)
-                secondInstanceStatus.meta.should.have.property('state', 'running')
-
-                const thirdInstanceStatus = application.instances.find((instance) => instance.id === thirdInstance.id)
-                thirdInstanceStatus.meta.should.have.property('state', 'starting')
-            })
-        })
-
-        describe('Get list of a teams projects', async function () {
-            // GET /api/v1/teams/:teamId/projects
-            // - Admin/Owner/Member/project-token/device-token
-
-            it('Device can get a list of team projects', async function () {
-                // GET /api/v1/team/:teamId/devices
-                // This test is for the case where a device requests a list of projects (i.e. the project-link nodes "target" dropdown)
-                const device = await createDevice({ name: 'New device in A-Team', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/projects`,
-                    headers: {
-                        authorization: `Bearer ${device.credentials.token}`
-                    }
-                })
-                response.statusCode.should.equal(200)
-                const result = response.json()
-                result.should.have.property('projects').and.be.an.Array()
-                result.projects.should.have.a.property('length', 1)
-            })
-
-            it('Device can not get a list of team projects without a valid token', async function () {
-                // GET /api/v1/team/:teamId/devices
-                const device = await createDevice({ name: 'New device in A-Team', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/projects`,
-                    headers: {
-                        authorization: `Bearer ${device.credentials.token + 'invalid'}`
-                    }
-                })
-                response.statusCode.should.equal(401)
-            })
-
-            it('Device can not get a list of team projects for a different team', async function () {
-                // GET /api/v1/team/:teamId/devices
-                const device = await createDevice({ name: 'New device in A-Team', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
-                const response = await app.inject({
-                    method: 'GET',
-                    url: `/api/v1/teams/${TestObjects.BTeam.hashid}/projects`,
-                    headers: {
-                        authorization: `Bearer ${device.credentials.token}`
-                    }
-                })
-                response.statusCode.should.equal(404)
-            })
-        })
-
-        describe('Create team', async function () {
-            // POST /api/v1/teams
-            // - Admin/Owner/Member
-        })
-
-        describe('Delete team', async function () {
-            // DELETE /api/v1/teams/:teamId
-            // - Admin/Owner/Member
-            // - should fail if team owns projects
-        })
-
-        describe('Edit team details', async function () {
-            // PUT /api/v1/teams/:teamId
-        })
-
-        describe('Get current users membership', async function () {
-            // GET /api/v1/teams/:teamId/user
-        })
-
-        describe('Get team audit-log', async function () {
-            // GET /api/v1/teams/:teamId/audit-log
+            response.statusCode.should.equal(404)
         })
     })
+
+    describe('Get team details by slug', async function () {
+        it('admin can access any team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id', TestObjects.BTeam.hashid)
+        })
+        it('member can access team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id', TestObjects.BTeam.hashid)
+        })
+        it('non-member cannot access team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/slug/${TestObjects.BTeam.slug}`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+            response.statusCode.should.equal(404)
+        })
+    })
+
+    describe('Get list of teams', async function () {
+        // GET /api/v1/teams/:teamId
+
+        const getTeams = async (limit, cursor, search) => {
+            const query = {}
+            // app.inject will inject undefined values as the string 'undefined' rather
+            // than ignore them. So need to build-up the query object the long way
+            if (limit !== undefined) {
+                query.limit = limit
+            }
+            if (cursor !== undefined) {
+                query.cursor = cursor
+            }
+            if (search !== undefined) {
+                query.query = search
+            }
+            const response = await app.inject({
+                method: 'GET',
+                url: '/api/v1/teams',
+                query,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            return response.json()
+        }
+
+        it('returns a list of all teams', async function () {
+            const result = await getTeams()
+            result.teams.should.have.length(4)
+        })
+
+        it('can page through list', async function () {
+            const firstPage = await getTeams(2)
+            firstPage.should.have.property('meta')
+            firstPage.meta.should.have.property('next_cursor', TestObjects.BTeam.hashid)
+            firstPage.teams.should.have.length(2)
+            firstPage.teams[0].should.have.property('name', 'ATeam')
+            firstPage.teams[1].should.have.property('name', 'BTeam')
+
+            const secondPage = await getTeams(2, firstPage.meta.next_cursor)
+            secondPage.meta.should.have.property('next_cursor', TestObjects.DTeam.hashid)
+            secondPage.teams.should.have.length(2)
+            secondPage.teams[0].should.have.property('name', 'CTeam abc')
+            secondPage.teams[1].should.have.property('name', 'DTeAbCam')
+
+            const thirdPage = await getTeams(2, secondPage.meta.next_cursor)
+            thirdPage.meta.should.not.have.property('next_cursor')
+            thirdPage.teams.should.have.length(0)
+        })
+        it('can search for teams - name', async function () {
+            const firstPage = await getTeams(undefined, undefined, 'aBC')
+            firstPage.meta.should.not.have.property('next_cursor')
+            firstPage.teams.should.have.length(2)
+            firstPage.teams[0].should.have.property('name', 'CTeam abc')
+            firstPage.teams[1].should.have.property('name', 'DTeAbCam')
+        })
+    })
+
+    describe('Get list of a teams applications and their instances', async function () {
+        beforeEach(async function () {
+            TestObjects.TeamAApp = await app.db.models.Application.create({ name: 'team-a-application', TeamId: TestObjects.ATeam.id })
+            TestObjects.TeamAApp2 = await app.db.models.Application.create({ name: 'team-a-application-2', TeamId: TestObjects.ATeam.id })
+            TestObjects.TeamBApp = await app.db.models.Application.create({ name: 'team-b-application', TeamId: TestObjects.BTeam.id })
+        })
+
+        it('for an admin lists all the applications in a team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/applications`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+
+            response.statusCode.should.equal(200)
+
+            // TODO Enhance test
+            const result = response.json()
+            result.should.have.property('count', 1)
+            result.should.have.property('applications').and.have.a.lengthOf(1)
+            result.applications[0].should.have.property('id', TestObjects.TeamBApp.hashid)
+            result.applications[0].should.have.property('name', 'team-b-application')
+        })
+
+        it('for an owner lists all the applications in a team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/applications`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+
+            response.statusCode.should.equal(200)
+
+            const result = response.json()
+            result.should.have.property('count', 1)
+            result.should.have.property('applications').and.have.a.lengthOf(1)
+            should(result.applications.some((application) => application.name === 'team-b-application')).equal(true)
+        })
+
+        it('for an member lists all the applications in a team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+
+            response.statusCode.should.equal(200)
+
+            const result = response.json()
+            result.should.have.property('count', 3)
+            result.should.have.property('applications').and.have.a.lengthOf(3)
+            should(result.applications.some((application) => application.name === 'team-a-application')).equal(true)
+            should(result.applications.some((application) => application.name === 'team-a-application-2')).equal(true)
+        })
+
+        it('lists all instances within each application', async function () {
+            const secondInstance = await app.factory.createInstance({ name: 'second-instance' }, app.application, app.stack, app.template, app.projectType)
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+
+            response.statusCode.should.equal(200)
+
+            const result = response.json()
+            const application = result.applications.find((application) => application.name === app.application.name)
+
+            application.should.have.property('instances').and.have.a.lengthOf(2)
+
+            should(application.instances.some((instance) => instance.name === app.project.name)).equal(true)
+            should(application.instances.some((instance) => instance.name === secondInstance.name)).equal(true)
+        })
+
+        it('includes the instance URL for each accounting for httpAdminRoot', async function () {
+            const instance = await app.factory.createInstance({ name: 'another-instance' }, app.application, app.stack, app.template, app.projectType, { start: true })
+            await instance.updateSetting(KEY_SETTINGS, { httpAdminRoot: '/editor' })
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+
+            response.statusCode.should.equal(200)
+
+            const result = response.json()
+            const application = result.applications.find((application) => application.name === app.application.name)
+
+            application.should.have.property('instances').and.have.a.lengthOf(2)
+
+            const instanceDetails = application.instances.find((instance) => instance.name === 'another-instance')
+
+            instanceDetails.should.have.property('id', instance.id)
+            instanceDetails.should.have.property('url', 'http://another-instance.example.com/editor') // from stub driver
+        })
+
+        it('fails if a user is not member of the team', async function () {
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications`,
+                cookies: { sid: TestObjects.tokens.chris }
+            })
+
+            response.statusCode.should.equal(404)
+
+            const result = response.json()
+            result.should.have.property('code', 'not_found')
+            result.should.have.property('error')
+        })
+    })
+
+    describe('Get list of a teams applications, their instances and their statuses', async function () {
+        it('lists all instances within each application', async function () {
+            const secondInstance = await app.factory.createInstance({ name: 'second-instance' }, app.application, app.stack, app.template, app.projectType, { start: false })
+            const thirdInstance = await app.factory.createInstance({ name: 'third-instance' }, app.application, app.stack, app.template, app.projectType, { start: false })
+
+            // Running
+            const startResult = await app.containers.start(secondInstance)
+            await startResult.started
+
+            // Starting
+            await app.containers.start(thirdInstance)
+
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/applications/status`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+
+            response.statusCode.should.equal(200)
+
+            const result = response.json()
+            const application = result.applications.find((application) => application.id === app.application.hashid)
+
+            application.should.have.property('instances').and.have.a.lengthOf(3)
+
+            const firstInstanceStatus = application.instances.find((instance) => instance.id === app.project.id)
+            firstInstanceStatus.meta.should.have.property('state', 'unknown')
+
+            const secondInstanceStatus = application.instances.find((instance) => instance.id === secondInstance.id)
+            secondInstanceStatus.meta.should.have.property('state', 'running')
+
+            const thirdInstanceStatus = application.instances.find((instance) => instance.id === thirdInstance.id)
+            thirdInstanceStatus.meta.should.have.property('state', 'starting')
+        })
+    })
+
+    describe('Get list of a teams projects', async function () {
+        // GET /api/v1/teams/:teamId/projects
+        // - Admin/Owner/Member/project-token/device-token
+
+        it('Device can get a list of team projects', async function () {
+            // GET /api/v1/team/:teamId/devices
+            // This test is for the case where a device requests a list of projects (i.e. the project-link nodes "target" dropdown)
+            const device = await createDevice({ name: 'New device in A-Team', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/projects`,
+                headers: {
+                    authorization: `Bearer ${device.credentials.token}`
+                }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('projects').and.be.an.Array()
+            result.projects.should.have.a.property('length', 1)
+        })
+
+        it('Device can not get a list of team projects without a valid token', async function () {
+            // GET /api/v1/team/:teamId/devices
+            const device = await createDevice({ name: 'New device in A-Team', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.ATeam.hashid}/projects`,
+                headers: {
+                    authorization: `Bearer ${device.credentials.token + 'invalid'}`
+                }
+            })
+            response.statusCode.should.equal(401)
+        })
+
+        it('Device can not get a list of team projects for a different team', async function () {
+            // GET /api/v1/team/:teamId/devices
+            const device = await createDevice({ name: 'New device in A-Team', type: '', team: TestObjects.ATeam.hashid, as: TestObjects.tokens.alice })
+            const response = await app.inject({
+                method: 'GET',
+                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/projects`,
+                headers: {
+                    authorization: `Bearer ${device.credentials.token}`
+                }
+            })
+            response.statusCode.should.equal(404)
+        })
+    })
+
+    describe('Create team', async function () {
+        // POST /api/v1/teams
+        // - Admin/Owner/Member
+    })
+
+    describe('Delete team', async function () {
+        // DELETE /api/v1/teams/:teamId
+        // - Admin/Owner/Member
+        // - should fail if team owns projects
+        it('cannot delete team with instance', async function () {
+            const team = await app.db.models.Team.create({ name: 'delete-team-1', TeamTypeId: app.defaultTeamType.id })
+            const application = await app.factory.createApplication({ name: 'application-1' }, team)
+            await app.factory.createInstance(
+                { name: 'delete-instance-1' },
+                application,
+                app.stack,
+                app.template,
+                app.projectType,
+                { start: false }
+            )
+
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${team.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'unexpected_error')
+            result.error.should.match(/delete team that owns/)
+        })
+        it('admin can delete team without instances', async function () {
+            const team = await app.db.models.Team.create({ name: 'delete-team-2', TeamTypeId: app.defaultTeamType.id })
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${team.hashid}`,
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+        })
+        it('owner can delete team without instances', async function () {
+            const team = await app.db.models.Team.create({ name: 'delete-team-3', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${team.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+        })
+        it('member cannot delete team without instances', async function () {
+            const team = await app.db.models.Team.create({ name: 'delete-team-4', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Member } })
+
+            const response = await app.inject({
+                method: 'DELETE',
+                url: `/api/v1/teams/${team.hashid}`,
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(403)
+        })
+    })
+
+    describe('Edit team details', async function () {
+        // PUT /api/v1/teams/:teamId
+        it('owner can modify team name/slug', async function () {
+            const team = await app.db.models.Team.create({ name: 'update-team-1', slug: 'team-1', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${team.hashid}`,
+                payload: {
+                    name: 'update-team-1-new',
+                    slug: 'team-1-new'
+                },
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('name', 'update-team-1-new')
+            result.should.have.property('slug', 'team-1-new')
+
+            await team.reload()
+            team.should.have.property('name', 'update-team-1-new')
+            team.should.have.property('slug', 'team-1-new')
+        })
+        it('member cannot modify team name/slug', async function () {
+            const team = await app.db.models.Team.create({ name: 'update-team-2', slug: 'team-2', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Member } })
+
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${team.hashid}`,
+                payload: {
+                    name: 'update-team-2-new',
+                    slug: 'team-2-new'
+                },
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(403)
+        })
+        it('cannot modify slug to in-use value', async function () {
+            const team = await app.db.models.Team.create({ name: 'update-team-5', slug: 'team-5', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${team.hashid}`,
+                payload: {
+                    slug: 'bteam'
+                },
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'unexpected_error')
+            result.error.should.match(/slug must be unique/)
+        })
+        it('cannot modify name and type in one request', async function () {
+            const team = await app.db.models.Team.create({ name: 'update-team-3', slug: 'team-3', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+            const newTeamType = await app.db.models.TeamType.create({
+                name: 'bigger-team-type',
+                description: 'team type description',
+                active: true,
+                order: 1,
+                properties: {
+                    instances: {
+                        [app.projectType.hashid]: { active: true }
+                    },
+                    devices: { },
+                    users: { },
+                    features: { }
+                }
+            })
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${team.hashid}`,
+                payload: {
+                    name: 'update-team-3-new',
+                    type: newTeamType.hashid
+                },
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(400)
+            const result = response.json()
+            result.should.have.property('code', 'invalid_request')
+            result.error.should.match(/Cannot modify other properties/i)
+        })
+
+        it('can modify team type', async function () {
+            const team = await app.db.models.Team.create({ name: 'update-team-4', slug: 'team-4', TeamTypeId: app.defaultTeamType.id })
+            await team.addUser(TestObjects.bob, { through: { role: Roles.Owner } })
+            const newTeamType = await app.db.models.TeamType.create({
+                name: 'bigger-team-type',
+                description: 'team type description',
+                active: true,
+                order: 1,
+                properties: {
+                    instances: {
+                        [app.projectType.hashid]: { active: true }
+                    },
+                    devices: { },
+                    users: { },
+                    features: { }
+                }
+            })
+            const response = await app.inject({
+                method: 'PUT',
+                url: `/api/v1/teams/${team.hashid}`,
+                payload: {
+                    type: newTeamType.hashid
+                },
+                cookies: { sid: TestObjects.tokens.bob }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('type')
+            result.type.should.have.property('id', newTeamType.hashid)
+
+            await team.reload()
+
+            team.should.have.property('TeamTypeId', newTeamType.id)
+        })
+    })
+
+    describe('Get current users membership', async function () {
+        // GET /api/v1/teams/:teamId/user
+    })
+
+    describe('Get team audit-log', async function () {
+        // GET /api/v1/teams/:teamId/audit-log
+    })
+
     describe('License limits', async function () {
         it('Permits overage when licensed', async function () {
             // This license has limit of 4 teams (2 created by default test setup)
@@ -483,60 +656,6 @@ describe('Team API', function () {
             failResponse.statusCode.should.equal(400)
             failResponse.json().error.should.match(/license limit/)
         })
-    })
-
-    describe('Create team', async function () {
-        // POST /api/v1/teams
-        // - Admin/Owner/Member
-    })
-
-    describe('Delete team', async function () {
-        // DELETE /api/v1/teams/:teamId
-        // - Admin/Owner/Member
-        // - should fail if team owns projects
-
-        it('removes pending invitations', async function () {
-            // Alice invites Chris to TeamA
-            // Delete TeamB
-            await app.inject({
-                method: 'POST',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
-                cookies: { sid: TestObjects.tokens.alice },
-                payload: {
-                    user: 'chris'
-                }
-            })
-            const inviteListA = (await app.inject({
-                method: 'GET',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}/invitations`,
-                cookies: { sid: TestObjects.tokens.alice }
-            })).json()
-            inviteListA.should.have.property('count', 1)
-            const deleteResult = await app.inject({
-                method: 'DELETE',
-                url: `/api/v1/teams/${TestObjects.BTeam.hashid}`,
-                cookies: { sid: TestObjects.tokens.alice }
-            })
-            deleteResult.statusCode.should.equal(200)
-            const inviteListChris = (await app.inject({
-                method: 'GET',
-                url: '/api/v1/user/invitations',
-                cookies: { sid: TestObjects.tokens.chris }
-            })).json()
-            inviteListChris.should.have.property('count', 0)
-        })
-    })
-
-    describe('Edit team details', async function () {
-        // PUT /api/v1/teams/:teamId
-    })
-
-    describe('Get current users membership', async function () {
-        // GET /api/v1/teams/:teamId/user
-    })
-
-    describe('Get team audit-log', async function () {
-        // GET /api/v1/teams/:teamId/audit-log
     })
 
     describe('Check slug availability', async function () {


### PR DESCRIPTION
## Description

Closes #2532 

This adds the ability to change the Team Type.

```[tasklist]
### Tasks
- [x] Update api to support modifying team type - CE only
- [x] Add audit log entry type for changing team type
- [x] Add Change Type UI - CE only
- [x] Add EE/Billing logic around changing type
- [x] Update Change Type UI to give better billing change feedback
- [ ] Unit Test coverage of API changes
``` 