### PR TITLE
Allow admin to create application/instances

### DIFF
--- a/forge/routes/api/application.js
+++ b/forge/routes/api/application.js
@@ -36,7 +36,18 @@ module.exports = async function (app) {
             async (request, reply) => {
                 request.teamMembership = await request.session.User.getTeamMembership(request.body.teamId)
                 if (!request.teamMembership) {
-                    return reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                    // This could be an admin who is allowed to create an application.
+                    if (!request.session.User.admin) {
+                        return reply.code(401).send({ code: 'unauthorized', error: 'unauthorized' })
+                    } else {
+                        // This is an admin
+                        request.team = await app.db.models.Team.byId(request.body.teamId)
+                    }
+                } else {
+                    request.team = await request.teamMembership.getTeam()
+                }
+                if (!request.team) {
+                    return reply.code(409).send({ code: 'invalid_team', error: 'Invalid team id' })
                 }
             },
             app.needsPermission('project:create') // TODO Using project level permissions
@@ -67,7 +78,7 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
-        const team = await request.teamMembership.getTeam()
+        const team = request.team
 
         const name = request.body.name?.trim()
         if (name === '') {

--- a/forge/routes/api/project.js
+++ b/forge/routes/api/project.js
@@ -151,7 +151,7 @@ module.exports = async function (app) {
             }
         }
     }, async (request, reply) => {
-        const team = await request.teamMembership.getTeam()
+        const team = await request.application.getTeam()
         const application = request.application
 
         const projectType = await app.db.models.ProjectType.byId(request.body.projectType)

--- a/test/unit/forge/routes/api/application_spec.js
+++ b/test/unit/forge/routes/api/application_spec.js
@@ -59,7 +59,30 @@ describe('Application API', function () {
 
     describe('Create application', async function () {
         // POST /api/v1/applications
-        it('Admin: Create a simple application', async function () {
+        it('Admin (non-member): Create a simple application', async function () {
+            const sid = await login('alice', 'aaPassword')
+
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/applications',
+                cookies: { sid },
+                payload: {
+                    name: 'my first admin application',
+                    description: 'my first application description',
+                    teamId: TestObjects.BTeam.hashid
+                }
+            })
+
+            response.statusCode.should.equal(200)
+
+            const result = response.json()
+            const newApplication = await app.db.models.Application.byId(result.id)
+            result.should.have.property('id', newApplication.hashid)
+            result.should.have.property('name', 'my first admin application')
+            result.should.have.property('description', 'my first application description')
+        })
+
+        it('Admin (member): Create a simple application', async function () {
             const sid = await login('alice', 'aaPassword')
 
             const response = await app.inject({
@@ -140,6 +163,25 @@ describe('Application API', function () {
             const result = response.json()
             result.should.have.property('code', 'unauthorized')
             result.should.have.property('error')
+        })
+
+        it('Admin (non-member): Cannot create an application in non-existent team', async function () {
+            const sid = await login('alice', 'aaPassword')
+
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/applications',
+                cookies: { sid },
+                payload: {
+                    name: 'my first admin application',
+                    description: 'my first application description',
+                    teamId: 'doesNotExist'
+                }
+            })
+
+            response.statusCode.should.equal(409)
+            const result = response.json()
+            result.should.have.property('code', 'invalid_team')
         })
     })
 

--- a/test/unit/forge/routes/api/project_spec.js
+++ b/test/unit/forge/routes/api/project_spec.js
@@ -162,6 +162,25 @@ describe('Project API', function () {
             response.statusCode.should.equal(401)
         })
 
+        it('Non-member admin can create project', async function () {
+            // Alice (non-member admin) cannot create in CTeam
+            const response = await app.inject({
+                method: 'POST',
+                url: '/api/v1/projects',
+                payload: {
+                    name: generateProjectName(),
+                    applicationId: TestObjects.ApplicationC.hashid,
+                    projectType: TestObjects.projectType1.hashid,
+                    template: TestObjects.template1.hashid,
+                    stack: TestObjects.stack1.hashid
+                },
+                cookies: { sid: TestObjects.tokens.alice }
+            })
+            response.statusCode.should.equal(200)
+            const result = response.json()
+            result.should.have.property('id')
+        })
+
         it('Fails for unknown template', async function () {
             const response = await app.inject({
                 method: 'POST',


### PR DESCRIPTION
## Description

Currently an Admin user is not able to create an Application or an Instance in a team they are not a member of.

The Create Instance endpoint did have some code to allow Admins to call it, however it then fails as it uses the user's `teamMembership` to retrieve the `Team` object - which a non-member admin won't have.

This PR fixes both items and adds test coverage.

Admins can now create applications and instances within a team they are not a member. This is inline with the other actions an admin is permitted to do.

This is purely an API level change - we do not expose this capability in the UI.

This was originally flagged in Node-RED slack by a user wanting to automate App/Instance creation on behalf of their users.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->

## Labels

 - [x] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

