### PR TITLE
Prevent polling for logs of a deleted instance

### DIFF
--- a/frontend/src/pages/instance/components/InstanceLogs.vue
+++ b/frontend/src/pages/instance/components/InstanceLogs.vue
@@ -75,6 +75,14 @@ export default {
         instance: 'fetchData'
     },
     async mounted () {
+        // https://github.com/flowforge/flowforge/issues/2707
+        // Something causes the InstanceLogs component to get remounted after
+        // the Instance is deleted and we navigate back to the Application view.
+        // Check the internal DELETE flag so we don't start polling for logs
+        // for the deleted instance.
+        if (this.instance.DELETED) {
+            return
+        }
         if (!this.instance.meta || this.instance.meta.state === 'suspended') {
             this.loading = false
         }
@@ -89,7 +97,7 @@ export default {
         },
         fetchData: async function () {
             if (this.instance.id) {
-                if (this.instance.meta && this.instance.meta.state !== 'suspended') {
+                if (this.instance.meta && this.instance.meta.state !== 'suspended' && this.instance.meta.state !== 'suspending') {
                     await this.loadItems(this.instance.id)
                     this.loading = false
                 } else {

--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -248,6 +248,11 @@ export default {
             const applicationId = this.instance.application.id
             this.loading.deleting = true
             InstanceApi.deleteInstance(this.instance).then(async () => {
+                // Something is triggering the instance components to get briefly
+                // remounted before the navigation back to the ApplicationInstances
+                // page occurs. To prevent those components from doing any work,
+                // setting a flag on the instance object.
+                this.instance.DELETED = true
                 await this.$store.dispatch('account/refreshTeam')
                 this.$router.push({ name: 'ApplicationInstances', params: { id: applicationId } })
                 alerts.emit('Instance successfully deleted.', 'confirmation')


### PR DESCRIPTION
Fixes #2707 

## Description

I'm not 100% happy with this fix. It is a workaround for something that Vue is doing unexpectedly - and a proper fix would be to do the right 'Vue' thing. But I cannot figure out what that be.

In summary:

1. The `InstanceLogs` component sets up a timer in its `mounted` function that polls for logs. It does this *after* an async call to get the initial set of logs.
2. The `$timer` mixin adds an `unmounted` function to clear the timers when the component is unmounted
3. When an Instance is deleted whilst viewing the logs page, I see:
      1. The existing `InstanceLogs` instance is unmounted and timer stopped
      2. A new instance of `InstanceLogs` is mounted - it makes its async call to get initial set of logs
      3. Before ^ completes, the component is unmounted and `$timer.stop` is called
      4. The initial log load from step 2 completes (with error as the instance has been deleted), it then calls `$timer.start`
      5. This means the timer is left running (as it got started (step 4) *after* the call to stop it (step 3)).

The result is a toast notification every 5 seconds reporting the logs couldn't be loaded - which keeps happening wherever you go in the app because the timer has been orphaned.

I cannot figure out why the component is getting remounted when we are triggering a navigation back to the ApplicationInstances page.

Instead, I set a flag on the instance object, `this.instance.DELETED`, to tell us this instance is deleted. The `InstanceLogs` component can then skip doing any work - in this case, both the initial load of the logs *and* starting the timer for ongoing polling.

It feels dirty to set a flag like this - there must be an explanation for why the component is being remounted briefly even though we're navigating away. 

---

Also spotted an issue with the log refresh of a suspend-**ing** instance - we shouldn't be polling if the instance is suspending.