### PR TITLE
Change default device command timeout to 10s

### DIFF
--- a/forge/comms/devices.js
+++ b/forge/comms/devices.js
@@ -6,7 +6,7 @@
 const { v4: uuidv4 } = require('uuid')
 
 const noop = () => {}
-const DEFAULT_TIMEOUT = 5000
+const DEFAULT_TIMEOUT = 10000
 
 // declare command and response monitor types (and freeze them)
 const CommandMonitorTemplate = {


### PR DESCRIPTION
## Description

This PR increases the command timeout for devices from 5s to 10s.

We have seen a case where a command is taking _just_ over 5s to respond due to a device on a slow network connection.

Increasing this timeout should give plenty of headroom for slow devices without impacting the user experience too much in the cases where a device is unresponsive and genuinely needs to be timed out and feedback to the user.
