### PR TITLE
Fix Tests: Guard against getOwners including a null

### DIFF
--- a/forge/db/models/Team.js
+++ b/forge/db/models/Team.js
@@ -260,7 +260,11 @@ module.exports = {
                         TeamId: this.id,
                         role: Roles.Owner
                     }
-                    return (await M.TeamMember.findAll({ where, include: M.User })).map(tm => tm.User)
+                    const owners = (await M.TeamMember.findAll({ where, include: M.User })).map(tm => tm.User)
+
+                    // There is a race condition (though it shouldn't happen) where a user, but not their membership, has been deleted
+                    // In this case the findAll above will return an array that includes null, this needs to be guarded against
+                    return owners.filter((owner) => owner !== null)
                 },
                 memberCount: async function (role) {
                     const where = {

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -100,7 +100,11 @@ module.exports = {
                 const teams = await app.db.models.Team.forUser(user)
                 for (const team of teams) {
                     const owners = await team.Team.getOwners()
-                    const isOwner = owners.find((owner) => owner.id === user.id)
+                    const isOwner = owners.find((owner) => {
+                        // It's possible (though it shouldn't happen) for a user, but not their membership to have been deleted
+                        // In this case Team.getOwners() will return a null, so we need to guard for this
+                        return owner?.id === user.id
+                    })
                     // if this user is the only owner of this team, throw an error
                     if (isOwner && owners.length <= 1) {
                         throw new Error('Cannot delete the last owner of a team')

--- a/forge/db/models/User.js
+++ b/forge/db/models/User.js
@@ -100,11 +100,8 @@ module.exports = {
                 const teams = await app.db.models.Team.forUser(user)
                 for (const team of teams) {
                     const owners = await team.Team.getOwners()
-                    const isOwner = owners.find((owner) => {
-                        // It's possible (though it shouldn't happen) for a user, but not their membership to have been deleted
-                        // In this case Team.getOwners() will return a null, so we need to guard for this
-                        return owner?.id === user.id
-                    })
+                    const isOwner = owners.find((owner) => owner.id === user.id)
+
                     // if this user is the only owner of this team, throw an error
                     if (isOwner && owners.length <= 1) {
                         throw new Error('Cannot delete the last owner of a team')


### PR DESCRIPTION
## Description

See: https://github.com/flowforge/flowforge/pull/2839

In the [failing test](https://github.com/flowforge/flowforge/blob/b621af4e195b42122904ede629eea66715d2bdcb/test/unit/forge/routes/api/user_spec.js#L613-L627) we're destroying the user bob, but not the team membership (that's done by a cascade). That leads to a race condition where `Team.getOwners()` can return null as the team membership still exists, but points to a `null` user.

A simple guard fixes this. Though it is a state that _should_ not be possible.

https://github.com/flowforge/flowforge/blob/b621af4e195b42122904ede629eea66715d2bdcb/test/unit/forge/routes/api/user_spec.js#L613-L616

## Related Issue(s)

Replaces https://github.com/flowforge/flowforge/pull/2839