### PR TITLE
Update websocket close codes to proper range

### DIFF
--- a/forge/ee/routes/deviceEditor/index.js
+++ b/forge/ee/routes/deviceEditor/index.js
@@ -175,13 +175,13 @@ module.exports = async function (app) {
             if (tunnelManager.verifyToken(deviceId, token)) {
                 const tunnelSetupOK = tunnelManager.initTunnel(deviceId, token, connection)
                 if (!tunnelSetupOK) {
-                    connection.socket.close(1008, 'Tunnel setup failed')
+                    connection.socket.close(4000, 'Tunnel setup failed')
                 }
             } else {
-                connection.socket.close(1008, 'Invalid token')
+                connection.socket.close(4001, 'Invalid token')
             }
         } else {
-            connection.socket.close(1008, 'No tunnel')
+            connection.socket.close(4004, 'No tunnel')
         }
     })
 
@@ -236,7 +236,7 @@ module.exports = async function (app) {
                 return // handled
             }
             // not handled
-            connection.socket.close(1008, 'No tunnel established')
+            connection.socket.close(4000, 'No tunnel established')
         }
     })
 


### PR DESCRIPTION
## Description

Partner PR to #2708 and https://github.com/flowforge/flowforge-device-agent/pull/169

In reviewing our WS close codes, I found we were using reserved codes from the `100x` range. Application specific codes should be in the unreserved space `4000+`.

As such, I've modified *some* of the return codes here that are relevant to the issue we're fixing to use distinct `400x` level codes.

I'll raise a follow up task to fully review and update the remaining. We have no code (other than newly added by the above linked PR) that cares about the actual code value, so we can change these without issue.