### PR TITLE
Use applications image instead of default

### DIFF
--- a/frontend/src/pages/team/Applications.vue
+++ b/frontend/src/pages/team/Applications.vue
@@ -8,6 +8,9 @@
                 <template #help-header>
                     Applications
                 </template>
+                <template #pictogram>
+                    <img src="../../images/pictograms/application_red.png">
+                </template>
                 <template #helptext>
                     <p>This is a list of all Applications hosted on the same domain as FlowFuse.</p>
                     <p>Each Application can host multiple Node-RED instances.</p>


### PR DESCRIPTION
fixes #2612 

## Description

Use correct image instead of default image in the applications page info popup

## Related Issue(s)

#2612 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

