### PR TITLE
Add appropriate E2E Tests for Device Snapshots

### DIFF
--- a/frontend/src/components/EmptyState.vue
+++ b/frontend/src/components/EmptyState.vue
@@ -1,6 +1,6 @@
 <template>
     <div data-el="empty-state">
-        <FeatureUnavailable v-if="featureUnavailable" />
+        <FeatureUnavailable v-if="featureUnavailable" :message="featureUnavailableMessage" />
         <FeatureUnavailableToTeam v-if="featureUnavailableToTeam" />
         <div
             class="ff-empty-state" :class="{'ff-empty-state-feature-unavailable': featureUnavailable}"
@@ -38,6 +38,10 @@ export default {
         featureUnavailable: {
             type: Boolean,
             default: false
+        },
+        featureUnavailableMessage: {
+            type: String,
+            default: null
         },
         featureUnavailableToTeam: {
             type: Boolean,

--- a/frontend/src/components/banners/FeatureUnavailable.vue
+++ b/frontend/src/components/banners/FeatureUnavailable.vue
@@ -5,7 +5,7 @@
     >
         <SparklesIcon class="ff-icon mr-2" style="stroke-width: 1px;" />
         <div>
-            This is a FlowFuse Premium feature. Please <a class="ff-link" href="https://flowfuse.com/docs/upgrade/open-source-to-premium/" target="_blank" rel="noopener noreferrer">upgrade</a> your instance of FlowFuse in order to use it.
+            {{ message }}. Please <a class="ff-link" href="https://flowfuse.com/docs/upgrade/open-source-to-premium/" target="_blank" rel="noopener noreferrer">upgrade</a> your instance of FlowFuse in order to use it.
         </div>
         <SparklesIcon class="ff-icon ml-2" style="stroke-width: 1px;" />
     </div>
@@ -18,6 +18,12 @@ export default {
     name: 'FeatureUnavailable',
     components: {
         SparklesIcon
+    },
+    props: {
+        message: {
+            type: String,
+            default: 'This is a FlowFuse Premium feature'
+        }
     }
 }
 </script>

--- a/frontend/src/pages/device/Overview.vue
+++ b/frontend/src/pages/device/Overview.vue
@@ -2,7 +2,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <InfoCard header="Connection:">
             <template #icon>
-                <WifiIcon/>
+                <WifiIcon />
             </template>
             <template #content>
                 <InfoCardRow property="Last Seen:">
@@ -12,15 +12,15 @@
                 </InfoCardRow>
                 <InfoCardRow property="Status:">
                     <template #value>
-                        <StatusBadge :status="device.status"/>
+                        <StatusBadge :status="device.status" />
                     </template>
                 </InfoCardRow>
-                <InfoCardRow property="Agent Version:" :value="device.agentVersion || 'unknown'"/>
+                <InfoCardRow property="Agent Version:" :value="device.agentVersion || 'unknown'" />
             </template>
         </InfoCard>
         <InfoCard header="Deployment:">
             <template #icon>
-                <TemplateIcon/>
+                <TemplateIcon />
             </template>
             <template #content>
                 <InfoCardRow property="Application:">
@@ -42,40 +42,40 @@
                     </InfoCardRow>
                     <InfoCardRow property="Active Snapshot:">
                         <template #value>
-                            <span class="flex space-x-4 pr-2">
+                            <span class="flex gap-2 pr-2">
                                 <span class="flex items-center space-x-2 text-gray-500 italic">
                                     <ExclamationIcon class="text-yellow-600 w-4" v-if="!device.activeSnapshot || !targetSnapshotDeployed" />
                                     <CheckCircleIcon class="text-green-700 w-4" v-else />
                                 </span>
+                                <template v-if="device.activeSnapshot">
+                                    <div class="flex flex-col">
+                                        <span>{{ device.activeSnapshot.name }}</span>
+                                        <span class="text-xs text-gray-500">{{ device.activeSnapshot.id }}</span>
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    No Snapshot Deployed
+                                </template>
                             </span>
-                            <template v-if="device.activeSnapshot">
-                                <div class="flex flex-col">
-                                    <span>{{ device.activeSnapshot.name }}</span>
-                                    <span class="text-xs text-gray-500">{{ device.activeSnapshot.id }}</span>
-                                </div>
-                            </template>
-                            <template v-else>
-                                No Snapshot Deployed
-                            </template>
                         </template>
                     </InfoCardRow>
                     <InfoCardRow property="Target Snapshot:">
                         <template #value>
-                            <span class="flex space-x-4 pr-2">
+                            <span class="flex gap-2 pr-2">
                                 <span class="flex items-center space-x-2 text-gray-500 italic">
                                     <ExclamationIcon class="text-yellow-600 w-4" v-if="!device.targetSnapshot" />
                                     <CheckCircleIcon class="text-green-700 w-4" v-else />
                                 </span>
+                                <template v-if="device.targetSnapshot">
+                                    <div class="flex flex-col">
+                                        <span>{{ device.targetSnapshot.name }}</span>
+                                        <span class="text-xs text-gray-500">{{ device.targetSnapshot.id }}</span>
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    No Target Snapshot Set
+                                </template>
                             </span>
-                            <template v-if="device.targetSnapshot">
-                                <div class="flex flex-col">
-                                    <span>{{ device.targetSnapshot.name }}</span>
-                                    <span class="text-xs text-gray-500">{{ device.targetSnapshot.id }}</span>
-                                </div>
-                            </template>
-                            <template v-else>
-                                No Target Snapshot Set
-                            </template>
                         </template>
                     </InfoCardRow>
                 </template>

--- a/frontend/src/pages/device/Snapshots/index.vue
+++ b/frontend/src/pages/device/Snapshots/index.vue
@@ -15,7 +15,7 @@
     </div>
     <div class="space-y-6">
         <ff-loading v-if="loading" message="Loading Snapshots..." />
-        <template v-if="snapshots.length > 0">
+        <template v-if="features.deviceEditor && snapshots.length > 0">
             <ff-data-table data-el="snapshots" class="space-y-4" :columns="columns" :rows="snapshots" :show-search="true" search-placeholder="Search Snapshots...">
                 <template v-if="hasPermission('device:snapshot:create')" #actions>
                     <ff-button kind="primary" data-action="create-snapshot" :disabled="!developerMode || busyMakingSnapshot" @click="showCreateSnapshotDialog"><template #icon-left><PlusSmIcon /></template>Create Snapshot</ff-button>
@@ -45,7 +45,7 @@
                     </p>
                 </template>
                 <template v-if="hasPermission('device:snapshot:create')" #actions>
-                    <ff-button kind="primary" :disabled="!developerMode || busyMakingSnapshot" data-action="create-snapshot" @click="showCreateSnapshotDialog">
+                    <ff-button kind="primary" :disabled="!developerMode || busyMakingSnapshot || !features.deviceEditor" data-action="create-snapshot" @click="showCreateSnapshotDialog">
                         <template #icon-left><PlusSmIcon /></template>Create Snapshot
                     </ff-button>
                 </template>
@@ -181,6 +181,9 @@ export default {
             return snapshot.device?.id === this.device.id
         },
         fetchData: async function () {
+            if (!this.features.deviceEditor) {
+                return
+            }
             if (this.device.id && this.device.application) {
                 this.loading = true
                 const ssFilter = {

--- a/frontend/src/pages/device/Snapshots/index.vue
+++ b/frontend/src/pages/device/Snapshots/index.vue
@@ -8,7 +8,7 @@
             </template>
             <template #tools>
                 <div class="space-x-2 flex align-center">
-                    <ff-checkbox v-model="showDeviceSnapshotsOnly" v-ff-tooltip:left="'Tick this to show snapshots from other devices and instances'" label="Show only Snapshots created by this device" />
+                    <ff-checkbox v-model="showDeviceSnapshotsOnly" v-ff-tooltip:left="'Tick this to show snapshots from other devices and instances'" data-form="device-only-snapshots" label="Show only Snapshots created by this device" />
                 </div>
             </template>
         </SectionTopMenu>

--- a/frontend/src/pages/device/Snapshots/index.vue
+++ b/frontend/src/pages/device/Snapshots/index.vue
@@ -27,7 +27,7 @@
             </ff-data-table>
         </template>
         <template v-else-if="!loading">
-            <EmptyState>
+            <EmptyState :feature-unavailable="!features.deviceEditor" :feature-unavailable-message="'This requires Developer Mode on Devices, which a FlowFuse Premium Feature'">
                 <template #img>
                     <img src="../../../images/empty-states/instance-snapshots.png">
                 </template>
@@ -37,7 +37,10 @@
                         Snapshots are point-in-time backups of your Node-RED Instances
                         and capture the flows, credentials and runtime settings.
                     </p>
-                    <p v-if="!developerMode" class="block">
+                    <p v-if="device.ownerType !== 'application'" class="block">
+                        A device must first be <a class="ff-link" href="https://flowfuse.com/docs/device-agent/register/#assign-the-device-to-an-application" target="_blank" rel="noreferrer">assigned to an Application</a>, in order to create snapshots.
+                    </p>
+                    <p v-else-if="!developerMode" class="block">
                         A device must be in developer mode and online to create a snapshot.
                     </p>
                 </template>
@@ -101,7 +104,7 @@ export default {
         }
     },
     computed: {
-        ...mapState('account', ['teamMembership']),
+        ...mapState('account', ['teamMembership', 'features']),
         showContextMenu: function () {
             return this.hasPermission('device:snapshot:delete')
         },

--- a/frontend/src/pages/device/components/DeveloperModeBadge.vue
+++ b/frontend/src/pages/device/components/DeveloperModeBadge.vue
@@ -2,6 +2,7 @@
     <div
         v-ff-tooltip:bottom="'Developer Mode: Enabled'"
         class="forge-badge forge-badge-devmode"
+        data-el="badge-devmode"
     >
         <BeakerIcon class="w-4 h-4" />
         <span class="ml-1">Developer Mode</span>

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -38,13 +38,13 @@
                                 <ExternalLinkIcon />
                             </span>
                         </a>
-                        <button v-else class="ff-btn ff-btn--secondary" disabled>
+                        <button v-else data-action="open-editor" class="ff-btn ff-btn--secondary" disabled>
                             Editor Disabled
                             <span class="ff-btn--icon ff-btn--icon-right">
                                 <ExternalLinkIcon />
                             </span>
                         </button>
-                        <DeveloperModeToggle :device="device" @mode-change="setDeviceMode" />
+                        <DeveloperModeToggle data-el="device-devmode-toggle" :device="device" @mode-change="setDeviceMode" />
                     </div>
                 </template>
             </SectionNavigationHeader>

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -171,7 +171,7 @@ export default {
                     icon: TerminalIcon
                 })
             }
-            if (this.device?.ownerType === 'application') {
+            if (this.device?.ownerType !== 'instance') {
                 this.navigation.splice(1, 0, {
                     label: 'Snapshots',
                     to: `/device/${this.$route.params.id}/snapshots`,

--- a/frontend/src/pages/device/index.vue
+++ b/frontend/src/pages/device/index.vue
@@ -17,7 +17,7 @@
                     <div class="space-x-6">
                         <DeviceLastSeenBadge :last-seen-at="device.lastSeenAt" :last-seen-ms="device.lastSeenMs" :last-seen-since="device.lastSeenSince" />
                         <StatusBadge :status="device.status" />
-                        <DeveloperModeBadge v-if="device.mode === 'developer'" />
+                        <DeveloperModeBadge v-if="isDevModeAvailable && device.mode === 'developer'" />
                     </div>
                 </template>
                 <template #context>
@@ -136,7 +136,7 @@ export default {
     },
     watch: {
         'device.mode': function () {
-            if (this.device.mode === 'developer') {
+            if (this.isDevModeAvailable && this.device.mode === 'developer') {
                 this.navigation.push({
                     label: 'Developer Mode',
                     to: `/device/${this.$route.params.id}/developer-mode`,

--- a/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/developer-mode.spec.js
@@ -1,0 +1,48 @@
+describe('FlowForge - Devices - With Billing', () => {
+    beforeEach(() => {
+        cy.enableBilling()
+        cy.intercept('/api/*/settings', (req) => {
+            req.reply((response) => {
+                // ensure we keep billing enabled
+                response.body.features.billing = true
+                // fake MQTT connection
+                response.body.features.deviceEditor = true
+                return response
+            })
+        }).as('getSettings')
+
+        cy.login('bob', 'bbPassword')
+
+        cy.visit('/team/bteam/devices')
+    })
+
+    it('provides an option to enable "Developer Mode" when deviceEditor feature is enabled', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-el=device-devmode-toggle]').should('exist')
+    })
+
+    it('has "Developer Mode" tab and status pill when Dev mode is enabled', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-devmode"]').should('not.exist')
+        cy.get('[data-el="badge-devmode"]').should('not.exist')
+        cy.get('[data-el=device-devmode-toggle]').click()
+        cy.get('[data-nav="device-devmode"]').should('exist')
+        cy.get('[data-el="badge-devmode"]').should('exist')
+
+        // reset dev mode state
+        cy.get('[data-el=device-devmode-toggle]').click()
+    })
+
+    it('is redirected away from the Developer Mode tab if leaving that mode, whilst the tab is open', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-el=device-devmode-toggle]').click()
+        cy.get('[data-nav="device-devmode"]').click()
+
+        cy.url().should('include', '/developer-mode')
+
+        // reset dev mode state
+        cy.get('[data-el=device-devmode-toggle]').click()
+
+        cy.url().should('not.include', '/developer-mode')
+    })
+})

--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -16,19 +16,37 @@ describe('FlowForge - Devices - With Billing', () => {
         cy.visit('/team/bteam/devices')
     })
 
-    it('doesn\'t show a "Snapshots" tab for unassigned devices', () => {
-        cy.contains('span', 'team2-unassigned-device').click()
-        cy.get('[data-nav="device-snapshots"]').should('not.exist')
-    })
-
     it('doesn\'t show a "Snapshots" tab for devices bound to an Instance', () => {
         cy.contains('span', 'assigned-device-a').click()
         cy.get('[data-nav="device-snapshots"]').should('not.exist')
     })
 
+    it('shows a "Snapshots" tab for unassigned devices', () => {
+        cy.contains('span', 'team2-unassigned-device').click()
+        cy.get('[data-nav="device-snapshots"]').should('exist')
+    })
+
+    it('empty state informs users they need to bind the Device to an Application for unassigned devices on the "Snapshot" tab', () => {
+        cy.contains('span', 'team2-unassigned-device').click()
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.contains('A device must first be assigned to an Application')
+    })
+
     it('shows a "Snapshots" tab for devices bound to an Instance', () => {
         cy.contains('span', 'application-device-a').click()
         cy.get('[data-nav="device-snapshots"]').should('exist')
+    })
+
+    it('empty state informs users they need to be in Developer Mode for Devices assigned to an Application on the "Snapshot" tab', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.contains('A device must be in developer mode and online to create a snapshot.')
+    })
+
+    it('doesn\'t show any "Premium Feature Only" guidance if billing is enabled', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.get('[data-el="page-banner-feature-unavailable"]').should('not.exist')
     })
 
     it('shows only Snapshots for this device by default', () => {

--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -1,0 +1,47 @@
+describe('FlowForge - Devices - With Billing', () => {
+    beforeEach(() => {
+        cy.enableBilling()
+        cy.intercept('/api/*/settings', (req) => {
+            req.reply((response) => {
+                // ensure we keep billing enabled
+                response.body.features.billing = true
+                // fake MQTT connection
+                response.body.features.deviceEditor = true
+                return response
+            })
+        }).as('getSettings')
+
+        cy.login('bob', 'bbPassword')
+
+        cy.visit('/team/bteam/devices')
+    })
+
+    it('doesn\'t show a "Snapshots" tab for unassigned devices', () => {
+        cy.contains('span', 'team2-unassigned-device').click()
+        cy.get('[data-nav="device-snapshots"]').should('not.exist')
+    })
+
+    it('doesn\'t show a "Snapshots" tab for devices bound to an Instance', () => {
+        cy.contains('span', 'assigned-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').should('not.exist')
+    })
+
+    it('shows a "Snapshots" tab for devices bound to an Instance', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').should('exist')
+    })
+
+    it('shows only Snapshots for this device by default', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.get('[data-el="empty-state"]').should('exist')
+    })
+
+    it('allows for users to view all Snapshots for this Device from it\'s parent Application', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.get('[data-form="device-only-snapshots"]').click()
+        cy.get('[data-el="empty-state"]').should('not.exist')
+        cy.get('[data-el="snapshots"] tbody').find('tr').should('have.length', 3)
+    })
+})

--- a/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
@@ -1,0 +1,16 @@
+describe('FlowForge - Devices', () => {
+    beforeEach(() => {
+        cy.login('bob', 'bbPassword')
+        cy.visit('/team/bteam/devices')
+        cy.contains('span', 'application-device-a').click()
+    })
+
+    it('should not show "Developer Mode" options without billing enabled', () => {
+        cy.get('[data-el=device-devmode-toggle]').should('not.exist')
+        cy.get('[data-action=open-editor]').should('not.exist')
+    })
+
+    it('exposes a "Snapshots" tab', () => {
+
+    })
+})

--- a/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests/devices/snapshots.spec.js
@@ -2,15 +2,30 @@ describe('FlowForge - Devices', () => {
     beforeEach(() => {
         cy.login('bob', 'bbPassword')
         cy.visit('/team/bteam/devices')
-        cy.contains('span', 'application-device-a').click()
     })
 
     it('should not show "Developer Mode" options without billing enabled', () => {
+        cy.contains('span', 'application-device-a').click()
         cy.get('[data-el=device-devmode-toggle]').should('not.exist')
         cy.get('[data-action=open-editor]').should('not.exist')
     })
 
-    it('exposes a "Snapshots" tab', () => {
+    it('exposes a "Snapshots" tab if assigned to an Application & informs users this is a Premium Feature', () => {
+        cy.contains('span', 'application-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').should('exist')
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')
+    })
 
+    it('exposes a "Snapshots" tab if not assigned to anything & informs users this is a Premium Feature', () => {
+        cy.contains('span', 'team2-unassigned-device').click()
+        cy.get('[data-nav="device-snapshots"]').should('exist')
+        cy.get('[data-nav="device-snapshots"]').click()
+        cy.get('[data-el="page-banner-feature-unavailable"]').should('exist')
+    })
+
+    it('does not expose a "Snapshots" tab if assigned to an Instance', () => {
+        cy.contains('span', 'assigned-device-a').click()
+        cy.get('[data-nav="device-snapshots"]').should('not.exist')
     })
 })

--- a/test/e2e/frontend/environments/standard.js
+++ b/test/e2e/frontend/environments/standard.js
@@ -140,6 +140,9 @@ module.exports = async function (settings = {}, config = {}) {
     await factory.createSnapshot({ name: 'snapshot 2' }, instanceWithDevices, userBob)
     await factory.createSnapshot({ name: 'snapshot 3' }, instanceWithDevices, userBob)
 
+    // create a device bound to an application directly
+    await factory.createDevice({ name: 'application-device-a', type: 'type2' }, team2, null, application2)
+
     forge.teams = [team1, team2]
     forge.projectTypes = [projectType, spareProjectType]
 


### PR DESCRIPTION
## Description

Adds E2E Tests. Checking:

- Developer Mode toggle appears when appropriate
- Snapshots tab appears when appropriate
- Snapshots table toggle works as expected

## Related Issue(s)

#2609 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->