### PR TITLE
Ensure content is cleared on selection change

### DIFF
--- a/frontend/src/pages/team/Library.vue
+++ b/frontend/src/pages/team/Library.vue
@@ -170,6 +170,7 @@ export default {
             if (entryIsFile) {
                 this.contents = contents
             } else {
+                this.contents = null // clear selection so that copy to clipboard is hidden
                 this.rows = this.formatEntries(contents, this.breadcrumbs.at(-1))
             }
         },


### PR DESCRIPTION
Fixes #2449 

## Description

Clears `this.content` to ensure copy button reflects current state

## Related Issue(s)

#2449 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

