### PR TITLE
Introduce Enterprise license tier

### DIFF
--- a/forge/ee/lib/index.js
+++ b/forge/ee/lib/index.js
@@ -6,9 +6,11 @@ module.exports = fp(async function (app, opts, done) {
     }
     require('./projectComms').init(app)
     require('./deviceEditor').init(app)
-    require('./ha').init(app)
 
-    app.decorate('sso', await require('./sso').init(app))
+    if (app.license.get('tier') === 'enterprise') {
+        require('./ha').init(app)
+        app.decorate('sso', await require('./sso').init(app))
+    }
 
     // Set the Team Library Feature Flag
     app.config.features.register('shared-library', true, true)

--- a/forge/ee/routes/index.js
+++ b/forge/ee/routes/index.js
@@ -13,8 +13,10 @@ module.exports = async function (app) {
     await app.register(require('./pipeline'), { prefix: '/api/v1', logLevel: app.config.logging.http })
     await app.register(require('./deviceEditor'), { prefix: '/api/v1/devices/:deviceId/editor', logLevel: app.config.logging.http })
 
-    await app.register(require('./ha'), { prefix: '/api/v1/projects/:projectId/ha', logLevel: app.config.logging.http })
+    if (app.license.get('tier') === 'enterprise') {
+        await app.register(require('./ha'), { prefix: '/api/v1/projects/:projectId/ha', logLevel: app.config.logging.http })
 
-    // Important: keep SSO last to avoid its error handling polluting other routes.
-    await app.register(require('./sso'), { logLevel: app.config.logging.http })
+        // Important: keep SSO last to avoid its error handling polluting other routes.
+        await app.register(require('./sso'), { logLevel: app.config.logging.http })
+    }
 }

--- a/forge/licensing/index.js
+++ b/forge/licensing/index.js
@@ -166,13 +166,14 @@ module.exports = fp(async function (app, opts, next) {
             app.log.info('  * Development-mode License *')
             app.log.info('  ****************************')
         }
-        app.log.info(` License ID : ${activeLicense.id}`)
-        app.log.info(` Org        : ${activeLicense.organisation}`)
-        app.log.info(` Valid From : ${activeLicense.validFrom.toISOString()}`)
+        app.log.info(` License ID   : ${activeLicense.id}`)
+        app.log.info(` Org          : ${activeLicense.organisation}`)
+        app.log.info(` Valid From   : ${activeLicense.validFrom.toISOString()}`)
+        app.log.info(` License Tier : ${activeLicense.tier}`)
         if (activeLicense.expired) {
-            app.log.warn(` Expired    : ${activeLicense.expiresAt.toISOString()}`)
+            app.log.warn(` Expired      : ${activeLicense.expiresAt.toISOString()}`)
         } else {
-            app.log.info(` Expires    : ${activeLicense.expiresAt.toISOString()}`)
+            app.log.info(` Expires      : ${activeLicense.expiresAt.toISOString()}`)
         }
         await reportUsage()
     }

--- a/forge/licensing/license-generator.js
+++ b/forge/licensing/license-generator.js
@@ -54,6 +54,8 @@ const { v4: uuidv4 } = require('uuid')
                 replace: '*'
             })
 
+        const licenseTier = await promptly.choose('License tier (team*, enterprise): ', ['team', 'enterprise'], { default: 'team', trim: true })
+
         const licenseHolder = await promptly.prompt('License holder name: ')
 
         const maxUsers = parseInt(await promptly.prompt('Max allowed users: ', { default: '150' }))
@@ -102,7 +104,8 @@ const { v4: uuidv4 } = require('uuid')
             users: maxUsers,
             teams: maxTeams,
             projects: maxProjects,
-            devices: maxDevices
+            devices: maxDevices,
+            tier: licenseTier
         }
 
         if (devLicense) {

--- a/forge/licensing/license-generator.js
+++ b/forge/licensing/license-generator.js
@@ -54,7 +54,7 @@ const { v4: uuidv4 } = require('uuid')
                 replace: '*'
             })
 
