### PR TITLE
Add invoice proration option to TeamType

### DIFF
--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -150,14 +150,14 @@ module.exports = {
      * @returns {Promise} Resolves when the project has been stopped
      */
     remove: async (project) => {
-        if (project.state !== 'suspended') {
+        if (this._driver.remove) {
+            await this._driver.remove(project)
+        }
+        if (!project.state !== 'suspended') {
             // Only updated billing if the project isn't already suspended
             if (this._isBillingEnabled()) {
                 await this._subscriptionHandler.removeProject(project)
             }
-        }
-        if (this._driver.remove) {
-            await this._driver.remove(project)
         }
     },
     details: async (project) => {

--- a/forge/containers/wrapper.js
+++ b/forge/containers/wrapper.js
@@ -153,7 +153,10 @@ module.exports = {
         if (this._driver.remove) {
             await this._driver.remove(project)
         }
-        if (!project.state !== 'suspended') {
+        if (project.state !== 'suspended') {
+            // Update state so it gets removed from the billing counts
+            project.state = 'deleting'
+            await project.save()
             // Only updated billing if the project isn't already suspended
             if (this._isBillingEnabled()) {
                 await this._subscriptionHandler.removeProject(project)

--- a/forge/ee/lib/billing/Team.js
+++ b/forge/ee/lib/billing/Team.js
@@ -187,6 +187,7 @@ module.exports = function (app) {
      * @returns 'always_invoice' | 'create_prorations'
      */
     app.db.models.Team.prototype.getBillingProrationBehavior = async function () {
+        await this.ensureTeamTypeExists()
         return this.TeamType.getProperty('billing.proration', 'always_invoice')
     }
 }

--- a/forge/ee/lib/billing/Team.js
+++ b/forge/ee/lib/billing/Team.js
@@ -181,4 +181,12 @@ module.exports = function (app) {
         await app.billing.updateTeamDeviceCount(this)
         await app.billing.updateTeamInstanceCount(this)
     }
+
+    /**
+     * Get the desired proration behaviour when a subscription is modified.
+     * @returns 'always_invoice' | 'create_prorations'
+     */
+    app.db.models.Team.prototype.getBillingProrationBehavior = async function () {
+        return this.TeamType.getProperty('billing.proration', 'always_invoice')
+    }
 }

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -144,6 +144,7 @@ module.exports.init = async function (app) {
             // If a trial price is set, move it over to the proper team price
             const billingIds = await team.getTeamBillingIds()
             const subscription = await team.getSubscription()
+            const prorationBehavior = await team.getBillingProrationBehavior()
             if (billingIds.trialPrice && billingIds.trialProduct) {
                 const stripeSubscription = await stripe.subscriptions.retrieve(subscription.subscription)
                 // The subscription should have an item for the trial product. It needs to
@@ -152,14 +153,14 @@ module.exports.init = async function (app) {
                 if (existingTrialItem) {
                     app.log.info(`Updating team ${team.hashid} subscription: adding team item`)
                     await stripe.subscriptions.update(subscription.subscription, {
-                        proration_behavior: 'always_invoice',
+                        proration_behavior: prorationBehavior,
                         items: [{
                             price: billingIds.price,
                             quantity: 1
                         }]
                     })
                     app.log.info(`Updating team ${team.hashid} subscription: removing trial item`)
-                    await stripe.subscriptionItems.del(existingTrialItem.id, { proration_behavior: 'always_invoice' })
+                    await stripe.subscriptionItems.del(existingTrialItem.id, { proration_behavior: prorationBehavior })
                 }
             }
             await app.billing.updateTeamInstanceCount(team)
@@ -175,6 +176,7 @@ module.exports.init = async function (app) {
             const counts = await team.instanceCountByType({ state: { [Op.ne]: 'suspended' } })
             const subscription = await team.getSubscription()
             if (subscription && subscription.isActive()) {
+                const prorationBehavior = await team.getBillingProrationBehavior()
                 const stripeSubscription = await stripe.subscriptions.retrieve(subscription.subscription)
                 const newItems = []
                 // Get a list of the active instanceTypes
@@ -215,7 +217,7 @@ module.exports.init = async function (app) {
                                 app.log.info(`Updating team ${team.hashid} subscription: set instance type ${instanceType.hashid} count to ${billableCount} - removing item`)
                                 try {
                                     await stripe.subscriptionItems.del(instanceItem.id, {
-                                        proration_behavior: 'always_invoice'
+                                        proration_behavior: prorationBehavior
                                     })
                                 } catch (error) {
                                     app.log.warn(`Problem updating team ${team.hashid} subscription: ${error.message}`)
@@ -226,7 +228,7 @@ module.exports.init = async function (app) {
                                 try {
                                     await stripe.subscriptionItems.update(instanceItem.id, {
                                         quantity: billableCount,
-                                        proration_behavior: 'always_invoice'
+                                        proration_behavior: prorationBehavior
                                     })
                                 } catch (error) {
                                     app.log.warn(`Problem updating team ${team.hashid} subscription: ${error.message}`)
@@ -242,7 +244,7 @@ module.exports.init = async function (app) {
                             try {
                                 app.log.info(`Updating team ${team.hashid} subscription: set instance type ${instanceType.hashid} count to 0 - removing item`)
                                 await stripe.subscriptionItems.del(instanceItem.id, {
-                                    proration_behavior: 'always_invoice'
+                                    proration_behavior: prorationBehavior
                                 })
                             } catch (error) {
                                 app.log.warn(`Problem updating team ${team.hashid} subscription: ${error.message}`)
@@ -255,7 +257,7 @@ module.exports.init = async function (app) {
                     // Add new items to the subscription
                     try {
                         await stripe.subscriptions.update(subscription.subscription, {
-                            proration_behavior: 'always_invoice',
+                            proration_behavior: prorationBehavior,
                             items: newItems
                         })
                     } catch (error) {
@@ -278,6 +280,7 @@ module.exports.init = async function (app) {
             if (subscription && subscription.isActive()) {
                 const deviceCount = await team.deviceCount()
                 const deviceFreeAllocation = await team.getDeviceFreeAllowance()
+                const prorationBehavior = await team.getBillingProrationBehavior()
                 const billableCount = Math.max(0, deviceCount - deviceFreeAllocation)
                 const existingSub = await stripe.subscriptions.retrieve(subscription.subscription)
                 const subItems = existingSub.items
@@ -287,7 +290,7 @@ module.exports.init = async function (app) {
                         app.log.info(`Updating team ${team.hashid} subscription device count to ${billableCount}`)
                         const update = {
                             quantity: billableCount,
-                            proration_behavior: 'always_invoice'
+                            proration_behavior: prorationBehavior
                         }
                         try {
                             await stripe.subscriptionItems.update(deviceItem.id, update)
@@ -408,12 +411,13 @@ module.exports.init = async function (app) {
 
                 // Get the team billing ids for the new team type
                 const targetTeamBillingIds = await targetTeamType.getTeamBillingIds()
+                const prorationBehavior = await team.getBillingProrationBehavior()
 
                 try {
                     // Add the new team plan item
                     app.log.info(`Updating team ${team.hashid} subscription: adding team plan ${targetTeamBillingIds.price}`)
                     await stripe.subscriptions.update(subscription.subscription, {
-                        proration_behavior: 'always_invoice',
+                        proration_behavior: prorationBehavior,
                         items: [{
                             price: targetTeamBillingIds.price,
                             quantity: 1
@@ -424,7 +428,7 @@ module.exports.init = async function (app) {
                     // later with the new billing ids
                     for (const item of stripeSubscription.items.data) {
                         app.log.info(`Updating team ${team.hashid} subscription: removing item ${item.price.id}`)
-                        await stripe.subscriptionItems.del(item.id, { proration_behavior: 'always_invoice' })
+                        await stripe.subscriptionItems.del(item.id, { proration_behavior: prorationBehavior })
                     }
                 } catch (err) {
                     app.log.warn(`Problem updating team ${team.hashid} subscription: ${err.message}`)

--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -134,9 +134,6 @@ module.exports.init = async function (app) {
         },
 
         removeProject: async (team, project) => {
-            // Update state so it gets removed from the billing counts
-            project.state = 'deleting'
-            await project.save()
             return app.billing.updateTeamInstanceCount(team)
         },
         /**

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -26,6 +26,7 @@
                         <FormRow v-model="input.properties.billing.priceId" :type="editDisabled?'uneditable':''">Price Id</FormRow>
                         <FormRow v-model="input.properties.billing.description" placeholder="eg. $10/month" :type="editDisabled?'uneditable':''">Description</FormRow>
                     </div>
+                    <FormRow v-model="input.properties.billing.proration" :options="prorationOptions" class="mb-4">Invoicing</FormRow>
                     <div class="space-y-2">
                         <FormRow v-model="input.properties.trial.active" type="checkbox" class="mb-4">Enable trial mode for personal teams</FormRow>
                         <div v-if="input.properties.trial.active" class="grid gap-2 grid-cols-3 pl-4">
@@ -156,6 +157,9 @@ export default {
                     if (this.input.properties.features.teamHttpSecurity === undefined) {
                         this.input.properties.features.teamHttpSecurity = true
                     }
+                    if (this.input.properties.billing.proration === undefined) {
+                        this.input.properties.billing.proration = 'always_invoice'
+                    }
                 } else {
                     this.editDisabled = false
                     this.input = {
@@ -194,6 +198,10 @@ export default {
             teamType: null,
             instanceTypes: [],
             trialInstanceTypes: [],
+            prorationOptions: [
+                { label: 'Generate invoice for each change', value: 'always_invoice' },
+                { label: 'Add proration items to monthly invoice', value: 'create_prorations' }
+            ],
             input: {
                 name: '',
                 active: true,

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -339,7 +339,6 @@ describe('Billing', function () {
             stripe.subscriptions.update.resetHistory()
             stripe.subscriptionItems.update.resetHistory()
 
-            await app.project.destroy()
             await app.billing.removeProject(app.team, app.project)
 
             should.equal(stripe.subscriptionItems.update.calledOnce, true)
@@ -352,7 +351,6 @@ describe('Billing', function () {
         })
 
         it('removes a project from a Stripe subscription with existing invoice item for project type with quantity = 1', async function () {
-            await app.project.destroy()
             await app.billing.removeProject(app.team, app.project)
 
             should.equal(stripe.subscriptionItems.del.calledOnce, true)
@@ -402,7 +400,6 @@ describe('Billing', function () {
             stripe.subscriptions.update.resetHistory()
             stripe.subscriptionItems.update.resetHistory()
 
-            await app.project.destroy()
             await app.billing.removeProject(app.team, app.project)
 
             should.equal(stripe.subscriptionItems.update.calledOnce, true)

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -227,7 +227,29 @@ describe('Billing', function () {
             args[1].should.have.property('items')
             args[1].items[0].should.have.property('price', 'price_123')
             args[1].items[0].should.have.property('quantity', 1)
+            args[1].should.have.property('proration_behavior', 'always_invoice')
+            // Calling again - ensure it doesn't double the quantity
+            await app.billing.addProject(app.team, app.project)
+            should.equal(stripe.subscriptions.update.calledOnce, true)
+        })
 
+        it('adds a project to Stripe subscription - non-default proration behaviour', async function () {
+            const teamTypeProps = app.defaultTeamType.properties
+            teamTypeProps.billing = { proration: 'create_prorations' }
+            app.defaultTeamType.properties = teamTypeProps
+            await app.defaultTeamType.save()
+            await app.team.reload({ include: [app.db.models.TeamType] })
+
+            await app.billing.addProject(app.team, app.project)
+
+            should.equal(stripe.subscriptions.update.calledOnce, true)
+
+            const args = stripe.subscriptions.update.lastCall.args
+            args[0].should.equal('sub_1234567890')
+            args[1].should.have.property('items')
+            args[1].items[0].should.have.property('price', 'price_123')
+            args[1].items[0].should.have.property('quantity', 1)
+            args[1].should.have.property('proration_behavior', 'create_prorations')
             // Calling again - ensure it doesn't double the quantity
             await app.billing.addProject(app.team, app.project)
             should.equal(stripe.subscriptions.update.calledOnce, true)
@@ -324,6 +346,7 @@ describe('Billing', function () {
             const itemsArgs = stripe.subscriptionItems.update.lastCall.args
             itemsArgs[0].should.equal('item-0')
             itemsArgs[1].should.have.property('quantity', 1)
+            itemsArgs[1].should.have.property('proration_behavior', 'always_invoice')
 
             should.equal(stripe.subscriptions.update.calledOnce, false)
         })
@@ -335,6 +358,7 @@ describe('Billing', function () {
             should.equal(stripe.subscriptionItems.del.calledOnce, true)
             const itemsArgs = stripe.subscriptionItems.del.lastCall.args
             itemsArgs[0].should.equal('item-0')
+            itemsArgs[1].should.have.property('proration_behavior', 'always_invoice')
 
             should.equal(stripe.subscriptions.update.calledOnce, false)
         })
@@ -385,6 +409,7 @@ describe('Billing', function () {
             const itemsArgs = stripe.subscriptionItems.update.lastCall.args
             itemsArgs[0].should.equal('item-0')
             itemsArgs[1].should.have.property('quantity', 1)
+            itemsArgs[1].should.have.property('proration_behavior', 'always_invoice')
         })
     })
 

--- a/test/unit/forge/ee/lib/billing/index_spec.js
+++ b/test/unit/forge/ee/lib/billing/index_spec.js
@@ -339,6 +339,10 @@ describe('Billing', function () {
             stripe.subscriptions.update.resetHistory()
             stripe.subscriptionItems.update.resetHistory()
 
+            // Mark the project as deleting so it gets ignored by billing
+            app.project.state = 'deleting'
+            await app.project.save()
+
             await app.billing.removeProject(app.team, app.project)
 
             should.equal(stripe.subscriptionItems.update.calledOnce, true)
@@ -351,6 +355,10 @@ describe('Billing', function () {
         })
 
         it('removes a project from a Stripe subscription with existing invoice item for project type with quantity = 1', async function () {
+            // Mark the project as deleting so it gets ignored by billing
+            app.project.state = 'deleting'
+            await app.project.save()
+
             await app.billing.removeProject(app.team, app.project)
 
             should.equal(stripe.subscriptionItems.del.calledOnce, true)
@@ -399,6 +407,10 @@ describe('Billing', function () {
             await app.billing.addProject(app.team, instanceTwo)
             stripe.subscriptions.update.resetHistory()
             stripe.subscriptionItems.update.resetHistory()
+
+            // Mark the project as deleting so it gets ignored by billing
+            app.project.state = 'deleting'
+            await app.project.save()
 
             await app.billing.removeProject(app.team, app.project)
 


### PR DESCRIPTION
Fixes #2746 

## Description

This adds a new option to the TeamType to set the invoice proration behaviour.

<img width="381" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/91aa1973-fab9-4671-b359-643ece87ac1c">

The default option is the existing behaviour - triggering an invoice with every change made.

The new option, 'Add proration items to monthly invoice', will mean the team invoice is still set monthly, but will list all of the changes made through the month and the protated charges.


This also addresses an issue where deleting an Instance would not remove it properly from billing.
The unit tests have been updated to match how the relevant parts of the code are called to ensure they properly match the real behaviour - specifically, not deleting the Project database object before calling `billing.removeProject`.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
