### PR TITLE
Revert "Bump eslint-plugin-cypress from 2.13.3 to 2.14.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11340,42 +11340,15 @@
             }
         },
         "node_modules/eslint-plugin-cypress": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.14.0.tgz",
-            "integrity": "sha512-eW6tv7iIg7xujleAJX4Ujm649Bf5jweqa4ObPEIuueYRyLZt7qXGWhCY/n4bfeFW/j6nQZwbIBHKZt6EKcL/cg==",
+            "version": "2.13.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.3.tgz",
+            "integrity": "sha512-nAPjZE5WopCsgJwl3vHm5iafpV+ZRO76Z9hMyRygWhmg5ODXDPd+9MaPl7kdJ2azj+sO87H3P1PRnggIrz848g==",
             "dev": true,
             "dependencies": {
-                "globals": "^13.20.0"
+                "globals": "^11.12.0"
             },
             "peerDependencies": {
                 "eslint": ">= 3.2.1"
-            }
-        },
-        "node_modules/eslint-plugin-cypress/node_modules/globals": {
-            "version": "13.21.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-            "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/eslint-plugin-cypress/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-plugin-es-x": {
@@ -31611,29 +31584,12 @@
             }
         },
         "eslint-plugin-cypress": {
-            "version": "2.14.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.14.0.tgz",
-            "integrity": "sha512-eW6tv7iIg7xujleAJX4Ujm649Bf5jweqa4ObPEIuueYRyLZt7qXGWhCY/n4bfeFW/j6nQZwbIBHKZt6EKcL/cg==",
+            "version": "2.13.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.3.tgz",
+            "integrity": "sha512-nAPjZE5WopCsgJwl3vHm5iafpV+ZRO76Z9hMyRygWhmg5ODXDPd+9MaPl7kdJ2azj+sO87H3P1PRnggIrz848g==",
             "dev": true,
             "requires": {
-                "globals": "^13.20.0"
-            },
-            "dependencies": {
-                "globals": {
-                    "version": "13.21.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-                    "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
-                    "dev": true,
-                    "requires": {
-                        "type-fest": "^0.20.2"
-                    }
-                },
-                "type-fest": {
-                    "version": "0.20.2",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-                    "dev": true
-                }
+                "globals": "^11.12.0"
             }
         },
         "eslint-plugin-es-x": {


### PR DESCRIPTION
Reverts flowforge/flowforge#2589

A bug has been identified in 2.14.0 that we are hitting:  https://github.com/cypress-io/eslint-plugin-cypress/issues/140

Reverting this change for now until a fix is available upstream.