-        const licenseTier = await promptly.choose('License tier (team*, enterprise): ', ['team', 'enterprise'], { default: 'team', trim: true })
+        const licenseTier = await promptly.choose('License tier (teams*, enterprise): ', ['teams', 'enterprise'], { default: 'teams', trim: true })
 
         const licenseHolder = await promptly.prompt('License holder name: ')
 

--- a/forge/licensing/loader.js
+++ b/forge/licensing/loader.js
@@ -19,6 +19,7 @@ class LicenseDetails {
         this.projects = claims.projects || 0
         this.devices = claims.devices || 0
         this.teams = claims.teams || 0
+        this.tier = claims.tier || 'enterprise'
         Object.freeze(this)
     }
 

--- a/frontend/src/pages/admin/Overview.vue
+++ b/frontend/src/pages/admin/Overview.vue
@@ -36,6 +36,7 @@
             <table v-if="license">
                 <tr><td class="font-medium p-2 pr-4 align-top">Type</td><td class="p-2"><span v-if="!license.dev">FlowFuse Enterprise Edition</span><span v-else class="font-bold">FlowFuse Development Only</span></td></tr>
                 <tr><td class="font-medium p-2 pr-4 align-top">Organisation</td><td class="p-2">{{ license.organisation }}</td></tr>
+                <tr><td class="font-medium p-2 pr-4 align-top">Tier</td><td class="p-2">{{ license.tier }}</td></tr>
                 <tr><td class="font-medium p-2 pr-4 align-top">Expires</td><td class="p-2">{{ license.expires }}<br><span class="text-xs">{{ license.expiresAt }}</span></td></tr>
             </table>
             <div v-else>

--- a/frontend/src/pages/admin/Settings/License.vue
+++ b/frontend/src/pages/admin/Settings/License.vue
@@ -39,6 +39,7 @@
                     <tr v-if="inspectedLicense.dev"><td class="font-medium p-2 pr-4 align-top" colspan="2">Development-mode Only</td></tr>
                     <tr><td class="font-medium p-2 pr-4 align-top">License ID</td><td class="p-2">{{ inspectedLicense.id }}</td></tr>
                     <tr><td class="font-medium p-2 pr-4 align-top">Organisation</td><td class="p-2">{{ inspectedLicense.organisation }}</td></tr>
+                    <tr><td class="font-medium p-2 pr-4 align-top">Tier</td><td class="p-2">{{ inspectedLicense.tier }}</td></tr>
                     <tr><td class="font-medium p-2 pr-4 align-top">Expires</td><td class="p-2">{{ inspectedLicense.expires }}<br><span class="text-xs">{{ inspectedLicense.expiresAt }}</span></td></tr>
                 </table>
                 <details><pre class="break-words">{{ inspectedLicense }}</pre></details>

