### PR TITLE
Handle errors whilst processing trial subscriptions

### DIFF
--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -39,7 +39,7 @@ module.exports.init = function (app) {
                     subscription.destroy()
                 }
             } catch (err) {
-                app.log.info(`Error handling expired trial subscription ${subscription.subscription}: ${err.toString()}`)
+                app.log.error(`Error handling expired trial subscription ${subscription.subscription}: ${err.toString()}`)
             }
         }
 
@@ -87,7 +87,7 @@ module.exports.init = function (app) {
                     subscription.destroy()
                 }
             } catch (err) {
-                app.log.info(`Error handling trial subscription ${subscription.subscription}: ${err.toString()}`)
+                app.log.error(`Error handling trial subscription ${subscription.subscription}: ${err.toString()}`)
             }
         }
     }

--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -12,26 +12,35 @@ module.exports.init = function (app) {
         })
 
         for (const subscription of expiredSubscriptions) {
-            if (subscription.isActive()) {
-                app.log.info(`Team ${subscription.Team.hashid} ending trial - billing setup`)
-                // Ensure device count is updated (if device billing enabled)
-                await subscription.Team.reload({ include: [app.db.models.TeamType] })
-                // The subscription has been setup on Stripe.
-                await app.billing.endTeamTrial(subscription.Team)
-                await sendTrialEmail(subscription.Team, 'TrialTeamEnded')
-            } else {
-                app.log.info(`Team ${subscription.Team.hashid} ending trial - suspending instances`)
-                // Stripe not configured - suspend the lot
-                await suspendAllProjects(subscription.Team)
-                await sendTrialEmail(subscription.Team, 'TrialTeamSuspended', {
-                    teamSettingsURL: `${app.config.base_url}/team/${subscription.Team.slug}/billing`
-                })
-            }
+            try {
+                if (subscription.Team) {
+                    if (subscription.isActive()) {
+                        app.log.info(`Team ${subscription.Team.hashid} ending trial - billing setup`)
+                        // Ensure device count is updated (if device billing enabled)
+                        await subscription.Team.reload({ include: [app.db.models.TeamType] })
+                        // The subscription has been setup on Stripe.
+                        await app.billing.endTeamTrial(subscription.Team)
+                        await sendTrialEmail(subscription.Team, 'TrialTeamEnded')
+                    } else {
+                        app.log.info(`Team ${subscription.Team.hashid} ending trial - suspending instances`)
+                        // Stripe not configured - suspend the lot
+                        await suspendAllProjects(subscription.Team)
+                        await sendTrialEmail(subscription.Team, 'TrialTeamSuspended', {
+                            teamSettingsURL: `${app.config.base_url}/team/${subscription.Team.slug}/billing`
+                        })
+                    }
 
-            // We have dealt with this team
-            subscription.trialEndsAt = null
-            subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.ENDED
-            await subscription.save()
+                    // We have dealt with this team
+                    subscription.trialEndsAt = null
+                    subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.ENDED
+                    await subscription.save()
+                } else {
+                    // Team has been deleted
+                    subscription.destroy()
+                }
+            } catch (err) {
+                app.log.info(`Error handling expired trial subscription ${subscription.subscription}: ${err.toString()}`)
+            }
         }
 
         // Email sending intervals
@@ -57,20 +66,29 @@ module.exports.init = function (app) {
         })
 
         for (const subscription of pendingEmailSubscriptions) {
-            const endingInDurationDays = Math.ceil((subscription.trialEndsAt - Date.now()) / ONE_DAY)
-            const endingInDuration = endingInDurationDays + ' day' + ((endingInDurationDays !== 1) ? 's' : '')
-            const billingUrl = `${app.config.base_url}/team/${subscription.Team.slug}/billing`
-            await sendTrialEmail(subscription.Team, 'TrialTeamReminder', {
-                endingInDuration,
-                billingSetup: subscription.isActive(),
-                billingUrl
-            })
-            if (subscription.trialStatus === app.db.models.Subscription.TRIAL_STATUS.CREATED) {
-                subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.WEEK_EMAIL_SENT
-            } else {
-                subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.DAY_EMAIL_SENT
+            try {
+                const endingInDurationDays = Math.ceil((subscription.trialEndsAt - Date.now()) / ONE_DAY)
+                const endingInDuration = endingInDurationDays + ' day' + ((endingInDurationDays !== 1) ? 's' : '')
+                if (subscription.Team) {
+                    const billingUrl = `${app.config.base_url}/team/${subscription.Team.slug}/billing`
+                    await sendTrialEmail(subscription.Team, 'TrialTeamReminder', {
+                        endingInDuration,
+                        billingSetup: subscription.isActive(),
+                        billingUrl
+                    })
+                    if (subscription.trialStatus === app.db.models.Subscription.TRIAL_STATUS.CREATED) {
+                        subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.WEEK_EMAIL_SENT
+                    } else {
+                        subscription.trialStatus = app.db.models.Subscription.TRIAL_STATUS.DAY_EMAIL_SENT
+                    }
+                    await subscription.save()
+                } else {
+                    // This team has been deleted
+                    subscription.destroy()
+                }
+            } catch (err) {
+                app.log.info(`Error handling trial subscription ${subscription.subscription}: ${err.toString()}`)
             }
-            await subscription.save()
         }
     }
 


### PR DESCRIPTION
## Description

If a team is deleted whilst in trial mode, the subscription object is left in the database. That is not ideal and should be addressed separately. However, it then causes the trial task to fail as it expects each subscription to have a team. The knock-on effect is it then fails to process the remaining subscriptions.

This adds individual error handling to ensure any problems with one subscription doesn't impact the handling of others.