### PR TITLE
More robust check for Snapshot count in Device Snapshots E2E test

### DIFF
--- a/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/devices/snapshots.spec.js
@@ -56,10 +56,23 @@ describe('FlowForge - Devices - With Billing', () => {
     })
 
     it('allows for users to view all Snapshots for this Device from it\'s parent Application', () => {
+        let snapshots = 3
+
+        cy.intercept('/api/*/applications/*/snapshots', (req) => {
+            req.reply((response) => {
+                snapshots = response.body.count
+                return response
+            })
+        }).as('getDeviceSnapshots')
+
         cy.contains('span', 'application-device-a').click()
         cy.get('[data-nav="device-snapshots"]').click()
+
         cy.get('[data-form="device-only-snapshots"]').click()
-        cy.get('[data-el="empty-state"]').should('not.exist')
-        cy.get('[data-el="snapshots"] tbody').find('tr').should('have.length', 3)
+
+        cy.wait('@getDeviceSnapshots').then(() => {
+            cy.get('[data-el="empty-state"]').should('not.exist')
+            cy.get('[data-el="snapshots"] tbody').find('tr').should('have.length', snapshots)
+        })
     })
 })


### PR DESCRIPTION
## Description

Had a hardcoded check for 3 snapshots, but `pipelines.spec.js` was also generating snapshots. Run order seems different between GH and local, so local hadn't flagged. THe original PR also hadn't flagged as the `pipelines.spec.js` wasn't present at that time.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
