### PR TITLE
Add file/context quotas to teamType UI

### DIFF
--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -74,8 +74,8 @@
                     <FormRow v-model="input.properties.features.projectComms" type="checkbox">Project Nodes</FormRow>
                     <FormRow v-model="input.properties.features.ha" type="checkbox">High Availability</FormRow>
                     <FormRow v-model="input.properties.features.teamHttpSecurity" type="checkbox">Team-based Endpoint Security</FormRow>
-                    <!--<FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
-                    <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow> -->
+                    <FormRow v-model="input.properties.features.fileStorageLimit">Persistent File storage limit (Mb)</FormRow>
+                    <FormRow v-model="input.properties.features.contextLimit">Persistent Context storage limit (Mb)</FormRow>
                 </div>
             </form>
         </template>
@@ -268,6 +268,9 @@ export default {
                         opts.properties.trial = { active: false }
                     }
                 }
+                formatNumber(opts.properties.features, 'fileStorageLimit')
+                formatNumber(opts.properties.features, 'contextLimit')
+
                 if (this.teamType) {
                     // For edits, we cannot touch the properties
                     // TODO: what can be edited when in use?


### PR DESCRIPTION
## Description

Adds file and context quota config option to TeamType UI. This will get properties set on the TeamType object for these values.

The values are stored as numbers and the UI says to provide them as `Mb` - *not* bytes. So any consumer of the value will need to convert to bytes if that's what's needed.

Within the forge app, the values can be retrieved with:

```
// Assume `team` is a Team object from the database:
// - second arg is the value to return if no value is set.
// - for other flags, a value of `0` means literally `0`, and `-1` used for 'unlimited'.
const fileStorageLimit = team.TeamType.getFeatureProperty('fileStorageLimit', -1))
const contextLimit = team.TeamType.getFeatureProperty('contextLimit', -1))
```