### PR TITLE
Update cypres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "copy-webpack-plugin": "^11.0.0",
                 "cross-env": "^7.0.3",
                 "css-loader": "^6.8.1",
-                "cypress": "^12.17.4",
+                "cypress": "^13.2.0",
                 "dotenv-webpack": "^8.0.1",
                 "eslint": "^8.48.0",
                 "eslint-config-standard": "^17.1.0",
@@ -3193,9 +3193,9 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "2.88.12",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-            "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+            "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
             "dev": true,
             "dependencies": {
                 "aws-sign2": "~0.7.0",
@@ -3211,7 +3211,7 @@
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "~6.10.3",
+                "qs": "6.10.4",
                 "safe-buffer": "^5.1.2",
                 "tough-cookie": "^4.1.3",
                 "tunnel-agent": "^0.6.0",
@@ -5257,9 +5257,9 @@
             "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "node_modules/@types/node": {
-            "version": "16.18.39",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
-            "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ=="
+            "version": "18.17.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+            "integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A=="
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -8164,15 +8164,15 @@
             "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
         },
         "node_modules/cypress": {
-            "version": "12.17.4",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-            "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+            "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@cypress/request": "2.88.12",
+                "@cypress/request": "^3.0.0",
                 "@cypress/xvfb": "^1.2.4",
-                "@types/node": "^16.18.39",
+                "@types/node": "^18.17.5",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
                 "arch": "^2.2.0",
@@ -8218,7 +8218,7 @@
                 "cypress": "bin/cypress"
             },
             "engines": {
-                "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+                "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
             }
         },
         "node_modules/cypress/node_modules/ansi-styles": {
@@ -23229,9 +23229,9 @@
             "requires": {}
         },
         "@cypress/request": {
-            "version": "2.88.12",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-            "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+            "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
@@ -23247,7 +23247,7 @@
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "~6.10.3",
+                "qs": "6.10.4",
                 "safe-buffer": "^5.1.2",
                 "tough-cookie": "^4.1.3",
                 "tunnel-agent": "^0.6.0",
@@ -24827,9 +24827,9 @@
             "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "@types/node": {
-            "version": "16.18.39",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
-            "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ=="
+            "version": "18.17.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.16.tgz",
+            "integrity": "sha512-e0zgs7qe1XH/X3KEPnldfkD07LH9O1B9T31U8qoO7lqGSjj3/IrBuvqMeJ1aYejXRK3KOphIUDw6pLIplEW17A=="
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -27017,14 +27017,14 @@
             "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
         },
         "cypress": {
-            "version": "12.17.4",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-            "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+            "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
             "dev": true,
             "requires": {
-                "@cypress/request": "2.88.12",
+                "@cypress/request": "^3.0.0",
                 "@cypress/xvfb": "^1.2.4",
-                "@types/node": "^16.18.39",
+                "@types/node": "^18.17.5",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
                 "arch": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "cross-env": "^7.0.3",
         "css-loader": "^6.8.1",
-        "cypress": "^12.17.4",
+        "cypress": "^13.2.0",
         "dotenv-webpack": "^8.0.1",
         "eslint": "^8.48.0",
         "eslint-config-standard": "^17.1.0",


### PR DESCRIPTION
This clears the last dependbot security CVE for flowforge

Tested the cypres tests locally and they all pass (before and after the update)

