### PR TITLE
Disable timers after unmount and fix instance log error

### DIFF
--- a/frontend/src/pages/instance/index.vue
+++ b/frontend/src/pages/instance/index.vue
@@ -254,7 +254,6 @@ export default {
             }).catch(err => {
                 console.warn(err)
                 alerts.emit('Instance failed to delete.', 'warning')
-            }).finally(() => {
                 this.loading.deleting = false
             })
         },


### PR DESCRIPTION
## Description

Full details in  https://github.com/flowforge/flowforge/pull/2732, but essentially, once the request to delete an instance completes, we were briefly re-mounting all of the instances components, before starting the redirect.

This PR:
- Only re-remounts the instance page if deleting if request fails

As a backstop, also adds a flag to the timers mixin that disables timers entirely for a component if it is unmounted. Printing an error in development to warn his has happened (because we should be avoiding it).

## Related Issue(s)

Replaces https://github.com/flowforge/flowforge/pull/2732
Fixes #2707 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

