### PR TITLE
Fix up multiple audit-log event filters

### DIFF
--- a/forge/db/views/AuditLog.js
+++ b/forge/db/views/AuditLog.js
@@ -30,7 +30,11 @@ module.exports = function (app) {
         $id: 'AuditLogQueryParams',
         type: 'object',
         properties: {
-            event: { type: 'string' },
+            // `event` can be a string or an array of strings (e.g. ['project.snapshot.device-target-set', 'project.snapshot.deviceTarget'])
+            // this is to handle legacy log entries that have multiple events
+            // One such example is the legacy entry 'project.snapshot.deviceTarget' which is now called 'project.snapshot.device-target-set'
+            // this results in a querystring of ?event=project.snapshot.deviceTarget&event=project.snapshot.device-target-set
+            event: { anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }] },
             username: { type: 'string' }
         }
     })

--- a/test/unit/forge/routes/api/application_spec.js
+++ b/test/unit/forge/routes/api/application_spec.js
@@ -578,8 +578,7 @@ describe('Application API', function () {
             result.should.have.property('log')
             result.log.should.have.length(1)
         })
-        it.skip('Owner can apply multiple filters to an application audit log', async function () {
-            // Disabled until PR #100 is merged
+        it('Owner can apply multiple filters to an application audit log', async function () {
             const sid = await login('bob', 'bbPassword')
             const application = await app.factory.createApplication({ name: generateName('app') }, TestObjects.BTeam)
 


### PR DESCRIPTION
closes #2816

## Description

### NOTE: Ideally, merge after #2819 (this is based on work in Application Audit Log)

* Update swagger schema definition of `AuditLogQueryParams` to support legacy filter items
* Enable test `Owner can apply multiple filters to an application audit log`

## Related Issue(s)

#2816

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