--- a/test/unit/forge/licensing/index_spec.js
+++ b/test/unit/forge/licensing/index_spec.js
@@ -41,10 +41,9 @@ describe('License API', async function () {
     */
     const TEST_LICENSE_0_CLAIMS = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNDgxOTY4fQ.kvFn4k9zPMEX8fL_VYrr4ElarqBd8MfrRh7UtIczqfPtWynijux37KjjPZPfMTKKr1hGWvb5rejn-mmceX9NfQ' // eslint-disable-line camelcase
 
-
     /**
     * Test License with tier: teams
-    * 
+    *
     * Details:
     * ```
     * {
@@ -65,9 +64,9 @@ describe('License API', async function () {
     */
     const TEST_LICENSE_TEAM = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQyOWE5ZjM1LTA3ZmMtNDlmYy1iNGY5LTA3MjY0ZGQxOTE2MCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6InRlYW1zIiwiZGV2Ijp0cnVlLCJpYXQiOjE2OTQ3MDExNzh9.ENcnQ-_c-sBGmEAQjiLbt5rIBRVCFBeLj2uZYXrGRoJ3JY7XL5r12KCNAW12BiMkTVqvCVnsRIA3lyQz-yteKA' // eslint-disable-line camelcase
 
-/**
+    /**
     * Test License with tier: enterprise
-    * 
+    *
     * Details:
     * ```
     * {
@@ -86,8 +85,7 @@ describe('License API', async function () {
     * }
     * ```
     */
-const TEST_LICENSE_ENTERPRISE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjJmZjAwMjJiLTAwOGMtNDI3OS1hNWU5LTEwOTI2YTNhNWNjMCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTY5NDcwMTM3Nn0.3Gtyr0axCR2LcBUFAJgDwfIjhLEBbd91rHiGpePHl_oBab9Y6f3osPK6xBtR5ZnRwuSg6XuTp6xc7bQtdONKmA' // eslint-disable-line camelcase
-
+    const TEST_LICENSE_ENTERPRISE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjJmZjAwMjJiLTAwOGMtNDI3OS1hNWU5LTEwOTI2YTNhNWNjMCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTY5NDcwMTM3Nn0.3Gtyr0axCR2LcBUFAJgDwfIjhLEBbd91rHiGpePHl_oBab9Y6f3osPK6xBtR5ZnRwuSg6XuTp6xc7bQtdONKmA' // eslint-disable-line camelcase
 
     /**
      * Get the forge application (licensed or unlicensed)
@@ -288,7 +286,7 @@ const TEST_LICENSE_ENTERPRISE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Ij
         })
     })
     describe('licensed - EE teams', function () {
-        before( async function () {
+        before(async function () {
             app = await getApp(TEST_LICENSE_TEAM)
         })
         after(async function () {
@@ -299,7 +297,7 @@ const TEST_LICENSE_ENTERPRISE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Ij
         })
     })
     describe('licensed - EE enterprise', function () {
-        before( async function () {
+        before(async function () {
             app = await getApp(TEST_LICENSE_ENTERPRISE)
         })
         after(async function () {

--- a/test/unit/forge/licensing/index_spec.js
+++ b/test/unit/forge/licensing/index_spec.js
@@ -41,6 +41,54 @@ describe('License API', async function () {
     */
     const TEST_LICENSE_0_CLAIMS = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbG93Rm9yZ2UgSW5jLiIsInN1YiI6IkZsb3dGb3JnZSBJbmMuIiwibmJmIjoxNjYyNDIyNDAwLCJleHAiOjc5ODY5MDIzOTksIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsImRldiI6dHJ1ZSwiaWF0IjoxNjYyNDgxOTY4fQ.kvFn4k9zPMEX8fL_VYrr4ElarqBd8MfrRh7UtIczqfPtWynijux37KjjPZPfMTKKr1hGWvb5rejn-mmceX9NfQ' // eslint-disable-line camelcase
 
+
+    /**
+    * Test License with tier: teams
+    * 
+    * Details:
+    * ```
+    * {
+    *   "id": "afb0e083-e560-4c07-a919-87dd775bb7a8",
+    *   "iss": "FlowForge Inc.",
+    *   "sub": "FlowForge Inc.",
+    *   "nbf": 1694649600,
+    *   "exp": 32503680000,,
+    *   "note": "Development-mode Only. Not for production",
+    *   "users": 150,
+    *   "teams": 50,
+    *   "projects": 50,
+    *   "devices": 50,
+    *   "tier": "teams",
+    *   "dev": true
+    * }
+    * ```
+    */
+    const TEST_LICENSE_TEAM = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQyOWE5ZjM1LTA3ZmMtNDlmYy1iNGY5LTA3MjY0ZGQxOTE2MCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6InRlYW1zIiwiZGV2Ijp0cnVlLCJpYXQiOjE2OTQ3MDExNzh9.ENcnQ-_c-sBGmEAQjiLbt5rIBRVCFBeLj2uZYXrGRoJ3JY7XL5r12KCNAW12BiMkTVqvCVnsRIA3lyQz-yteKA' // eslint-disable-line camelcase
+
+/**
+    * Test License with tier: enterprise
+    * 
+    * Details:
+    * ```
+    * {
+    *   "id": "afb0e083-e560-4c07-a919-87dd775bb7a8",
+    *   "iss": "FlowForge Inc.",
+    *   "sub": "FlowForge Inc.",
+    *   "nbf": 1694649600,
+    *   "exp": 32503680000,,
+    *   "note": "Development-mode Only. Not for production",
+    *   "users": 150,
+    *   "teams": 50,
+    *   "projects": 50,
+    *   "devices": 50,
+    *   "tier": "enterprise",
+    *   "dev": true
+    * }
+    * ```
+    */
+const TEST_LICENSE_ENTERPRISE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjJmZjAwMjJiLTAwOGMtNDI3OS1hNWU5LTEwOTI2YTNhNWNjMCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTY5NDcwMTM3Nn0.3Gtyr0axCR2LcBUFAJgDwfIjhLEBbd91rHiGpePHl_oBab9Y6f3osPK6xBtR5ZnRwuSg6XuTp6xc7bQtdONKmA' // eslint-disable-line camelcase
+
+
     /**
      * Get the forge application (licensed or unlicensed)
      * @param {String} [license] (optional) The license to use. If null, use the default license
@@ -237,6 +285,28 @@ describe('License API', async function () {
             app.license.get('teams').should.equal(0)
             app.license.get('projects').should.equal(0)
             app.license.get('devices').should.equal(0)
+        })
+    })
+    describe('licensed - EE teams', function () {
+        before( async function () {
+            app = await getApp(TEST_LICENSE_TEAM)
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Identifies as Team Tier', async function () {
+            app.license.get('tier').should.equal('teams')
+        })
+    })
+    describe('licensed - EE enterprise', function () {
+        before( async function () {
+            app = await getApp(TEST_LICENSE_ENTERPRISE)
+        })
+        after(async function () {
+            await app.close()
+        })
+        it('Identifies as Enterprise Tier', async function () {
+            app.license.get('tier').should.equal('enterprise')
         })
     })
 })

--- a/test/unit/forge/licensing/loader_spec.js
+++ b/test/unit/forge/licensing/loader_spec.js
@@ -14,7 +14,6 @@ describe('License Loader', function () {
         const licenseDetails = await licensing.verifyLicense(TEST_LICENSE)
         licenseDetails.should.have.property('organisation', 'Acme Customer')
         licenseDetails.expired.should.false()
-        console.log(licenseDetails)
     })
     it('should load a newer license with id', async function () {
         // {

--- a/test/unit/forge/licensing/loader_spec.js
+++ b/test/unit/forge/licensing/loader_spec.js
@@ -75,7 +75,7 @@ describe('License Loader', function () {
         const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJTb21lb25lIEVsc2UiLCJleHAiOjcyNTgxMTg0MDAsInN1YiI6IkFjbWUgQ3VzdG9tZXIiLCJ0aWVyIjoidGVhbXMiLCJpYXQiOjE2Mjc1ODg3NjV9.SJP4dMqJdl7xb1ZKXn9SYdaJSDGOcOCIHk-rDdqr0RqC-vBTh-mFESFGNXyt6gEXiOFrZdevo624irU1Ntr-Hg'
         await licensing.verifyLicense(TEST_LICENSE).should.be.rejected()
     })
-    it('should load enterprise tire license', async function () {
+    it('should load enterprise tier license', async function () {
         const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjJmZjAwMjJiLTAwOGMtNDI3OS1hNWU5LTEwOTI2YTNhNWNjMCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTY5NDcwMTM3Nn0.3Gtyr0axCR2LcBUFAJgDwfIjhLEBbd91rHiGpePHl_oBab9Y6f3osPK6xBtR5ZnRwuSg6XuTp6xc7bQtdONKmA'
         const licenseDetails = await licensing.verifyLicense(TEST_LICENSE)
         licenseDetails.should.have.property('tier', 'enterprise')

--- a/test/unit/forge/licensing/loader_spec.js
+++ b/test/unit/forge/licensing/loader_spec.js
@@ -75,4 +75,9 @@ describe('License Loader', function () {
         const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJTb21lb25lIEVsc2UiLCJleHAiOjcyNTgxMTg0MDAsInN1YiI6IkFjbWUgQ3VzdG9tZXIiLCJ0aWVyIjoidGVhbXMiLCJpYXQiOjE2Mjc1ODg3NjV9.SJP4dMqJdl7xb1ZKXn9SYdaJSDGOcOCIHk-rDdqr0RqC-vBTh-mFESFGNXyt6gEXiOFrZdevo624irU1Ntr-Hg'
         await licensing.verifyLicense(TEST_LICENSE).should.be.rejected()
     })
+    it('should load enterprise tire license', async function () {
+        const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjJmZjAwMjJiLTAwOGMtNDI3OS1hNWU5LTEwOTI2YTNhNWNjMCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTY5NDcwMTM3Nn0.3Gtyr0axCR2LcBUFAJgDwfIjhLEBbd91rHiGpePHl_oBab9Y6f3osPK6xBtR5ZnRwuSg6XuTp6xc7bQtdONKmA'
+        const licenseDetails = await licensing.verifyLicense(TEST_LICENSE)
+        licenseDetails.should.have.property('tier', 'enterprise')
+    })
 })

--- a/test/unit/forge/licensing/loader_spec.js
+++ b/test/unit/forge/licensing/loader_spec.js
@@ -14,6 +14,7 @@ describe('License Loader', function () {
         const licenseDetails = await licensing.verifyLicense(TEST_LICENSE)
         licenseDetails.should.have.property('organisation', 'Acme Customer')
         licenseDetails.expired.should.false()
+        console.log(licenseDetails)
     })
     it('should load a newer license with id', async function () {
         // {
@@ -79,5 +80,10 @@ describe('License Loader', function () {
         const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjJmZjAwMjJiLTAwOGMtNDI3OS1hNWU5LTEwOTI2YTNhNWNjMCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6ImVudGVycHJpc2UiLCJkZXYiOnRydWUsImlhdCI6MTY5NDcwMTM3Nn0.3Gtyr0axCR2LcBUFAJgDwfIjhLEBbd91rHiGpePHl_oBab9Y6f3osPK6xBtR5ZnRwuSg6XuTp6xc7bQtdONKmA'
         const licenseDetails = await licensing.verifyLicense(TEST_LICENSE)
         licenseDetails.should.have.property('tier', 'enterprise')
+    })
+    it('should load teams tier license', async function () {
+        const TEST_LICENSE = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjQyOWE5ZjM1LTA3ZmMtNDlmYy1iNGY5LTA3MjY0ZGQxOTE2MCIsImlzcyI6IkZsb3dGb3JnZSBJbmMuIiwic3ViIjoiRmxvd0ZvcmdlIEluYy4iLCJuYmYiOjE2OTQ2NDk2MDAsImV4cCI6MzI1MDM2ODAwMDAsIm5vdGUiOiJEZXZlbG9wbWVudC1tb2RlIE9ubHkuIE5vdCBmb3IgcHJvZHVjdGlvbiIsInVzZXJzIjoxNTAsInRlYW1zIjo1MCwicHJvamVjdHMiOjUwLCJkZXZpY2VzIjo1MCwidGllciI6InRlYW1zIiwiZGV2Ijp0cnVlLCJpYXQiOjE2OTQ3MDExNzh9.ENcnQ-_c-sBGmEAQjiLbt5rIBRVCFBeLj2uZYXrGRoJ3JY7XL5r12KCNAW12BiMkTVqvCVnsRIA3lyQz-yteKA'
+        const licenseDetails = await licensing.verifyLicense(TEST_LICENSE)
+        licenseDetails.should.have.property('tier', 'teams')
     })
 })


### PR DESCRIPTION
part of #2652

Needs tests

## Description

<!-- Describe your changes in detail -->
Adds the `tier` field to licenses to distinguish between `team` and `enterprise` leveles.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#2652 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

