### PR TITLE
Add option not to create NR instance when creating Application

### DIFF
--- a/frontend/src/pages/instance/components/InstanceForm.vue
+++ b/frontend/src/pages/instance/components/InstanceForm.vue
@@ -66,6 +66,9 @@
 
         <FormRow v-if="creatingApplication" v-model="input.createInstance" type="checkbox" data-form="create-instance">
             Create Node-RED Instance
+            <template #description>
+                This will create an instance of Node-RED that will be managed in your new Application.
+            </template>
         </FormRow>
         <div v-if="!creatingApplication || input.createInstance" :class="creatingApplication ? 'ml-6' : ''" class="space-y-6">
             <!-- Instance Name -->


### PR DESCRIPTION
Closes #1986 

## Description

Adds a checkbox to the Create Application page to optionally *not* create a Node-RED instance. By default the box is checked.

The InstanceForm component gets reused in a few places. The checkbox is only shown in the Create Application context.

<img width="1086" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/3809bb2a-0008-457b-a974-2d3c77769904">


<img width="1094" alt="image" src="https://github.com/flowforge/flowforge/assets/51083/c9dfd2b2-b5af-45f3-b914-73d5b5776e88">



## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

