### PR TITLE
Do not add module to instance settings if error in audit event object

### DIFF
--- a/forge/routes/logging/index.js
+++ b/forge/routes/logging/index.js
@@ -49,9 +49,9 @@ module.exports = async function (app) {
                 auditEvent
             )
         }
-        if (event === 'nodes.install') {
+        if (event === 'nodes.install' && !error) {
             await app.db.controllers.Project.addProjectModule(request.project, auditEvent.module, auditEvent.version)
-        } else if (event === 'nodes.remove') {
+        } else if (event === 'nodes.remove' && !error) {
             await app.db.controllers.Project.removeProjectModule(request.project, auditEvent.module)
         }
         response.status(200).send()

--- a/test/unit/forge/routes/logging/index_spec.js
+++ b/test/unit/forge/routes/logging/index_spec.js
@@ -1,4 +1,6 @@
 const should = require('should') // eslint-disable-line
+const sinon = require('sinon')
+
 const setup = require('../setup')
 
 describe('Logging API', function () {
@@ -24,6 +26,13 @@ describe('Logging API', function () {
         await TestObjects.team1.addProject(TestObjects.project2)
         TestObjects.tokens.project1 = (await TestObjects.project1.refreshAuthTokens()).token
         TestObjects.tokens.project2 = (await TestObjects.project2.refreshAuthTokens()).token
+
+        sinon.stub(app.db.controllers.Project, 'addProjectModule')
+        sinon.stub(app.db.controllers.Project, 'removeProjectModule')
+    })
+    afterEach(function () {
+        app.db.controllers.Project.addProjectModule.reset()
+        app.db.controllers.Project.removeProjectModule.reset()
     })
 
     after(async () => {
@@ -33,6 +42,8 @@ describe('Logging API', function () {
         delete TestObjects.project1
         delete TestObjects.project2
         delete TestObjects.alice
+        app.db.controllers.Project.addProjectModule.restore()
+        app.db.controllers.Project.removeProjectModule.restore()
     })
 
     it('Accepts valid token', async function () {
@@ -72,5 +83,56 @@ describe('Logging API', function () {
             payload: { event: 'start-failed', error: { code: 'test_code', error: 'test_error' } }
         })
         response.should.have.property('statusCode', 200)
+    })
+
+    it('Adds module to instance settings for nodes.install event', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
+        const response = await app.inject({
+            method: 'POST',
+            url,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project1}`
+            },
+            payload: { event: 'nodes.install', module: '@flowforge/newmodule', version: '0.4.0', path: '/nodes' }
+        })
+        response.should.have.property('statusCode', 200)
+        app.db.controllers.Project.addProjectModule.called.should.be.true()
+        const args = app.db.controllers.Project.addProjectModule.lastCall.args
+        args.should.have.length(3)
+        args[0].should.have.property('id', TestObjects.project1.id)
+        args[1].should.equal('@flowforge/newmodule')
+        args[2].should.equal('0.4.0')
+    })
+
+    it('Does not add module to instance settings for nodes.install event with error', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
+        const response = await app.inject({
+            method: 'POST',
+            url,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project1}`
+            },
+            payload: { event: 'nodes.install', module: '@flowforge/error', error: 'not_found', version: '0.4.0', path: '/nodes' }
+        })
+        response.should.have.property('statusCode', 200)
+        app.db.controllers.Project.addProjectModule.called.should.be.false()
+    })
+
+    it('Removes module from instance settings for nodes.remove event', async function () {
+        const url = `/logging/${TestObjects.project1.id}/audit`
+        const response = await app.inject({
+            method: 'POST',
+            url,
+            headers: {
+                authorization: `Bearer ${TestObjects.tokens.project1}`
+            },
+            payload: { event: 'nodes.remove', module: '@flowforge/removemodule', version: '0.4.0', path: '/nodes' }
+        })
+        response.should.have.property('statusCode', 200)
+        app.db.controllers.Project.removeProjectModule.called.should.be.true()
+        const args = app.db.controllers.Project.removeProjectModule.lastCall.args
+        args.should.have.length(2)
+        args[0].should.have.property('id', TestObjects.project1.id)
+        args[1].should.equal('@flowforge/removemodule')
     })
 })


### PR DESCRIPTION
Fixes #2710 

## Description

If a node install fails, the audit log entry includes an 'error' property. We were not filtering on that, so we believed the install was successful and then adding the node to the instance settings.

This PR fixes that - adds the necessary filtering and adds test coverage for the audit-log handling in this area.

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
