### PR TITLE
Disable filestore by default

### DIFF
--- a/docs/install/local/README.md
+++ b/docs/install/local/README.md
@@ -233,6 +233,25 @@ you can use a pre-built docker image that provides everything needed.
 
     This will map the `1883`/`1884` ports to the host machine so they can be accessed outside of the container. If you already have an MQTT broker running on port 1883, then you'll need to modify the `-p` options to use a different set of ports. For example: `-p 9883:1883 -p 9884:1884`.
 
+## File Server
+
+By default the FlowFuse File Server component is disabled as it is a licensed feature. If you provide a license you can start the File Server with the following command:
+
+```bash
+sudo service flowforge-file start
+```
+
+You can then uncomment the following section in the `/opt/flowforge/etc/flowforge.yml` file
+
+```yaml
+#################################################
+# File Server config                            #
+#################################################
+
+fileStore:
+  url: http://localhost:3001
+
+```
 
 ## Upgrade
 

--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -71,8 +71,8 @@ driver:
 # File Server config                            #
 #################################################
 
-fileStore:
-  url: http://localhost:3001
+# fileStore:
+#   url: http://localhost:3001
 
 
 #################################################


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
As this is a licensed feature it is already diabled by default, but the localfs installer does not include the file-server. So When you add a license to the localfs build it enables persistent context and fails to start instance.

With this off by default it will require file-server to be installed and started and configured.

Will look at bundling file-server in installer, but this is best safe quick option

## Related Issue(s)

<!-- What issue does this PR relate to? -->
Mentioned on NR Slack
https://node-red.slack.com/archives/C02V3BN77GU/p1693347012101579


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

