### PR TITLE
Further Postgres memory limit increase

### DIFF
--- a/.github/workflows/test-postgresql.yml
+++ b/.github/workflows/test-postgresql.yml
@@ -57,5 +57,5 @@ jobs:
           FF_TEST_DB_POSTGRES_USER: postgres
           FF_TEST_DB_POSTGRES_PASSWORD: secret
           FF_TEST_DB_POSTGRES_DATABASE: flowforge
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max-old-space-size=6144"
         run: npm run test

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 
 import { fileURLToPath, URL } from 'url'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 import Vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
@@ -11,9 +11,9 @@ export default defineConfig({
     test: {
         globals: true,
         environment: 'jsdom',
+        exclude: [...configDefaults.exclude, 'coverage/*'],
         coverage: {
             provider: 'istanbul',
-            src: ['./frontend/src'],
             reportsDirectory: 'coverage/reports/frontend',
             all: true,
             reporter: [ 'json' ]


### PR DESCRIPTION
## Description

Possible fix for the latest round of OOM errors in our progress tests.

- Instead npm memory limit to 6gb
- Configure vitest to ignore coverage directory

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1960

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

