### PR TITLE
Fix create TeamType dialog

### DIFF
--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <ff-dialog ref="dialog" :header="dialogTitle">
+    <ff-dialog ref="dialog" :header="dialogTitle" data-el="team-type-dialog">
         <template #default>
             <form class="space-y-6 mt-2" @submit.prevent>
                 <div class="grid gap-3 grid-cols-3 items-middle">

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -82,11 +82,11 @@
         <template #actions>
             <div class="w-full grow flex justify-between">
                 <div>
-                    <ff-button v-if="teamType" kind="danger" style="margin: 0;" @click="$emit('show-delete-dialog', teamType); $refs.dialog.close()">Delete Team Type</ff-button>
+                    <ff-button v-if="isEditingExisting" kind="danger" style="margin: 0;" @click="$emit('show-delete-dialog', teamType); $refs.dialog.close()">Delete Team Type</ff-button>
                 </div>
                 <div class="flex">
                     <ff-button kind="secondary" @click="$refs['dialog'].close()">Cancel</ff-button>
-                    <ff-button :disabled="!formValid" @click="confirm(); $refs.dialog.close()">{{ teamType ? 'Update' : 'Create' }}</ff-button>
+                    <ff-button :disabled="!formValid" @click="confirm(); $refs.dialog.close()">{{ isEditingExisting ? 'Update' : 'Create' }}</ff-button>
                 </div>
             </div>
         </template>
@@ -165,6 +165,7 @@ export default {
                         order: '0',
                         properties: {
                             billing: {},
+                            trial: {},
                             users: {},
                             devices: {},
                             instances: {},
@@ -215,6 +216,9 @@ export default {
         ...mapState('account', ['features']),
         formValid () {
             return (this.input.name)
+        },
+        isEditingExisting () {
+            return !!this.teamType
         },
         dialogTitle () {
             if (this.teamType) {

--- a/frontend/src/pages/admin/TeamTypes/index.vue
+++ b/frontend/src/pages/admin/TeamTypes/index.vue
@@ -2,7 +2,7 @@
     <div class="space-y-6">
         <SectionTopMenu hero="Team Types">
             <template #tools>
-                <ff-button data-action="create-type" @click="showEditTeamTypeDialog">
+                <ff-button data-action="create-type" @click="showEditTeamTypeDialog()">
                     <template #icon-right>
                         <PlusSmIcon />
                     </template>

--- a/test/e2e/frontend/cypress/tests/admin/team-types.spec.js
+++ b/test/e2e/frontend/cypress/tests/admin/team-types.spec.js
@@ -1,0 +1,86 @@
+describe('FlowForge - Instance Types', () => {
+    beforeEach(() => {
+        cy.intercept('GET', '/api/*/project-types*').as('getInstanceTypes')
+        cy.intercept('GET', '/api/*/team-types*').as('getTeamTypes')
+
+        cy.login('alice', 'aaPassword')
+        cy.home()
+        cy.visit('/admin/team-types')
+        cy.wait('@getTeamTypes')
+    })
+
+    it('can successfully create a team type', () => {
+        cy.intercept('POST', '/api/*/team-types').as('postTeamTypes')
+
+        cy.get('[data-el="team-type-dialog"]').should('not.be.visible')
+
+        cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').its('length').then((activeTypes) => {
+            cy.get('[data-action="create-type"]').should('exist')
+            cy.get('[data-action="create-type"]').click()
+            cy.get('[data-el="team-type-dialog"]').should('exist')
+
+            cy.get('[data-form="name"] input[type="text"]').type('New Team Type')
+            cy.get('[data-form="description"] textarea').type('Description goes here')
+
+            cy.get('[data-el="team-type-dialog"] button.ff-btn.ff-btn--primary').click()
+
+            cy.wait('@postTeamTypes')
+
+            cy.get('[data-el="team-type-dialog"]').should('not.be.visible')
+
+            cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').should('have.length', activeTypes + 1)
+        })
+    })
+
+    it('can successfully set an team type as inactive', () => {
+        cy.intercept('PUT', '/api/*/team-types/*').as('updateTeamType')
+
+        cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').its('length').then((activeTypes) => {
+            // should have "No Data" row
+            cy.get('[data-el="inactive-types"] tbody').find('tr').should('have.length', 1)
+            cy.get('[data-el="inactive-types"] tbody').contains('td', 'No Data Found')
+
+            cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').eq(1).find('.ff-tile-selection-option--edit').click()
+
+            cy.get('[data-el="team-type-dialog"]').should('be.visible')
+
+            // set as inactive
+            cy.get('[data-form="active"] span.checkbox').click()
+            // confirm changes
+            cy.get('[data-el="team-type-dialog"] button.ff-btn.ff-btn--primary').click()
+
+            cy.wait('@updateTeamType')
+
+            // one active stacks
+            cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').should('have.length', activeTypes - 1)
+
+            // one inactive stacks
+            cy.get('[data-el="inactive-types"] tbody').find('tr').should('have.length', 1)
+            cy.get('[data-el="inactive-types"] tbody').contains('td', 'New Team Type')
+        })
+    })
+
+    it('can successfully delete an inactive instance type', () => {
+        cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').its('length').then((activeTypes) => {
+            cy.get('[data-el="inactive-types"] tbody .ff-kebab-menu').click()
+            cy.get('[data-el="inactive-types"] tbody .ff-kebab-menu .ff-kebab-options').find('.ff-list-item').eq(1).click()
+
+            // TODO: Adding local exception until our dialog boxes provide a data attr to use
+            // eslint-disable-next-line cypress/require-data-selectors
+            cy.get('.ff-dialog-box').should('be.visible')
+            // eslint-disable-next-line cypress/require-data-selectors
+            cy.get('.ff-dialog-box .ff-dialog-header').contains('Delete Team Type')
+
+            // confirm delete
+            // eslint-disable-next-line cypress/require-data-selectors
+            cy.get('.ff-dialog-box button.ff-btn.ff-btn--danger').click()
+
+            // no change in active types
+            cy.get('[data-el="active-types"]').find('.ff-tile-selection-option').should('have.length', activeTypes)
+
+            // no inactive instance types
+            cy.get('[data-el="inactive-types"] tbody').find('tr').should('have.length', 1) // no data found message
+            cy.get('[data-el="inactive-types"] tbody').contains('td', 'No Data Found')
+        })
+    })
+})


### PR DESCRIPTION
## Description

The Create TeamType dialog wasn't behaving for two reasons:

 - the event handler on the button to open the dialog was passing through the MouseEvent which was being misinterpreted as a TeamType to be edited
 - the dialog was looking accessing properties of an undefined on the blank TeamType object

