### PR TITLE
Add banner to DeviceBrowser when device limit reached

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -104,6 +104,15 @@ module.exports = {
                                         "members"."TeamId" = "Team"."id"
                                     )`),
                                     'memberCount'
+                                ],
+                                [
+                                    literal(`(
+                                        SELECT COUNT(*)
+                                        FROM "Devices" AS "devices"
+                                        WHERE
+                                        "devices"."TeamId" = "Team"."id"
+                                    )`),
+                                    'deviceCount'
                                 ]
                             ]
                         }
@@ -134,6 +143,15 @@ module.exports = {
                                         "members"."TeamId" = "Team"."id"
                                     )`),
                                     'memberCount'
+                                ],
+                                [
+                                    literal(`(
+                                        SELECT COUNT(*)
+                                        FROM "Devices" AS "devices"
+                                        WHERE
+                                        "devices"."TeamId" = "Team"."id"
+                                    )`),
+                                    'deviceCount'
                                 ]
                             ]
                         }
@@ -177,6 +195,15 @@ module.exports = {
                                         "members"."TeamId" = "Team"."id"
                                     )`),
                                     'memberCount'
+                                ],
+                                [
+                                    literal(`(
+                                        SELECT COUNT(*)
+                                        FROM "Devices" AS "devices"
+                                        WHERE
+                                        "devices"."TeamId" = "Team"."id"
+                                    )`),
+                                    'deviceCount'
                                 ]
                             ]
                         }

--- a/forge/db/views/Team.js
+++ b/forge/db/views/Team.js
@@ -33,6 +33,7 @@ module.exports = function (app) {
             instanceCount: { type: 'number' },
             instanceCountByType: { type: 'object', additionalProperties: true },
             memberCount: { type: 'number' },
+            deviceCount: { type: 'number' },
             createdAt: { type: 'string' },
             updatedAt: { type: 'string' },
             billing: { type: 'object', additionalProperties: true },
@@ -51,6 +52,7 @@ module.exports = function (app) {
                 avatar: result.avatar,
                 instanceCount: result.projectCount,
                 memberCount: result.memberCount,
+                deviceCount: result.deviceCount,
                 createdAt: result.createdAt,
                 updatedAt: result.updatedAt,
                 links: result.links

--- a/frontend/src/api/application.js
+++ b/frontend/src/api/application.js
@@ -87,9 +87,7 @@ const getApplicationInstances = async (applicationId, cursor, limit) => {
 const getApplicationDevices = async (applicationId, cursor, limit) => {
     const url = paginateUrl(`/api/v1/applications/${applicationId}/devices`, cursor, limit)
     const res = await client.get(url)
-    if (!res?.data?.count) {
-        return []
-    }
+
     res.data.devices = res.data.devices.map((item) => {
         item.createdSince = daysSince(item.createdAt)
         item.updatedSince = daysSince(item.updatedAt)

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -375,12 +375,12 @@ export default {
             )
         },
         teamDeviceLimitReached () {
-            const teamTypeDeviceProperties = this.team.type.properties.devices
-            if (teamTypeDeviceProperties.limit !== undefined) {
-                // TODO: check the current device count.
+            const teamTypeDeviceLimit = this.team.type.properties?.devices?.limit
+            if (!teamTypeDeviceLimit || teamTypeDeviceLimit < 0) {
+                return false
             }
 
-            return true
+            return this.team.deviceCount >= teamTypeDeviceLimit
         }
     },
     watch: {

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -16,7 +16,7 @@
             message="Deleting Device..."
         />
         <template v-else>
-            <FeatureUnavailableToTeam v-if="teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." />
+            <FeatureUnavailableToTeam v-if="devices.size > 0 && teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-status" label="Last Known Status" :devices="Array.from(devices.values())" property="status" :filter="filter" @filter-selected="applyFilter" />
             <ff-data-table

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -16,6 +16,7 @@
             message="Deleting Device..."
         />
         <template v-else>
+            <FeatureUnavailableToTeam v-if="teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-status" label="Last Known Status" :devices="Array.from(devices.values())" property="status" :filter="filter" @filter-selected="applyFilter" />
             <ff-data-table
@@ -47,6 +48,7 @@
                         class="font-normal"
                         data-action="register-device"
                         kind="primary"
+                        :disabled="teamDeviceLimitReached"
                         @click="showCreateDeviceDialog"
                     >
                         <template #icon-left>
@@ -249,6 +251,7 @@ import Alerts from '../services/alerts.js'
 import Dialog from '../services/dialog.js'
 
 import EmptyState from './EmptyState.vue'
+import FeatureUnavailableToTeam from './banners/FeatureUnavailableToTeam.vue'
 import DevicesStatusBar from './charts/DeviceStatusBar.vue'
 
 const POLL_TIME = 10000
@@ -260,6 +263,7 @@ export default {
         DeviceAssignApplicationDialog,
         DeviceAssignInstanceDialog,
         DeviceCredentialsDialog,
+        FeatureUnavailableToTeam,
         PlusSmIcon,
         SnapshotAssignDialog,
         TeamDeviceCreateDialog,
@@ -369,6 +373,14 @@ export default {
                 (this.displayingApplication && !!this.application?.id) ||
                 (this.displayingTeam && !!this.team?.id)
             )
+        },
+        teamDeviceLimitReached () {
+            const teamTypeDeviceProperties = this.team.type.properties.devices
+            if (teamTypeDeviceProperties.limit !== undefined) {
+                // TODO: check the current device count.
+            }
+
+            return true
         }
     },
     watch: {

--- a/frontend/src/components/banners/FeatureUnavailableToTeam.vue
+++ b/frontend/src/components/banners/FeatureUnavailableToTeam.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="ff-page-banner my-4"
+        class="ff-page-banner mb-4"
         data-el="page-banner-feature-unavailable-to-team"
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />


### PR DESCRIPTION
## Description

This is part of the Team Types work. It adds the standard banner to the DeviceBrowser component and disabled the 'add device' button if the device limit has been reached.

Except... it doesn't quite work yet. Given the work around Device pagination, the DeviceBrowser is getting a bunch of rework in parallel. The current code doesn't appear to have the 'total number of devices in this team' baked into it. If I go about adding that, it'll insta-clash badly with the pagination work. So this is a placeholder PR to get the bulk of this work in - and the final piece can be updated when the pagination work lands.

Alternatively, if the pagination work is delayed, it will be a quick task to add the right logic here and get this merged and deal with the clashes later.