### PR TITLE
Push Snapshots Though Devops Pipelines

### DIFF
--- a/forge/db/migrations/20230919-01-add-action-to-pipeline-stage.js
+++ b/forge/db/migrations/20230919-01-add-action-to-pipeline-stage.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * Add ProjectSnapshots table
+ */
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+    /**
+     * upgrade database
+     * @param {QueryInterface} context Sequelize.QueryInterface
+     */
+    up: async (context) => {
+        const SNAPSHOT_ACTIONS = {
+            CREATE_SNAPSHOT: 'create_snapshot',
+            USE_LATEST_SNAPSHOT: 'use_latest_snapshot',
+            PROMPT: 'prompt'
+        }
+
+        await context.addColumn('PipelineStages', 'action', {
+            type: DataTypes.ENUM(Object.values(SNAPSHOT_ACTIONS)),
+            defaultValue: SNAPSHOT_ACTIONS.CREATE_SNAPSHOT,
+            allowNull: false
+        })
+    },
+    down: async (context) => {
+    }
+}

--- a/forge/db/models/Project.js
+++ b/forge/db/models/Project.js
@@ -288,6 +288,14 @@ module.exports = {
                     result.meta.isDeploying = isDeploying
 
                     return result
+                },
+
+                async getLatestSnapshot () {
+                    const snapshots = await this.getProjectSnapshots({
+                        order: [['createdAt', 'DESC']],
+                        limit: 1
+                    })
+                    return snapshots[0]
                 }
             },
             static: {

--- a/forge/ee/db/models/PipelineStage.js
+++ b/forge/ee/db/models/PipelineStage.js
@@ -2,6 +2,15 @@ const {
     DataTypes
 } = require('sequelize')
 
+const SNAPSHOT_ACTIONS = {
+    // Any changes to this list *must* be made via migration.
+    CREATE_SNAPSHOT: 'create_snapshot',
+    USE_LATEST_SNAPSHOT: 'use_latest_snapshot',
+    PROMPT: 'prompt'
+}
+
+Object.freeze(SNAPSHOT_ACTIONS)
+
 module.exports = {
     name: 'PipelineStage',
     schema: {
@@ -13,7 +22,13 @@ module.exports = {
             type: DataTypes.BOOLEAN,
             default: false
         },
+        action: {
+            type: DataTypes.ENUM(Object.values(SNAPSHOT_ACTIONS)),
+            defaultValue: SNAPSHOT_ACTIONS.CREATE_SNAPSHOT,
+            allowNull: false
+        },
 
+        // relations
         NextStageId: {
             type: DataTypes.INTEGER,
             allowNull: true
@@ -55,6 +70,7 @@ module.exports = {
                 }
             },
             static: {
+                SNAPSHOT_ACTIONS,
                 byId: async function (idOrHash) {
                     let id = idOrHash
                     if (typeof idOrHash === 'string') {

--- a/forge/ee/db/views/PipelineStage.js
+++ b/forge/ee/db/views/PipelineStage.js
@@ -6,6 +6,7 @@ module.exports = function (app) {
             id: { type: 'string' },
             name: { type: 'string' },
             instances: { type: 'array', items: { ref: 'InstanceSummaryList' } },
+            action: { type: 'string', enum: Object.values(app.db.models.PipelineStage.SNAPSHOT_ACTIONS) },
             NextStageId: { type: 'string' }
         }
     })
@@ -15,6 +16,7 @@ module.exports = function (app) {
         const filtered = {
             id: result.hashid,
             name: result.name,
+            action: result.action,
             deployToDevices: result.deployToDevices
         }
 

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -289,7 +289,7 @@ module.exports = async function (app) {
                 options
             )
         } catch (err) {
-            console.error(err)
+            app.log.error(err)
             return reply.status(500).send({ code: 'unexpected_error', error: err.toString() })
         }
         const instance = await app.db.models.Project.byId(instanceId)

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -499,7 +499,7 @@ module.exports = async function (app) {
                 })
             } else if (sourceStage.action === app.db.models.PipelineStage.SNAPSHOT_ACTIONS.PROMPT) {
                 const sourceSnapshotId = request.body?.sourceSnapshotId
-                if (!sourceSnapshotId) { 
+                if (!sourceSnapshotId) {
                     return reply.code(400).send({ code: 'no_source_snapshot', error: 'Source snapshot is required as deploy action is set to prompt for snapshot' })
                 }
 

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -525,7 +525,7 @@ module.exports = async function (app) {
                 decryptAndReEncryptCredentialsSecret: await sourceInstance.getCredentialSecret(),
                 targetSnapshotProperties: {
                     name: generateDeploySnapshotName(sourceSnapshot),
-                    description: generateDeploySnapshotDescription(sourceStage, targetStage, request.pipeline)
+                    description: generateDeploySnapshotDescription(sourceStage, targetStage, request.pipeline, sourceSnapshot)
                 }
             })
 

--- a/forge/ee/routes/pipeline/index.js
+++ b/forge/ee/routes/pipeline/index.js
@@ -255,7 +255,8 @@ module.exports = async function (app) {
                 properties: {
                     name: { type: 'string' },
                     instanceId: { type: 'string' },
-                    source: { type: 'string' }
+                    source: { type: 'string' },
+                    action: { type: 'string', enum: Object.values(app.db.models.PipelineStage.SNAPSHOT_ACTIONS) }
                 }
             },
             response: {
@@ -270,14 +271,15 @@ module.exports = async function (app) {
     }, async (request, reply) => {
         const team = await request.teamMembership.getTeam()
         const name = request.body.name?.trim() // name of the stage
-        const { instanceId, deployToDevices } = request.body
+        const { instanceId, deployToDevices, action } = request.body
 
         let stage
         try {
             const options = {
                 name,
                 instanceId,
-                deployToDevices
+                deployToDevices,
+                action
             }
             if (request.body.source) {
                 options.source = request.body.source
@@ -321,7 +323,8 @@ module.exports = async function (app) {
                 type: 'object',
                 properties: {
                     name: { type: 'string' },
-                    instanceId: { type: 'string' }
+                    instanceId: { type: 'string' },
+                    action: { type: 'string', enum: Object.values(app.db.models.PipelineStage.SNAPSHOT_ACTIONS) }
                 }
             },
             response: {
@@ -339,6 +342,10 @@ module.exports = async function (app) {
 
             if (request.body.name) {
                 stage.name = request.body.name
+            }
+
+            if (request.body.action) {
+                stage.action = request.body.action
             }
 
             if (request.body.instanceId) {

--- a/forge/services/snapshots.js
+++ b/forge/services/snapshots.js
@@ -133,8 +133,8 @@ module.exports.copySnapshot = async (
 
         let newCredentials
         if (!decryptAndReEncryptCredentialsSecret) {
-            console.warn(
-                'Assuming credentials are not encrypted as no decryptAndReEncryptCredentialsSecret was passed'
+            app.log.warn(
+                `Assuming credentials from snapshot ${name} (${snapshot.hashid}) are not encrypted as no decryptAndReEncryptCredentialsSecret was passed`
             )
             newCredentials = app.db.controllers.Project.exportCredentials(
                 oldCredentials,

--- a/forge/services/snapshots.js
+++ b/forge/services/snapshots.js
@@ -72,7 +72,7 @@ module.exports.generateDeploySnapshotDescription = (
             .trim()
 
         if (existingDescription) {
-            description += `\n\n${existingDescription}`
+            description = `${existingDescription}\n\n${description}`
         }
     }
 

--- a/forge/services/snapshots.js
+++ b/forge/services/snapshots.js
@@ -47,9 +47,9 @@ module.exports.generateDeploySnapshotName = (sourceSnapshot = null) => {
         new Date().toLocaleString('sv-SE') // YYYY-MM-DD HH:MM:SS
     ]
 
-    if (sourceSnapshot) {
+    if (sourceSnapshot?.name) {
         const extractedGroups = sourceSnapshot.name.match(extractNameRegex)
-        const existingName = extractedGroups?.groups.name ?? sourceSnapshot.name
+        const existingName = extractedGroups?.groups.name ?? (extractedGroups?.length > 0 ? '' : sourceSnapshot.name)
         if (existingName) {
             nameParts.unshift(existingName)
         }

--- a/frontend/src/api/pipeline.js
+++ b/frontend/src/api/pipeline.js
@@ -70,10 +70,15 @@ const deletePipelineStage = async (pipelineId, stageId) => {
  * @param {string} pipelineId
  * @param {string} sourceStageId
  * @param {string} targetStageId
+ * @param {string} sourceSnapshotId Optional, required if source stage is set to prompt
  * Deploy pipeline stage
  * */
-const deployPipelineStage = async (pipelineId, sourceStageId) => {
-    return client.put(`/api/v1/pipelines/${pipelineId}/stages/${sourceStageId}/deploy`).then(res => {
+const deployPipelineStage = async (pipelineId, sourceStageId, sourceSnapshotId) => {
+    const options = {}
+    if (sourceSnapshotId) {
+        options.sourceSnapshotId = sourceSnapshotId
+    }
+    return client.put(`/api/v1/pipelines/${pipelineId}/stages/${sourceStageId}/deploy`, options).then(res => {
         return res.data
     })
 }

--- a/frontend/src/api/pipeline.js
+++ b/frontend/src/api/pipeline.js
@@ -26,7 +26,8 @@ const addPipelineStage = async (pipelineId, stage) => {
     const options = {
         name: stage.name,
         instanceId: stage.instanceId,
-        deployToDevices: stage.deployToDevices
+        deployToDevices: stage.deployToDevices,
+        action: stage.action
     }
     if (stage.source) {
         options.source = stage.source

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -1,0 +1,60 @@
+<template>
+    <ff-dialog
+        ref="dialog"
+        data-el="deploy-stage-dialog"
+        :header="`Push to &quot;${target?.name}&quot;`"
+    >
+        <template #default>
+            <p>Are you sure you want to push from "{{ stage.name }}" to "{{ target?.name }}"?</p>
+            <p class="my-4">This will copy over all flows, nodes and credentials from "{{ stage.name }}".</p>
+            <template v-if="target?.deployToDevices">
+                <p class="my-4">And push out the changes to all devices connected to "{{ target?.name }}".</p>
+            </template>
+            <p class="my-4">It will also transfer the keys of any newly created Environment Variables that your target instance does not currently have.</p>
+        </template>
+        <template #actions>
+            <ff-button kind="secondary" @click="$refs['dialog'].close()">Cancel</ff-button>
+            <ff-button :disabled="!formValid" @click="confirm(); $refs.dialog.close()">Confirm</ff-button>
+        </template>
+    </ff-dialog>
+</template>
+
+<script>
+export default {
+    name: 'DeployStageDialog',
+    props: {
+        stage: {
+            required: true,
+            type: Object
+        }
+    },
+    emits: ['deploy-stage'],
+    setup () {
+        return {
+            show (target) {
+                this.target = target
+
+                this.$refs.dialog.show()
+            }
+        }
+    },
+    data () {
+        return {
+            target: null
+        }
+    },
+    computed: {
+        formValid () {
+            return this.target !== null
+        }
+    },
+    methods: {
+        close () {
+            this.$refs.dialog.close()
+        },
+        confirm () {
+            this.$emit('deploy-stage', this.target)
+        }
+    }
+}
+</script>

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -5,23 +5,88 @@
         :header="`Push to &quot;${target?.name}&quot;`"
     >
         <template #default>
-            <p>Are you sure you want to push from "{{ stage.name }}" to "{{ target?.name }}"?</p>
-            <p class="my-4">This will copy over all flows, nodes and credentials from "{{ stage.name }}".</p>
+            <p>
+                Are you sure you want to push from "{{ stage.name }}" to "{{
+                    target?.name
+                }}"?
+            </p>
+            <p class="my-4">
+                This will copy over all flows, nodes and credentials from "{{
+                    stage.name
+                }}".
+            </p>
             <template v-if="target?.deployToDevices">
-                <p class="my-4">And push out the changes to all devices connected to "{{ target?.name }}".</p>
+                <p class="my-4">
+                    And push out the changes to all devices connected to "{{
+                        target?.name
+                    }}".
+                </p>
             </template>
-            <p class="my-4">It will also transfer the keys of any newly created Environment Variables that your target instance does not currently have.</p>
+            <p class="my-4">
+                It will also transfer the keys of any newly created Environment
+                Variables that your target instance does not currently have.
+            </p>
+
+            <template v-if="promptForSnapshot">
+                <ff-loading v-if="loadingSnapshots" message="Loading stage Snapshots..." />
+                <form class="space-y-2" @submit.prevent="confirm">
+                    <p>
+                        Please select the Snapshot that you wish to push to "{{
+                            target?.name
+                        }}":
+                    </p>
+                    <FormRow data-form="snapshot" containerClass="w-full">
+                        Source Snapshot
+                        <template #input>
+                            <ff-dropdown
+                                v-if="snapshots.length > 0"
+                                v-model="input.selectedSnapshotId"
+                                placeholder="Select a snapshot"
+                                data-form="snapshot-select"
+                                class="w-full"
+                            >
+                                <ff-dropdown-option
+                                    v-for="snapshot in snapshotOptions"
+                                    :key="snapshot.value"
+                                    :label="snapshot.label"
+                                    :value="snapshot.value"
+                                />
+                            </ff-dropdown>
+                            <div v-else>
+                                There are no snapshots to choose from for this stage's instance
+                                yet!<br>
+                                Snapshots can be managed on the
+                                <router-link
+                                    :to="{
+                                        name: 'InstanceSnapshots',
+                                        params: { id: stage.instance.id },
+                                    }"
+                                >
+                                    Instance Snapshots
+                                </router-link>
+                                page.
+                            </div>
+                        </template>
+                    </FormRow>
+                </form>
+            </template>
         </template>
         <template #actions>
-            <ff-button kind="secondary" @click="$refs['dialog'].close()">Cancel</ff-button>
-            <ff-button :disabled="!formValid" @click="confirm(); $refs.dialog.close()">Confirm</ff-button>
+            <ff-button kind="secondary" @click="close">Cancel</ff-button>
+            <ff-button :disabled="!formValid" @click="confirm">Confirm</ff-button>
         </template>
     </ff-dialog>
 </template>
 
 <script>
+import SnapshotApi from '../../api/projectSnapshots.js'
+import FormRow from '../FormRow.vue'
+
 export default {
     name: 'DeployStageDialog',
+    components: {
+        FormRow
+    },
     props: {
         stage: {
             required: true,
@@ -34,26 +99,73 @@ export default {
             show (target) {
                 this.target = target
 
+                this.fetchData()
+
                 this.$refs.dialog.show()
             }
         }
     },
     data () {
         return {
-            target: null
+            target: null,
+            loadingSnapshots: false,
+            snapshots: [],
+            input: {
+                selectedSnapshotId: null
+            }
         }
     },
     computed: {
+        promptForSnapshot () {
+            return this.stage.action === 'prompt'
+        },
+
         formValid () {
-            return this.target !== null
+            return (
+                this.target !== null &&
+                    (this.promptForSnapshot ? this.input.selectedSnapshotId !== null : true)
+            )
+        },
+
+        snapshotOptions () {
+            return this.snapshots.map((snapshot) => {
+                return {
+                    value: snapshot.id,
+                    label: `${snapshot.name}${
+                        this.stage.instance.targetSnapshot?.id === snapshot.id
+                            ? ' (active)'
+                            : ''
+                    }`
+                }
+            })
         }
     },
     methods: {
         close () {
             this.$refs.dialog.close()
         },
+        fetchData: async function () {
+            this.loadingSnapshots = true
+
+            const data = await SnapshotApi.getInstanceSnapshots(
+                this.stage.instance.id
+            )
+            this.snapshots = data.snapshots
+
+            this.loadingSnapshots = false
+        },
         confirm () {
-            this.$emit('deploy-stage', this.target)
+            if (!this.formValid) {
+                return
+            }
+
+            const sourceSnapshot = this.snapshots.find(
+                (snapshot) => snapshot.id === this.input.selectedSnapshotId
+            )
+
+            this.$emit('deploy-stage', this.target, sourceSnapshot)
+
+            this.$refs.dialog.close()
         }
     }
 }

--- a/frontend/src/components/pipelines/DeployStageDialog.vue
+++ b/frontend/src/components/pipelines/DeployStageDialog.vue
@@ -11,19 +11,25 @@
                 }}"?
             </p>
             <p class="my-4">
-                This will copy over all flows, nodes and credentials from "{{
-                    stage.name
-                }}".
+                This will
+                <template v-if="stage.action === 'create_snapshot'">
+                    create a new snapshot in "{{ stage.name }}" and
+                </template>
+                <template v-else-if="stage.action === 'use_latest_snapshot'">
+                    use the latest instance snapshot from "{{ stage.name }}" and
+                </template>
+                <template v-else-if="stage.action==='prompt'">
+                    use the snapshot selected below from "{{ stage.name }}" and
+                </template>
+                copy over all flows, nodes and credentials to "{{ target?.name }}".
             </p>
             <template v-if="target?.deployToDevices">
                 <p class="my-4">
-                    And push out the changes to all devices connected to "{{
-                        target?.name
-                    }}".
+                    And push out the changes to all devices connected to "{{ target?.name }}".
                 </p>
             </template>
             <p class="my-4">
-                It will also transfer the keys of any newly created Environment
+                It will also transfer the keys, but not the values, of any newly created Environment
                 Variables that your target instance does not currently have.
             </p>
 
@@ -31,9 +37,7 @@
                 <ff-loading v-if="loadingSnapshots" message="Loading stage Snapshots..." />
                 <form class="space-y-2" @submit.prevent="confirm">
                     <p>
-                        Please select the Snapshot that you wish to push to "{{
-                            target?.name
-                        }}":
+                        Please select the Snapshot from "{{ stage.name }}" that you wish to push to "{{ target?.name }}":
                     </p>
                     <FormRow data-form="snapshot" containerClass="w-full">
                         Source Snapshot

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -153,19 +153,30 @@ export default {
             })
         },
 
-        async deployStage (target) {
+        async deployStage (target, sourceSnapshot) {
             this.$emit('stage-deploy-starting')
 
             try {
-                await PipelineAPI.deployPipelineStage(this.pipeline.id, this.stage.id)
+                await PipelineAPI.deployPipelineStage(this.pipeline.id, this.stage.id, sourceSnapshot.id)
             } catch (error) {
                 Alerts.emit(error.message, 'error')
                 return
             }
 
             this.$emit('stage-deploy-started')
+
+            const messageParts = ['Deployment']
+            if (sourceSnapshot) {
+                messageParts.push(`of snapshot "${sourceSnapshot.name}"`)
+            }
+            messageParts.push(`from "${this.stage.name}" to "${target.name}"`)
+            if (target.deployToDevices) {
+                messageParts.push(', and all its devices')
+            }
+            messageParts.push('has started.')
+
             Alerts.emit(
-                `Deployment from "${this.stage.name}" to "${target.name}"${target.deployToDevices ? ', and all its devices, ' : ''} has started.`,
+                messageParts.join(' '),
                 'confirmation'
             )
         },

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -156,7 +156,7 @@ export default {
             this.$refs.deployStageDialog.show(target)
         },
         edit () {
-            this.$router.push({
+            const route = {
                 name: 'EditPipelineStage',
                 params: {
                     // url params
@@ -164,7 +164,15 @@ export default {
                     pipelineId: this.pipeline.id,
                     stageId: this.stage.id
                 }
-            })
+            }
+
+            if (this.pipeline.stages.length > 0 && this.pipeline.stages.indexOf(this.stage) > 0) {
+                route.query = {
+                    sourceStage: this.pipeline.stages[this.pipeline.stages.indexOf(this.stage)].id
+                }
+            }
+
+            this.$router.push(route)
         },
 
         async deployStage (target, sourceSnapshot) {

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -58,7 +58,7 @@
                 <label>Status:</label>
                 <InstanceStatusBadge :status="stage.state" />
             </div>
-            <div class="ff-pipeline-stage-row">
+            <div v-if="playEnabled" class="ff-pipeline-stage-row">
                 <label>Deploy Action:</label>
                 <span>
                     <template v-if="stage.action === 'create_snapshot'">

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="stage" class="ff-pipeline-stage">
+    <div v-if="stage" class="ff-pipeline-stage" data-el="ff-pipeline-stage">
         <div class="ff-pipeline-stage-banner">
             <label>{{ stage.name }}</label>
             <div class="ff-pipeline-actions">

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -191,7 +191,8 @@ export default {
 
             Alerts.emit(
                 messageParts.join(' '),
-                'confirmation'
+                'confirmation',
+                5000
             )
         },
 

--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -58,6 +58,20 @@
                 <label>Status:</label>
                 <InstanceStatusBadge :status="stage.state" />
             </div>
+            <div class="ff-pipeline-stage-row">
+                <label>Deploy Action:</label>
+                <span>
+                    <template v-if="stage.action === 'create_snapshot'">
+                        Create new snapshot
+                    </template>
+                    <template v-else-if="stage.action === 'use_latest_snapshot'">
+                        Use latest instance snapshot
+                    </template>
+                    <template v-else-if="stage.action==='prompt'">
+                        Prompt to select snapshot
+                    </template>
+                </span>
+            </div>
         </div>
         <div v-else class="flex justify-center py-6">No Instances Bound</div>
         <DeployStageDialog

--- a/frontend/src/pages/application/PipelineStage/create.vue
+++ b/frontend/src/pages/application/PipelineStage/create.vue
@@ -55,7 +55,8 @@ export default {
             const options = {
                 name: input.name,
                 instanceId: input.instanceId,
-                deployToDevices: input.deployToDevices
+                deployToDevices: input.deployToDevices,
+                action: input.action
             }
             if (this.$route.query.sourceStage) {
                 options.source = this.$route.query.sourceStage

--- a/frontend/src/pages/application/PipelineStage/edit.vue
+++ b/frontend/src/pages/application/PipelineStage/edit.vue
@@ -8,6 +8,7 @@
             :instances="instances"
             :pipeline="pipeline"
             :stage="stage"
+            :sourceStage="$route.query.sourceStage"
             @submit="update"
         />
     </main>

--- a/frontend/src/pages/application/PipelineStage/edit.vue
+++ b/frontend/src/pages/application/PipelineStage/edit.vue
@@ -70,7 +70,8 @@ export default {
             const options = {
                 name: input.name,
                 instanceId: input.instanceId,
-                deployToDevices: input.deployToDevices
+                deployToDevices: input.deployToDevices,
+                action: input.action
             }
 
             await PipelinesAPI.updatePipelineStage(this.pipeline.id, this.stage.id, options)

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -66,16 +66,16 @@
                     <slot name="pictogram"><img src="../../../images/pictograms/snapshot_red.png"></slot>
                     <div>
                         <p>
-                            When a Pipeline stage is deployed from, the way the snapshot used to push the flows and settings can be configured.
+                            When a Pipeline stage is triggered an Instance Snapshot is deployed to the next stage. You can configure how this stage picks what snapshot to deploy.
                         </p>
                         <p>
-                            Create New Snapshot: Creates a new snapshot with the current time in the source stage and copies it to the target stage.
+                            Create New Snapshot: Creates a new snapshot using the current flows and settings.
                         </p>
                         <p>
-                            Use Latest Instance Snapshot: Requires a snapshot to be manually created in the source stage, and will copy that to the target stage.
+                            Use Latest Instance Snapshot: Uses the most recent existing snapshot of the instance. The deploy will fail if no snapshot exists.
                         </p>
                         <p>
-                            Prompt to Select Snapshot: Will ask at deploy time, which snapshot from the source stage should be copied to the target.
+                            Prompt to Select Snapshot: Will ask at deploy time, which snapshot from the source stage should be copied to the next stage.
                         </p>
                     </div>
                 </div>

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -44,6 +44,18 @@
             </template>
         </FormRow>
 
+        <!-- Actiom -->
+        <FormRow
+            v-model="input.action"
+            :options="actionOptions"
+            data-form="stage-action"
+            placeholder="Select Action"
+        >
+            <template #default>
+                Choose Instance
+            </template>
+        </FormRow>
+
         <!-- Deploy to Devices -->
         <FormRow
             v-model="input.deployToDevices"
@@ -129,8 +141,14 @@ export default {
             input: {
                 name: stage?.name,
                 instanceId: stage.instances?.[0].id,
+                action: stage?.action,
                 deployToDevices: stage.deployToDevices || false
-            }
+            },
+            actionOptions: [
+                { value: 'create_snapshot', label: 'Create new snapshot' },
+                { value: 'use_latest_snapshot', label: 'Use latest instance snapshot' },
+                { value: 'prompt', label: 'Prompt to select snapshot' }
+            ]
         }
     },
     computed: {
@@ -141,11 +159,12 @@ export default {
             return (
                 this.input.name !== this.stage.name ||
                 this.input.instanceId !== this.stage.instances?.[0].id ||
+                this.input.action !== this.stage.action ||
                 this.input.deployToDevices !== this.stage.deployToDevices
             )
         },
         submitEnabled () {
-            return this.formDirty && this.input.instanceId && this.input.name
+            return this.formDirty && this.input.instanceId && this.input.name && this.input.action
         },
         instancesNotInUse () {
             const instanceIdsInUse = this.pipeline.stages.reduce((acc, stage) => {

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -125,8 +125,8 @@ export default {
             }
         },
         sourceStage: {
-            type: Boolean,
-            default: true // TODO: Disabled for not
+            type: String,
+            default: null
         }
     },
     emits: ['submit'],

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -53,11 +53,37 @@
         >
             <template #default>
                 Select Action
+                <InformationCircleIcon class="ff-icon ff-icon-sm text-gray-800 cursor-pointer hover:text-blue-700" @click="$refs['help-dialog'].show()" />
             </template>
             <template #description>
                 When this stage is pushed to the next, which action will be performed?
             </template>
         </FormRow>
+
+        <ff-dialog ref="help-dialog" class="ff-dialog-box--info" header="Snapshot Actions">
+            <template #default>
+                <div class="flex gap-8">
+                    <slot name="pictogram"><img src="../../../images/pictograms/snapshot_red.png"></slot>
+                    <div>
+                        <p>
+                            When a Pipeline stage is deployed from, the way the snapshot used to push the flows and settings can be configured.
+                        </p>
+                        <p>
+                            Create New Snapshot: Creates a new snapshot with the current time in the source stage and copies it to the target stage.
+                        </p>
+                        <p>
+                            Use Latest Instance Snapshot: Requires a snapshot to be manually created in the source stage, and will copy that to the target stage.
+                        </p>
+                        <p>
+                            Prompt to Select Snapshot: Will ask at deploy time, which snapshot from the source stage should be copied to the target.
+                        </p>
+                    </div>
+                </div>
+            </template>
+            <template #actions>
+                <ff-button @click="$refs['help-dialog'].close()">Close</ff-button>
+            </template>
+        </ff-dialog>
 
         <!-- Deploy to Devices -->
         <FormRow
@@ -98,7 +124,7 @@
 </template>
 
 <script>
-import { ChevronLeftIcon } from '@heroicons/vue/solid'
+import { InformationCircleIcon } from '@heroicons/vue/outline'
 
 import FormRow from '../../../components/FormRow.vue'
 import SectionTopMenu from '../../../components/SectionTopMenu.vue'
@@ -106,6 +132,7 @@ import SectionTopMenu from '../../../components/SectionTopMenu.vue'
 export default {
     name: 'PipelineForm',
     components: {
+        InformationCircleIcon,
         SectionTopMenu,
         FormRow
     },
@@ -134,9 +161,6 @@ export default {
         const stage = this.stage
 
         return {
-            icons: {
-                chevronLeft: ChevronLeftIcon
-            },
             loading: {
                 create: false,
                 update: false

--- a/frontend/src/pages/application/PipelineStage/form.vue
+++ b/frontend/src/pages/application/PipelineStage/form.vue
@@ -44,7 +44,7 @@
             </template>
         </FormRow>
 
-        <!-- Actiom -->
+        <!-- Action -->
         <FormRow
             v-model="input.action"
             :options="actionOptions"
@@ -52,7 +52,10 @@
             placeholder="Select Action"
         >
             <template #default>
-                Choose Instance
+                Select Action
+            </template>
+            <template #description>
+                When this stage is pushed to the next, which action will be performed?
             </template>
         </FormRow>
 

--- a/frontend/src/pages/instance/Snapshots/index.vue
+++ b/frontend/src/pages/instance/Snapshots/index.vue
@@ -138,8 +138,8 @@ export default {
         }
     },
     watch: {
-        team: 'fetchData',
-        instance: 'fetchData'
+        'team.id': 'fetchData',
+        'instance.id': 'fetchData'
     },
     mounted () {
         this.fetchData()

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -62,6 +62,10 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
 
+        cy.get('[data-form="stage-action"]').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
         cy.get('[data-action="add-stage"]').click()
 
         // Add stage 2
@@ -74,6 +78,10 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-form="stage-instance"]').click()
         cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:last').click()
 
         cy.get('[data-action="add-stage"]').click()
 
@@ -98,6 +106,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
     it('can edit the instance assigned to a stage', () => {
         cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
         cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
+        cy.intercept('POST', '/api/v1/pipelines/*/stages').as('createPipelineStage')
 
         cy.visit(`/application/${application.id}/pipelines`)
         cy.wait('@getPipelines')
@@ -116,13 +125,19 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
             cy.get('[data-action="add-stage"]').click()
         })
 
-        cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 1')
+        cy.get('[data-form="stage-name"] input[type="text"]').type(`Stage 1 for ${PIPELINE_NAME}`)
 
-        cy.get('[data-form="stage-instance"]').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
         cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
 
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:last').click() // prompt
+
         cy.get('[data-action="add-stage"]').click()
+
+        cy.wait('@createPipelineStage')
 
         cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
             cy.contains('instance-2-1')
@@ -132,7 +147,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         // Stage Edit Form
         cy.get('[data-form="stage-name"] input').should(($input) => {
             const stageName = $input.val()
-            expect(stageName).to.equal('Stage 1')
+            expect(stageName).to.equal(`Stage 1 for ${PIPELINE_NAME}`)
         })
 
         cy.get('[data-form="stage-instance"] .ff-dropdown-selected').should('contain', 'instance-2-1')
@@ -142,6 +157,8 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:last').click()
 
         cy.get('[data-form="stage-instance"] .ff-dropdown-selected').should('contain', 'instance-2-with-devices')
+
+        cy.get('[data-form="stage-action"] .ff-dropdown-selected').should('contain', 'Prompt to select snapshot')
 
         cy.get('[data-action="add-stage"]').click()
 

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -1,6 +1,6 @@
 describe('FlowForge - Application - DevOps Pipelines', () => {
     let application
-    function navigateToApplication (teamName, projectName) {
+    function loadApplication (teamName, applicationName) {
         cy.request('GET', '/api/v1/user/teams')
             .then((response) => {
                 const team = response.body.teams.find(
@@ -10,10 +10,8 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
             })
             .then((response) => {
                 application = response.body.applications.find(
-                    (app) => app.name === projectName
+                    (app) => app.name === applicationName
                 )
-                cy.visit(`/application/${application.id}/instances`)
-                cy.wait('@getApplication')
             })
     }
 
@@ -22,12 +20,13 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.login('bob', 'bbPassword')
         cy.home()
-        navigateToApplication('BTeam', 'application-2')
-        cy.get('[data-nav="application-pipelines"]').should('exist')
+        loadApplication('BTeam', 'application-2')
     })
 
     it('can navigate to the /pipelines page with EE license', () => {
-        cy.visit(`/application/${application.id}/pipelines`)
+        cy.visit(`/application/${application.id}`)
+        cy.get('[data-nav="application-pipelines"]').should('exist').click()
+
         cy.url().should('include', `/application/${application.id}/pipelines`)
     })
 
@@ -58,11 +57,11 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 1')
 
-        cy.get('[data-form="stage-instance"]').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
         cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
 
-        cy.get('[data-form="stage-action"]').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
         cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:first').click()
 
@@ -75,7 +74,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 2')
 
-        cy.get('[data-form="stage-instance"]').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
         cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
 
@@ -152,7 +151,7 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.get('[data-form="stage-instance"] .ff-dropdown-selected').should('contain', 'instance-2-1')
 
-        cy.get('[data-form="stage-instance"]').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
         cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
         cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:last').click()
 
@@ -164,6 +163,115 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
 
         cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
             cy.contains('instance-2-with-devices')
+        })
+    })
+
+    it('can push from one stage to another, prompting for snapshot', () => {
+        cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
+        cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
+
+        /// Create stages ready to push between
+        cy.visit(`/application/${application.id}/pipelines`)
+        cy.wait('@getPipelines')
+
+        const PIPELINE_NAME = `My New Pipeline - ${Math.random().toString(36).substring(2, 7)}`
+
+        // Add pipeline
+        cy.get('[data-action="pipeline-add"]').click()
+        cy.get('[data-form="pipeline-form"]').should('be.visible')
+
+        cy.get('[data-form="pipeline-name"] input').type(PIPELINE_NAME)
+        cy.get('[data-action="create-pipeline"]').click()
+
+        cy.wait('@createPipeline')
+
+        // Add stage 1
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-action="add-stage"]').click()
+        })
+
+        cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 1')
+
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:last').click() // prompt
+
+        cy.get('[data-action="add-stage"]').click()
+
+        let instance
+        cy.request('GET', '/api/v1/user/teams').then((response) => {
+            const team = response.body.teams.find((team) => team.name === 'BTeam')
+
+            return cy.request('GET', `/api/v1/teams/${team.id}/projects`)
+        }).then((response) => {
+            instance = response.body.projects.find((project) => project.name === 'instance-2-1')
+
+            return cy.request('POST', `/api/v1/projects/${instance.id}/snapshots`, {
+                name: `Snapshot 1 for ${PIPELINE_NAME} test`,
+                description: 'Description',
+                setAsTarget: false
+            })
+        }).then((response) => {
+            return cy.request('POST', `/api/v1/projects/${instance.id}/snapshots`, {
+                name: `Snapshot 2 for ${PIPELINE_NAME} test`,
+                description: 'Description 2',
+                setAsTarget: false
+            })
+        }).then((response) => {
+            // Add stage 2
+            cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+                cy.get('[data-action="add-stage"]').click()
+            })
+
+            cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 2')
+
+            cy.get('[data-form="stage-instance"] .ff-dropdown').click()
+            cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
+            cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+            cy.get('[data-form="stage-action"] .ff-dropdown').click()
+            cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+            cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+            cy.get('[data-action="add-stage"]').click()
+
+            /// Push from stage 1 to stage 2
+            cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+                cy.get('[data-el="ff-pipeline-stage"]:contains("Stage 1")').within(() => {
+                    cy.get('[data-action="stage-run"]').click()
+                })
+            })
+
+            cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').should('be.visible')
+            cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').within(() => {
+                cy.get('[data-form="snapshot-select"]').click()
+                cy.get(`[data-form="snapshot-select"] .ff-dropdown-options:contains("Snapshot 2 for ${PIPELINE_NAME} test")`).click()
+
+                /* eslint-disable cypress/require-data-selectors */
+                cy.get('button.ff-btn.ff-btn--primary').click()
+                /* eslint-enable */
+            })
+
+            // Tidy Up
+            cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+                cy.contains('Stage 1')
+                cy.contains('Stage 2')
+
+                cy.get('[data-action="delete-pipeline"]').click()
+            })
+
+            cy.get('[data-el="platform-dialog"]')
+                .should('be.visible')
+                .within(() => {
+                    /* eslint-disable cypress/require-data-selectors */
+                    cy.get('.ff-dialog-header').contains('Delete Pipeline')
+                    cy.get('button.ff-btn.ff-btn--danger').click()
+                    /* eslint-enable */
+                })
         })
     })
 })

