### PR TITLE
Device Limit Banner Improvements

### DIFF
--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -303,7 +303,8 @@ export default {
             deletingDevice: false,
             nextCursor: null,
             devices: new Map(),
-            firstRequest: true
+            firstRequest: true,
+            deviceCountDeltaSincePageLoad: 0
         }
     },
     computed: {
@@ -374,13 +375,16 @@ export default {
                 (this.displayingTeam && !!this.team?.id)
             )
         },
+        teamDeviceCount () {
+            return this.team.deviceCount + this.deviceCountDeltaSincePageLoad
+        },
         teamDeviceLimitReached () {
             const teamTypeDeviceLimit = this.team.type.properties?.devices?.limit
             if (!teamTypeDeviceLimit || teamTypeDeviceLimit < 0) {
                 return false
             }
 
-            return this.team.deviceCount >= teamTypeDeviceLimit
+            return this.teamDeviceCount >= teamTypeDeviceLimit
         }
     },
     watch: {
@@ -441,6 +445,7 @@ export default {
                     this.$refs.deviceCredentialsDialog.show(device)
                 }, 500)
                 this.devices.set(device.id, device)
+                this.deviceCountDeltaSincePageLoad++
                 this.applyFilter()
             }
         },
@@ -544,6 +549,7 @@ export default {
                         await deviceApi.deleteDevice(device.id)
                         Alerts.emit('Successfully deleted the device', 'confirmation')
                         this.devices.delete(device.id)
+                        this.deviceCountDeltaSincePageLoad--
                     } catch (err) {
                         Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
                     } finally {

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -8,7 +8,7 @@
             message="Loading Devices..."
         />
         <template v-else>
-            <FeatureUnavailableToTeam v-if="devices.size > 0 && teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." />
+            <FeatureUnavailableToTeam v-if="devices.size > 0 && teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." :class="{'mt-0': displayingTeam }" />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-status" label="Last Known Status" :devices="Array.from(devices.values())" property="status" :filter="filter" @filter-selected="applyFilter" />
             <ff-data-table
@@ -166,7 +166,6 @@
     <TeamDeviceCreateDialog
         ref="teamDeviceCreateDialog"
         :team="team"
-        @device-creating="deviceCreating"
         @device-created="deviceCreated"
         @device-updated="deviceUpdated"
     >
@@ -216,6 +215,7 @@
 import { ClockIcon } from '@heroicons/vue/outline'
 import { PlusSmIcon } from '@heroicons/vue/solid'
 
+import semver from 'semver'
 import { markRaw } from 'vue'
 
 import ApplicationApi from '../api/application.js'

--- a/frontend/src/components/DevicesBrowser.vue
+++ b/frontend/src/components/DevicesBrowser.vue
@@ -7,14 +7,6 @@
             v-if="loading"
             message="Loading Devices..."
         />
-        <ff-loading
-            v-else-if="creatingDevice"
-            message="Creating Device..."
-        />
-        <ff-loading
-            v-else-if="deletingDevice"
-            message="Deleting Device..."
-        />
         <template v-else>
             <FeatureUnavailableToTeam v-if="devices.size > 0 && teamDeviceLimitReached" fullMessage="You have reached the device limit for this team." />
             <DevicesStatusBar v-if="devices.size > 0" data-el="devicestatus-lastseen" label="Last Seen" :devices="Array.from(devices.values())" property="lastseen" :filter="filter" @filter-selected="applyFilter" />
@@ -224,7 +216,6 @@
 import { ClockIcon } from '@heroicons/vue/outline'
 import { PlusSmIcon } from '@heroicons/vue/solid'
 
-import semver from 'semver'
 import { markRaw } from 'vue'
 
 import ApplicationApi from '../api/application.js'
@@ -299,8 +290,6 @@ export default {
         return {
             loading: true,
             filter: null,
-            creatingDevice: false,
-            deletingDevice: false,
             nextCursor: null,
             devices: new Map(),
             firstRequest: true,
@@ -434,12 +423,7 @@ export default {
             this.$refs.snapshotAssignDialog.show()
         },
 
-        deviceCreating () {
-            this.creatingDevice = true
-        },
-
         deviceCreated (device) {
-            this.creatingDevice = false
             if (device) {
                 setTimeout(() => {
                     this.$refs.deviceCredentialsDialog.show(device)
@@ -544,7 +528,6 @@ export default {
                     text: 'Are you sure you want to delete this device? Once deleted, there is no going back.',
                     confirmLabel: 'Delete'
                 }, async () => {
-                    this.deletingDevice = true
                     try {
                         await deviceApi.deleteDevice(device.id)
                         Alerts.emit('Successfully deleted the device', 'confirmation')
@@ -552,8 +535,6 @@ export default {
                         this.deviceCountDeltaSincePageLoad--
                     } catch (err) {
                         Alerts.emit('Failed to delete device: ' + err.toString(), 'warning', 7500)
-                    } finally {
-                        this.deletingDevice = false
                     }
                 })
             } else if (action === 'updateCredentials') {

--- a/frontend/src/components/banners/FeatureUnavailableToTeam.vue
+++ b/frontend/src/components/banners/FeatureUnavailableToTeam.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="ff-page-banner mb-4"
+        class="ff-page-banner my-4"
         data-el="page-banner-feature-unavailable-to-team"
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />


### PR DESCRIPTION
## Description

Keeps track of added/deleted devices so the banner can display/hide.

https://github.com/flowforge/flowforge/assets/507155/6721dbe9-8ff5-426e-86d9-4c257ee8d1f6

## Related Issue(s)

https://github.com/flowforge/flowforge/pull/2670

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

