### PR TITLE
Fix sending welcome email at start of new trial type

### DIFF
--- a/forge/ee/lib/billing/emailTemplates/TrialTeamCreated.js
+++ b/forge/ee/lib/billing/emailTemplates/TrialTeamCreated.js
@@ -16,6 +16,7 @@ To get started, log in to FlowFuse and begin creating Node-RED flows in your fir
 
 You can also invite other users to join your team to collaborate on your applications.
 
+{{#if trialProjectTypeName}}
 Your {{{trialDuration}}} day trial allows you to create a {{{trialProjectTypeName}}} instance
 for free. Once the trial ends, you will need to add your credit card details to
 keep it running. But don't worry - we'll remind you when the trial is
@@ -24,7 +25,13 @@ nearing its end.
 If you want to do more with your team during the trial, you can add your credit
 card details at any time and create more instances.  Again, we'll email to remind
 you what is happening with the trial.
+{{else}}
+Your {{{trialDuration}}} day trial gives you full access to your new Starter team,
+where you can have up to two Node-RED instances and two devices.
 
+Once the trial ends, you will need to add your credit card details to keep it running.
+But don't worry - we'll remind you when the trial is nearing its end.
+{{/if}}
 We hope you enjoy the FlowFuse experience.
 
 Cheers!
@@ -41,14 +48,22 @@ Your friendly FlowFuse Team
 
 <p>You can also invite other users to join your team to collaborate on your applications.</p>
 
+{{#if trialProjectTypeName}}
 <p>Your {{{trialDuration}}} day trial allows you to create a {{{trialProjectTypeName}}} instance
 for free. Once the trial ends, you will need to add your credit card details to
-keep the it running. But don't worry - we'll remind you when the trial is
+keep it running. But don't worry - we'll remind you when the trial is
 nearing its end.</p>
 
 <p>If you want to do more with your team during the trial, you can add your credit
 card details at any time and create more instances.  Again, we'll email to remind
 you what is happening with the trial.</p>
+{{else}}
+<p>Your {{{trialDuration}}} day trial gives you full access to your new Starter team,
+where you can have up to two Node-RED instances and two devices.</p>
+
+<p>Once the trial ends, you will need to add your credit card details to keep it running.
+But don't worry - we'll remind you when the trial is nearing its end.</p>
+{{/if}}
 
 <p>We hope you enjoy the FlowFuse experience.</p>
 

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -337,19 +337,20 @@ module.exports.init = async function (app) {
                         team,
                         Date.now() + teamTrialDuration * ONE_DAY
                     )
+                    const emailInserts = {
+                        username: user.name,
+                        teamName: team.name,
+                        trialDuration: teamTrialDuration
+                    }
                     if (teamTrialInstanceTypeId) {
                         const trialProjectType = await app.db.models.ProjectType.byId(teamTrialInstanceTypeId)
-                        await app.postoffice.send(
-                            user,
-                            'TrialTeamCreated',
-                            {
-                                username: user.name,
-                                teamName: team.name,
-                                trialDuration: teamTrialDuration,
-                                trialProjectTypeName: trialProjectType.name
-                            }
-                        )
+                        emailInserts.trialProjectTypeName = trialProjectType.name
                     }
+                    await app.postoffice.send(
+                        user,
+                        'TrialTeamCreated',
+                        emailInserts
+                    )
                 }
             }
         },


### PR DESCRIPTION
## Description

Fixes #2687 

The trial welcome email was not being sent for the new Starter trials as it was expecting the trial mode to specific an instance type that was available to the trial so the email could reference it. That is no longer the case for the new Starter trial mode.

This fixes the logic and updates the email template to handle both cases.