--- a/test/unit/forge/ee/routes/api/pipeline_spec.js
+++ b/test/unit/forge/ee/routes/api/pipeline_spec.js
@@ -972,7 +972,7 @@ describe('Pipelines API', function () {
             afterEach(async function () {
                 await app.db.models.ProjectSnapshot.destroy({
                     where: {
-                        projectId: [TestObjects.instanceOne.id, TestObjects.instanceTwo.id]
+                        ProjectId: [TestObjects.instanceOne.id, TestObjects.instanceTwo.id]
                     }
                 })
             })
@@ -1143,7 +1143,7 @@ describe('Pipelines API', function () {
             afterEach(async function () {
                 await app.db.models.ProjectSnapshot.destroy({
                     where: {
-                        projectId: TestObjects.instanceOne.id
+                        ProjectId: TestObjects.instanceOne.id
                     }
                 })
             })

--- a/test/unit/forge/services/snapshots_spec.js
+++ b/test/unit/forge/services/snapshots_spec.js
@@ -2,7 +2,7 @@ const crypto = require('crypto')
 
 const should = require('should') // eslint-disable-line
 const snapshots = require('../../../../forge/services/snapshots')
-const factory = require('../../../lib/TestModelFactory')
+const Factory = require('../../../lib/TestModelFactory')
 const { decryptCreds } = require('../../../lib/credentials')
 
 const setup = require('../ee/setup') // EE setup for Pipeline support
@@ -13,7 +13,7 @@ describe('Snapshots Service', function () {
     before(async function () {
         APP = await setup()
 
-        FACTORY = new factory(APP)
+        FACTORY = new Factory(APP)
 
         USER = APP.user
         TEAM = APP.team

--- a/test/unit/forge/services/snapshots_spec.js
+++ b/test/unit/forge/services/snapshots_spec.js
@@ -45,7 +45,7 @@ describe('Snapshots Service', function () {
             name.should.match(/Version 1\.1\.0 - Deploy Snapshot - \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
         })
 
-        it('Handles a source snapshot already having a date by stripping the date', async function () {
+        it('Handles a source snapshot already having a date and name by stripping the date and keeping the name', async function () {
             const instance = await APP.db.models.Project.create({ name: 'instance-2', type: '', url: '' })
 
             await TEAM.addProject(instance)
@@ -73,6 +73,28 @@ describe('Snapshots Service', function () {
 
             const name3 = snapshots.generateDeploySnapshotName(snapshot3)
             name3.should.match(/Version 1\.1\.0 - Deploy Snapshot - \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
+        })
+
+        it('Handles a source snapshot having only a date by replacing the name entirely', async function () {
+            const instance = await APP.db.models.Project.create({ name: 'instance-3', type: '', url: '' })
+
+            await TEAM.addProject(instance)
+
+            const snapshot = await snapshots.createSnapshot(APP, instance, USER, {
+                name: 'Deploy Snapshot - 2023-09-22 11:40:45',
+                setAsTarget: false // no need to deploy to devices of the source
+            })
+
+            const name = snapshots.generateDeploySnapshotName(snapshot)
+            name.should.match(/^Deploy Snapshot - \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+
+            const snapshot2 = await snapshots.createSnapshot(APP, instance, USER, {
+                name,
+                setAsTarget: false // no need to deploy to devices of the source
+            })
+
+            const name2 = snapshots.generateDeploySnapshotName(snapshot2)
+            name2.should.match(/^Deploy Snapshot - \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/)
         })
     })
 

--- a/test/unit/forge/services/snapshots_spec.js
+++ b/test/unit/forge/services/snapshots_spec.js
@@ -104,7 +104,7 @@ describe('Snapshots Service', function () {
         before(async function () {
             const application = await FACTORY.createApplication({ name: 'application1' }, TEAM)
 
-            const instance = await APP.db.models.Project.create({ name: 'instance-3', type: '', url: '' })
+            const instance = await APP.db.models.Project.create({ name: 'instance-4', type: '', url: '' })
 
             pipeline = await FACTORY.createPipeline({ name: 'pipeline-1' }, application)
 
@@ -301,7 +301,7 @@ describe('Snapshots Service', function () {
         })
 
         it('Imports the snapshot if importSnapshot copying across the environment variables', async function () {
-            const instance = await APP.db.models.Project.create({ name: 'instance-4', type: '', url: '' })
+            const instance = await APP.db.models.Project.create({ name: 'instance-5', type: '', url: '' })
 
             await TEAM.addProject(instance)
 
@@ -345,7 +345,7 @@ describe('Snapshots Service', function () {
         })
 
         it('Sets the snapshot as the target if setAsTarget is true', async function () {
-            const toInstance = await APP.db.models.Project.create({ name: 'instance-5', type: '', url: '' })
+            const toInstance = await APP.db.models.Project.create({ name: 'instance-6', type: '', url: '' })
 
             await TEAM.addProject(toInstance)
             toInstance.reload()
@@ -383,7 +383,7 @@ describe('Snapshots Service', function () {
         })
 
         it('Re-encrypts any credentials found on the source instance', async function () {
-            const sourceInstance = await APP.db.models.Project.create({ name: 'instance-6', type: '', url: '' })
+            const sourceInstance = await APP.db.models.Project.create({ name: 'instance-7', type: '', url: '' })
 
             await TEAM.addProject(sourceInstance)
             sourceInstance.reload()
@@ -405,7 +405,7 @@ describe('Snapshots Service', function () {
             sourceSnapshot.flows.credentials.should.match(credentialsEncrypted)
 
             // Copy over
-            const toInstance = await APP.db.models.Project.create({ name: 'instance-7', type: '', url: '' })
+            const toInstance = await APP.db.models.Project.create({ name: 'instance-8', type: '', url: '' })
 
             await TEAM.addProject(toInstance)
             toInstance.reload()


### PR DESCRIPTION
## Description

Marked draft as I'd like some UI feedback from @joepavitt (can be completed in a follow up though!).
Edit: And test failures

Key features:
 - A stage can now be configured on deploy to either create a new snapshot, always copy the existing snapshot, or prompt 
 - Deploy snapshot names and descriptions are more intelligent and persist the original details along the pipeline stages
 - User is prompted to select a snapshot on deploy if set as such

### Edit Pipeline Stage
![Screenshot 2023-09-25 at 16 40 20](https://github.com/flowforge/flowforge/assets/507155/ef3a0cd8-9444-455c-bfee-490aa5b401c0)

### Improved Names
![Screenshot 2023-09-25 at 16 34 28](https://github.com/flowforge/flowforge/assets/507155/e6430890-bb4c-45c6-b499-de5cf92becec)

### Select Snapshot to Deploy
![Screenshot 2023-09-25 at 16 33 51](https://github.com/flowforge/flowforge/assets/507155/2103da39-2883-40a1-bb2c-1ac7ab20b62b)

## Related Issue(s)

Fixes #2651, https://github.com/flowforge/flowforge/issues/2600

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

