### PR TITLE
Show sparkles if library feature unavailable for given team type

### DIFF
--- a/frontend/src/components/SideNavigationTeamOptions.vue
+++ b/frontend/src/components/SideNavigationTeamOptions.vue
@@ -95,7 +95,7 @@ export default {
                     to: '/library',
                     tag: 'shared-library',
                     icon: FolderIcon,
-                    featureUnavailable: !this.features?.['shared-library']
+                    featureUnavailable: !this.features?.['shared-library'] || this.team?.type.properties.features?.['shared-library'] === false
                 },
                 {
                     label: 'Members',


### PR DESCRIPTION
## Description

Shows sparkles in the nav sidebar if the Team Library feature is unavailable for a given team.

<img width="321" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/fb164276-6e12-4a36-941c-220a92cabb13">
