### PR TITLE
Devices Pagination: Coverage and fixes of devices search/filter/query

### DIFF
--- a/forge/db/controllers/Device.js
+++ b/forge/db/controllers/Device.js
@@ -159,8 +159,11 @@ module.exports = {
         }
 
         if (paginationOptions.sort) {
-            paginationOptions.order[paginationOptions.sort] = paginationOptions.sort
+            paginationOptions.order = {
+                [paginationOptions.sort]: paginationOptions.order
+            }
             delete paginationOptions.sort
+            delete paginationOptions.dir
         }
 
         return paginationOptions

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -205,8 +205,8 @@ module.exports = {
 
                     // Filtering
                     if (pagination.filters?.state) {
-                        // Offline is the blank state
-                        where.state = pagination.filters.state === 'offline' ? '' : pagination.filters.state
+                        // Unknown is the blank state
+                        where.state = pagination.filters.state === 'unknown' ? '' : pagination.filters.state
                     }
 
                     if (pagination.filters?.lastseen) {

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -238,7 +238,13 @@ module.exports = {
                     if (pagination.order && Object.keys(pagination.order).length) {
                         for (const key in pagination.order) {
                             if (key === 'application') {
-                                order.unshift([M.Application, 'name', pagination.order[key] || 'ASC'])
+                                // Sort by Device->Instance->Application.name
+                                if (includeInstanceApplication) {
+                                    order.unshift([M.Project, M.Application, 'name', pagination.order[key] || 'ASC'])
+                                // Order Device->Application.name
+                                } else {
+                                    order.unshift([M.Application, 'name', pagination.order[key] || 'ASC'])
+                                }
                             } else if (key === 'instance') {
                                 order.unshift([M.Project, 'name', pagination.order[key] || 'ASC'])
                             } else {

--- a/forge/db/models/Device.js
+++ b/forge/db/models/Device.js
@@ -291,7 +291,7 @@ module.exports = {
 
                     const [rows, count] = await Promise.all([
                         this.findAll({
-                            where: buildPaginationSearchClause(pagination, where, ['Device.name', 'Device.type', 'Device.id'], {}, order),
+                            where: buildPaginationSearchClause(pagination, where, ['Device.name', 'Device.type'], {}, order),
                             include: pagination.statusOnly ? statusOnlyIncludes : includes,
                             order,
                             limit: pagination.statusOnly ? null : limit

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -190,7 +190,7 @@ describe('Team Devices API', function () {
                 const resultName = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application`)
 
                 // SQLite puts undefined includes first ASC, Postgres has it last...
-                const usingSQLite = resultName[0].application === undefined
+                const usingSQLite = app.db.sequelize.getDialect() === 'sqlite'
                 const ascendingOrder = ['application-1', 'application-1', 'application-2']
                 const descendingOrder = ['application-2', 'application-1', 'application-1']
                 if (usingSQLite) {
@@ -217,7 +217,7 @@ describe('Team Devices API', function () {
                 const resultName = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance`)
 
                 // SQLite puts undefined includes first ASC, Postgres has it last...
-                const usingSQLite = resultName[0].instance === undefined
+                const usingSQLite = app.db.sequelize.getDialect() === 'sqlite'
                 const ascendingOrder = ['instance-2', 'project1', 'project1']
                 const descendingOrder = ['project1', 'project1', 'instance-2']
                 if (usingSQLite) {

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -29,12 +29,7 @@ describe('Team Devices API', function () {
         await TestObjects.ATeam.addUser(TestObjects.chris, { through: { role: Roles.Member } })
 
         // create 1 device for ATeam
-        TestObjects.Device1 = await app.db.models.Device.create({
-            name: 'device 1',
-            type: 'test device',
-            credentialSecret: ''
-        })
-        await TestObjects.ATeam.addDevice(TestObjects.Device1)
+        TestObjects.Device1 = await app.factory.createDevice({ name: 'device 1', type: 'test device' }, TestObjects.ATeam, TestObjects.Project1)
 
         TestObjects.tokens = {}
         await login('alice', 'aaPassword')
@@ -106,6 +101,7 @@ describe('Team Devices API', function () {
             result.should.have.property('devices').and.be.an.Array()
             result.devices.should.have.a.property('length', 3)
         })
+
         it('Non member does not get a list of devices', async function () {
             // GET /api/v1/team/:teamId/devices
             await login('dave', 'ddPassword')
@@ -116,7 +112,205 @@ describe('Team Devices API', function () {
             })
             response.statusCode.should.equal(404) // not found
         })
+
+        describe('Supports searching the devices', async function () {
+            before(async function () {
+                // Add 2 more devices
+                await app.factory.createDevice({ name: 'device 2', type: 'it is another type of device' }, TestObjects.ATeam)
+                await app.factory.createDevice({ name: 'device 3', type: 'it is another type of device' }, TestObjects.ATeam)
+            })
+
+            after(async function () {
+                await app.db.models.Device.destroy({
+                    where: {
+                        name: ['device 2', 'device 3']
+                    }
+                })
+            })
+
+            it('by name', async function () {
+                // Match device on name
+                const responseName = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?query=Device%202`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultName = responseName.json()
+                resultName.should.have.property('devices').and.be.an.Array()
+                resultName.devices.should.have.a.property('length', 1)
+            })
+
+            it('by type', async function () {
+                // Match device on type
+                const responseType = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?query=another%20type`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultType = responseType.json()
+                resultType.should.have.property('devices').and.be.an.Array()
+                resultType.devices.should.have.a.property('length', 2)
+
+                responseType.statusCode.should.equal(200)
+            })
+        })
+
+        describe('Supports sorting the devices', function () {
+            before(async function () {
+                const application2 = await app.factory.createApplication({ name: 'application-2' }, TestObjects.ATeam)
+
+                const instance2 = await app.factory.createInstance(
+                    { name: 'instance-2' },
+                    application2,
+                    app.stack,
+                    app.template,
+                    app.projectType,
+                    { start: false }
+                )
+
+                // Add 3 more devices
+                await app.factory.createDevice({ name: 'device 2' }, TestObjects.ATeam, TestObjects.Project1)
+                await app.factory.createDevice({ name: 'device 3', type: 'it is another type of device' }, TestObjects.ATeam, instance2)
+                await app.factory.createDevice({ name: 'device 4', type: 'it is another type of device, no instance' }, TestObjects.ATeam)
+            })
+
+            after(async function () {
+                await app.db.models.Device.destroy({
+                    where: {
+                        name: ['device 2', 'device 3', 'device 4']
+                    }
+                })
+            })
+
+            it('by name', async function () {
+                // Sort by name ASC (default)
+                const responseName = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=name`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultName = responseName.json()
+                resultName.should.have.property('devices').and.be.an.Array()
+                resultName.devices.map((device) => device.name).should.match(['device 1', 'device 2', 'device 3', 'device 4'])
+
+                responseName.statusCode.should.equal(200)
+
+                // Sort by name DESC (explicit)
+                const responseNameDesc = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=name&order=desc`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultNameDesc = responseNameDesc.json()
+                resultNameDesc.should.have.property('devices').and.be.an.Array()
+                resultNameDesc.devices.map((device) => device.name).should.match(['device 4', 'device 3', 'device 2', 'device 1'])
+
+                responseNameDesc.statusCode.should.equal(200)
+
+                // Sort by name ASC (explicit)
+                const responseNameAsc = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=name&order=asc`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultNameAsc = responseNameAsc.json()
+                resultNameAsc.should.have.property('devices').and.be.an.Array()
+                resultNameAsc.devices.map((device) => device.name).should.match(['device 1', 'device 2', 'device 3', 'device 4'])
+
+                responseNameAsc.statusCode.should.equal(200)
+            })
+
+            it('by instance->application name', async function () {
+                // Sort by application name ASC (default)
+                const responseName = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultName = responseName.json()
+                resultName.should.have.property('devices').and.be.an.Array()
+                resultName.devices.map((device) => device.application?.name).should.match([undefined, 'application-1', 'application-1', 'application-2'])
+
+                responseName.statusCode.should.equal(200)
+
+                // Sort by application name DESC (explicit)
+                const responseNameDesc = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application&order=desc`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultNameDesc = responseNameDesc.json()
+                resultNameDesc.should.have.property('devices').and.be.an.Array()
+                resultNameDesc.devices.map((device) => device.application?.name).should.match(['application-2', 'application-1', 'application-1', undefined])
+
+                responseNameDesc.statusCode.should.equal(200)
+
+                // Sort by application name ASC (explicit)
+                const responseNameAsc = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application&order=asc`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultNameAsc = responseNameAsc.json()
+                resultNameAsc.should.have.property('devices').and.be.an.Array()
+                resultNameAsc.devices.map((device) => device.application?.name).should.match([undefined, 'application-1', 'application-1', 'application-2'])
+
+                responseNameAsc.statusCode.should.equal(200)
+            })
+
+            it('by instance name', async function () {
+                // Sort by instance name ASC (default)
+                const responseName = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultName = responseName.json()
+                resultName.should.have.property('devices').and.be.an.Array()
+                resultName.devices.map((device) => device.instance?.name).should.match([undefined, 'instance-2', 'project1', 'project1'])
+
+                responseName.statusCode.should.equal(200)
+
+                // Sort by instance name DESC (explicit)
+                const responseNameDesc = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance&order=desc`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultNameDesc = responseNameDesc.json()
+                resultNameDesc.should.have.property('devices').and.be.an.Array()
+                resultNameDesc.devices.map((device) => device.instance?.name).should.match(['project1', 'project1', 'instance-2', undefined])
+
+                responseNameDesc.statusCode.should.equal(200)
+
+                // Sort by instance name ASC (explicit)
+                const responseNameAsc = await app.inject({
+                    method: 'GET',
+                    url: `/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance&order=asc`,
+                    cookies: { sid: TestObjects.tokens.alice }
+                })
+
+                const resultNameAsc = responseNameAsc.json()
+                resultNameAsc.should.have.property('devices').and.be.an.Array()
+                resultNameAsc.devices.map((device) => device.instance?.name).should.match([undefined, 'instance-2', 'project1', 'project1'])
+
+                responseNameAsc.statusCode.should.equal(200)
+            })
+        })
+
+        describe('Supports filtering the devices', function () {
     })
+
     describe('Provisioning Tokens', function () {
         it('Get list of provisioning tokens for the team', async function () {
             // /api/v1/team/:teamId/devices/provisioning

--- a/test/unit/forge/routes/api/teamDevices_spec.js
+++ b/test/unit/forge/routes/api/teamDevices_spec.js
@@ -188,29 +188,55 @@ describe('Team Devices API', function () {
             it('by instance->application name', async function () {
                 // Sort by application name ASC (default)
                 const resultName = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application`)
-                resultName.map((device) => device.application?.name).should.match([undefined, 'application-1', 'application-1', 'application-2'])
+
+                // SQLite puts undefined includes first ASC, Postgres has it last...
+                const usingSQLite = resultName[0].application === undefined
+                const ascendingOrder = ['application-1', 'application-1', 'application-2']
+                const descendingOrder = ['application-2', 'application-1', 'application-1']
+                if (usingSQLite) {
+                    ascendingOrder.unshift(undefined)
+                    descendingOrder.push(undefined)
+                } else {
+                    ascendingOrder.push(undefined)
+                    descendingOrder.unshift(undefined)
+                }
+
+                resultName.map((device) => device.application?.name).should.match(ascendingOrder)
 
                 // Sort by application name DESC (explicit)
                 const resultNameDesc = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application&order=desc`)
-                resultNameDesc.map((device) => device.application?.name).should.match(['application-2', 'application-1', 'application-1', undefined])
+                resultNameDesc.map((device) => device.application?.name).should.match(descendingOrder)
 
                 // Sort by application name ASC (explicit)
                 const resultNameAsc = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=application&order=asc`)
-                resultNameAsc.map((device) => device.application?.name).should.match([undefined, 'application-1', 'application-1', 'application-2'])
+                resultNameAsc.map((device) => device.application?.name).should.match(ascendingOrder)
             })
 
             it('by instance name', async function () {
                 // Sort by instance name ASC (default)
                 const resultName = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance`)
-                resultName.map((device) => device.instance?.name).should.match([undefined, 'instance-2', 'project1', 'project1'])
+
+                // SQLite puts undefined includes first ASC, Postgres has it last...
+                const usingSQLite = resultName[0].instance === undefined
+                const ascendingOrder = ['instance-2', 'project1', 'project1']
+                const descendingOrder = ['project1', 'project1', 'instance-2']
+                if (usingSQLite) {
+                    ascendingOrder.unshift(undefined)
+                    descendingOrder.push(undefined)
+                } else {
+                    ascendingOrder.push(undefined)
+                    descendingOrder.unshift(undefined)
+                }
+
+                resultName.map((device) => device.instance?.name).should.match(ascendingOrder)
 
                 // Sort by instance name DESC (explicit)
                 const resultNameDesc = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance&order=desc`)
-                resultNameDesc.map((device) => device.instance?.name).should.match(['project1', 'project1', 'instance-2', undefined])
+                resultNameDesc.map((device) => device.instance?.name).should.match(descendingOrder)
 
                 // Sort by instance name ASC (explicit)
                 const resultNameAsc = await queryDevices(`/api/v1/teams/${TestObjects.ATeam.hashid}/devices?sort=instance&order=asc`)
-                resultNameAsc.map((device) => device.instance?.name).should.match([undefined, 'instance-2', 'project1', 'project1'])
+                resultNameAsc.map((device) => device.instance?.name).should.match(ascendingOrder)
             })
         })
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/flowforge/flowforge/pull/2677 that adds full server side test coverage after issues on staging causes by postgres (cypress uses sqlite).

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/2379

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

