### PR TITLE
Pin reusable workflow to commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       ( github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' ) ||
       github.event_name == 'schedule'
-    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
+    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@e3e734b910af78371b2c9a1c6856446d17421f50'
     with:
       package_name: flowforge
       build_package: true


### PR DESCRIPTION
## Description

Pin reusable workflow to commit SHA instead of branch name.

## Related Issue(s)

[220](https://github.com/flowforge/CloudProject/issues/220)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

