### PR TITLE
Add TeamType option to disable email sending for Team Trial

### DIFF
--- a/forge/ee/lib/billing/index.js
+++ b/forge/ee/lib/billing/index.js
@@ -340,20 +340,22 @@ module.exports.init = async function (app) {
                         team,
                         Date.now() + teamTrialDuration * ONE_DAY
                     )
-                    const emailInserts = {
-                        username: user.name,
-                        teamName: team.name,
-                        trialDuration: teamTrialDuration
+                    if (await team.TeamType.getProperty('trial.sendEmail', true)) {
+                        const emailInserts = {
+                            username: user.name,
+                            teamName: team.name,
+                            trialDuration: teamTrialDuration
+                        }
+                        if (teamTrialInstanceTypeId) {
+                            const trialProjectType = await app.db.models.ProjectType.byId(teamTrialInstanceTypeId)
+                            emailInserts.trialProjectTypeName = trialProjectType.name
+                        }
+                        await app.postoffice.send(
+                            user,
+                            'TrialTeamCreated',
+                            emailInserts
+                        )
                     }
-                    if (teamTrialInstanceTypeId) {
-                        const trialProjectType = await app.db.models.ProjectType.byId(teamTrialInstanceTypeId)
-                        emailInserts.trialProjectTypeName = trialProjectType.name
-                    }
-                    await app.postoffice.send(
-                        user,
-                        'TrialTeamCreated',
-                        emailInserts
-                    )
                 }
             }
         },

--- a/forge/ee/lib/billing/trialTask.js
+++ b/forge/ee/lib/billing/trialTask.js
@@ -93,17 +93,20 @@ module.exports.init = function (app) {
     }
 
     async function sendTrialEmail (team, template, inserts) {
-        const owners = await team.getOwners()
-        for (const user of owners) {
-            await app.postoffice.send(
-                user,
-                template,
-                {
-                    username: user.name,
-                    teamName: team.name,
-                    ...inserts
-                }
-            )
+        const teamType = await team.getTeamType()
+        if (await teamType.getProperty('trial.sendEmail', true)) {
+            const owners = await team.getOwners()
+            for (const user of owners) {
+                await app.postoffice.send(
+                    user,
+                    template,
+                    {
+                        username: user.name,
+                        teamName: team.name,
+                        ...inserts
+                    }
+                )
+            }
         }
     }
 

--- a/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
+++ b/frontend/src/pages/admin/TeamTypes/dialogs/TeamTypeEditDialog.vue
@@ -29,6 +29,7 @@
                     <FormRow v-model="input.properties.billing.proration" :options="prorationOptions" class="mb-4">Invoicing</FormRow>
                     <div class="space-y-2">
                         <FormRow v-model="input.properties.trial.active" type="checkbox" class="mb-4">Enable trial mode for personal teams</FormRow>
+                        <FormRow v-if="input.properties.trial.active" v-model="input.properties.trial.sendEmail" type="checkbox" class="pl-4 mb-4">Send trial emails</FormRow>
                         <div v-if="input.properties.trial.active" class="grid gap-2 grid-cols-3 pl-4">
                             <FormRow v-model="input.properties.trial.duration" :type="editDisabled?'uneditable':''" placeholder="days">Duration</FormRow>
                             <div class="col-span-2">
@@ -159,6 +160,9 @@ export default {
                     }
                     if (this.input.properties.billing.proration === undefined) {
                         this.input.properties.billing.proration = 'always_invoice'
+                    }
+                    if (this.input.properties.trial.active && this.input.properties.trial.sendEmail === undefined) {
+                        this.input.properties.trial.sendEmail = true
                     }
                 } else {
                     this.editDisabled = false


### PR DESCRIPTION
Fixes #2021 

## Description

This adds an option to TeamType to disable sending of Team Trial emails.

It does not touch any of the other emails the platform sends.

As Team Trials are configured against the Team Type it made sense to include the email sending flag there.
